### PR TITLE
Fixed line_col failing for positions on the last line

### DIFF
--- a/lalrpop/src/build/filetext.rs
+++ b/lalrpop/src/build/filetext.rs
@@ -52,7 +52,7 @@ impl FileText {
             .filter(|&i| self.newlines[i] > pos)
             .map(|i| i-1)
             .next()
-            .unwrap();
+            .unwrap_or(num_lines - 1);
 
         // offset of the first character in `line`
         let line_offset = self.newlines[line];


### PR DESCRIPTION
If pos was greater than the position of the last newline in the file, then the filter would return an empty set and unwrap would fail.