### PR TITLE
Drop rand from required dependencies

### DIFF
--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -15,11 +15,13 @@ doctest = false
 [dependencies]
 regex = "0.1"
 diff = "0.1"
-rand = "0.3"
 itertools = "0.3"
 term = "0.2"
 unicode-xid = "0.0.2"
 petgraph = "0.1.11"
+
+[dev-dependencies]
+rand = "0.3"
 
 [dependencies.lalrpop-util]
 path = "../lalrpop-util"

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -12,11 +12,13 @@ extern crate diff;
 extern crate lalrpop_intern as intern;
 extern crate lalrpop_util;
 extern crate petgraph;
-extern crate rand;
 extern crate regex;
 extern crate term;
 extern crate itertools;
 extern crate unicode_xid;
+
+#[cfg(test)]
+extern crate rand;
 
 // rust exports a macro that others use, so hoist it early.
 #[macro_use]


### PR DESCRIPTION
The rand crate pulls in a lot of dependencies which many users of
lalrpop probably wouldn't otherwise require. It is enough to require it
to run the tests, which means using lalrpop doesn't require this
anymore.

This will come to full fruition eventually when a new lalrpop snapshot
is created, until then rand will still be pulled in.