### PR TITLE
Unset read only on generated rust file before removing it to fix build failure on Windows

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -33,10 +33,11 @@ fn process_dir<P:AsRef<Path>>(root_dir: P, force_build: bool) -> io::Result<()> 
     for lalrpop_file in lalrpop_files {
         let rs_file = lalrpop_file.with_extension("rs");
         if force_build || try!(needs_rebuild(&lalrpop_file, &rs_file)) {
+            try!(make_read_only(&rs_file, false));
             try!(remove_old_file(&rs_file));
             let grammar = try!(parse_and_normalize_grammar(lalrpop_file));
             try!(emit_recursive_ascent(&rs_file, &grammar));
-            try!(make_read_only(&rs_file));
+            try!(make_read_only(&rs_file, true));
         }
     }
     Ok(())
@@ -99,10 +100,10 @@ fn needs_rebuild(lalrpop_file: &Path,
     }
 }
 
-fn make_read_only(rs_file: &Path) -> io::Result<()> {
+fn make_read_only(rs_file: &Path, ro: bool) -> io::Result<()> {
     let rs_metadata = try!(fs::metadata(&rs_file));
     let mut rs_permissions = rs_metadata.permissions();
-    rs_permissions.set_readonly(true);
+    rs_permissions.set_readonly(ro);
     fs::set_permissions(&rs_file, rs_permissions)
 }
 

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -101,10 +101,14 @@ fn needs_rebuild(lalrpop_file: &Path,
 }
 
 fn make_read_only(rs_file: &Path, ro: bool) -> io::Result<()> {
-    let rs_metadata = try!(fs::metadata(&rs_file));
-    let mut rs_permissions = rs_metadata.permissions();
-    rs_permissions.set_readonly(ro);
-    fs::set_permissions(&rs_file, rs_permissions)
+    if (rs_file.is_file()) {
+        let rs_metadata = try!(fs::metadata(&rs_file));
+        let mut rs_permissions = rs_metadata.permissions();
+        rs_permissions.set_readonly(ro);
+        fs::set_permissions(&rs_file, rs_permissions)
+    } else {
+        Ok(())
+    }
 }
 
 fn lalrpop_files<P:AsRef<Path>>(root_dir: P) -> io::Result<Vec<PathBuf>> {

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -101,7 +101,7 @@ fn needs_rebuild(lalrpop_file: &Path,
 }
 
 fn make_read_only(rs_file: &Path, ro: bool) -> io::Result<()> {
-    if (rs_file.is_file()) {
+    if rs_file.is_file() {
         let rs_metadata = try!(fs::metadata(&rs_file));
         let mut rs_permissions = rs_metadata.permissions();
         rs_permissions.set_readonly(ro);


### PR DESCRIPTION
See [#53](https://github.com/nikomatsakis/lalrpop/issues/53)

After a normal `cargo build` using LALRPOP 0.9.0, the generated rust file is set as read-only. Subsequent calls to `cargo build` fail, but if I manually remove the read-only attribute on the file, the build succeeds.

This patch unsets read-only on the generated rust file before attempting to remove it and generate a new one. It still sets read-only after the file has been generated in an attempt to preserve the external semantics of the build.

This appears to consistently resolve my build issues on Windows. I have not and cannot test it on any other platforms.