### PR TITLE
Add file time checking for windows (re)builds

### DIFF
--- a/lalrpop-snap/src/build/mod.rs
+++ b/lalrpop-snap/src/build/mod.rs
@@ -79,7 +79,16 @@ fn needs_rebuild(lalrpop_file: &Path,
         lalrpop_metadata.mtime() >= rs_metadata.mtime()
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    fn compare_modification_times(lalrpop_metadata: &fs::Metadata,
+                                  rs_metadata: &fs::Metadata)
+                                  -> bool
+    {
+        use std::os::windows::fs::MetadataExt;
+        lalrpop_metadata.last_write_time() >= rs_metadata.last_write_time()
+    }
+
+    #[cfg(not(any(unix,windows)))]
     fn compare_modification_times(lalrpop_metadata: &fs::Metadata,
                                   rs_metadata: &fs::Metadata)
                                   -> bool


### PR DESCRIPTION
I noticed (due to long build times) that on windows the rebuild checker was always returning true.

I discovered in this thread that windows does support file modification times: https://www.reddit.com/r/rust/comments/3dhxxv/metadata_modified/

Looking in my local documentation I found the `last_write_time()` so I added a windows specific check.