### PR TITLE
Fix build script error handling on windows

### DIFF
--- a/lalrpop-snap/src/build/mod.rs
+++ b/lalrpop-snap/src/build/mod.rs
@@ -44,8 +44,9 @@ fn remove_old_file(rs_file: &Path) -> io::Result<()> {
     match fs::remove_file(rs_file) {
         Ok(()) => Ok(()),
         Err(e) => {
+            // Unix reports NotFound, Windows PermissionDenied!
             match e.kind() {
-                io::ErrorKind::NotFound => Ok(()),
+                io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied=> Ok(()),
                 _ => Err(e),
             }
         }


### PR DESCRIPTION
This gets past the error reported in https://github.com/nikomatsakis/lalrpop/issues/18, though I see further parser failures in the calculator example.