### PR TITLE
Alternative / Production Annotations

### DIFF
--- a/lalrpop-snap/src/grammar/consts.rs
+++ b/lalrpop-snap/src/grammar/consts.rs
@@ -13,3 +13,5 @@ pub const INPUT_PARAMETER: &'static str = "input";
 /// The annotation to request inlining.
 pub const INLINE: &'static str = "inline";
 
+/// The annotation to set precedence.
+pub const PRECEDENCE: &'static str = "precedence";

--- a/lalrpop-snap/src/grammar/consts.rs
+++ b/lalrpop-snap/src/grammar/consts.rs
@@ -12,6 +12,3 @@ pub const INPUT_PARAMETER: &'static str = "input";
 
 /// The annotation to request inlining.
 pub const INLINE: &'static str = "inline";
-
-/// The annotation to set precedence.
-pub const PRECEDENCE: &'static str = "precedence";

--- a/lalrpop-snap/src/grammar/consts.rs
+++ b/lalrpop-snap/src/grammar/consts.rs
@@ -12,3 +12,4 @@ pub const INPUT_PARAMETER: &'static str = "input";
 
 /// The annotation to request inlining.
 pub const INLINE: &'static str = "inline";
+

--- a/lalrpop/src/grammar/consts.rs
+++ b/lalrpop/src/grammar/consts.rs
@@ -13,3 +13,5 @@ pub const INPUT_PARAMETER: &'static str = "input";
 /// The annotation to request inlining.
 pub const INLINE: &'static str = "inline";
 
+/// The annotation to set precedence.
+pub const PRECEDENCE: &'static str = "precedence";

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -153,6 +153,8 @@ pub struct NonterminalData {
 pub struct Annotation {
     pub id_span: Span,
     pub id: InternedString,
+    // TODO nixpulvis: This is not exactly the correct type.
+    pub parameters: Vec<(InternedString, InternedString)>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -153,8 +153,14 @@ pub struct NonterminalData {
 pub struct Annotation {
     pub id_span: Span,
     pub id: InternedString,
-    // TODO nixpulvis: This is not exactly the correct type.
-    pub parameters: Vec<(InternedString, InternedString)>,
+    pub parameters: Vec<AnnotationKeyValue>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AnnotationKeyValue {
+    pub span: Span,
+    pub key: InternedString,
+    pub value: InternedString,  // TODO: Still not sure of this type.
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -149,7 +149,7 @@ pub struct NonterminalData {
     pub alternatives: Vec<Alternative>
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Annotation {
     pub id_span: Span,
     pub id: InternedString,
@@ -160,6 +160,8 @@ pub struct Alternative {
     pub span: Span,
 
     pub expr: ExprSymbol,
+
+    pub annotations: Vec<Annotation>,
 
     // if C, only legal in macros
     pub condition: Option<Condition>,

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -88,6 +88,7 @@ pub struct Production {
     // handy to have it
     pub nonterminal: NonterminalString,
     pub symbols: Vec<Symbol>,
+    pub annotations: Vec<Annotation>,
     pub action: ActionFn,
     pub span: Span,
 }

--- a/lalrpop/src/lr1/trace/trace_graph/test.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/test.rs
@@ -21,6 +21,7 @@ macro_rules! production {
         Production {
             nonterminal: nt!($x),
             symbols: syms![$($y),*],
+            annotations: vec![],
             action: ActionFn::new(0),
             span: Span(0, 0)
         }

--- a/lalrpop/src/normalize/inline/mod.rs
+++ b/lalrpop/src/normalize/inline/mod.rs
@@ -112,7 +112,7 @@ impl<'a> Inliner<'a> {
                 nonterminal: self.into_production.nonterminal,
                 span: self.into_production.span,
                 symbols: prod_symbols,
-                annotations: vec![],
+                annotations: self.into_production.annotations.clone(),
                 action: action_fn,
             });
         } else {

--- a/lalrpop/src/normalize/inline/mod.rs
+++ b/lalrpop/src/normalize/inline/mod.rs
@@ -112,6 +112,7 @@ impl<'a> Inliner<'a> {
                 nonterminal: self.into_production.nonterminal,
                 span: self.into_production.span,
                 symbols: prod_symbols,
+                annotations: vec![],
                 action: action_fn,
             });
         } else {

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -110,6 +110,7 @@ impl LowerState {
                                   nonterminal: nt_name,
                                   span: alt.span,
                                   symbols: symbols,
+                                  annotations: vec![],
                                   action: action,
                               }
                           })
@@ -190,6 +191,7 @@ impl LowerState {
                    let production = r::Production {
                        nonterminal: fake_name,
                        symbols: symbols,
+                       annotations: vec![],
                        action: action_fn,
                        span: nt.span
                    };

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -110,7 +110,7 @@ impl LowerState {
                                   nonterminal: nt_name,
                                   span: alt.span,
                                   symbols: symbols,
-                                  annotations: vec![],
+                                  annotations: alt.annotations.clone(),
                                   action: action,
                               }
                           })

--- a/lalrpop/src/normalize/macro_expand/mod.rs
+++ b/lalrpop/src/normalize/macro_expand/mod.rs
@@ -190,6 +190,7 @@ impl MacroExpander {
             alternatives.push(Alternative {
                 span: span,
                 expr: self.macro_expand_expr_symbol(&args, &alternative.expr),
+                annotations: vec![], // TODO nixpulvis
                 condition: None,
                 action: alternative.action.clone(),
             });
@@ -367,6 +368,7 @@ impl MacroExpander {
             type_decl: Some(ty_ref),
             alternatives: vec![Alternative { span: span,
                                              expr: expr,
+                                             annotations: vec![],  // TODO nixpulvis
                                              condition: None,
                                              action: action("(<>)") }]
         }))
@@ -404,6 +406,7 @@ impl MacroExpander {
                         Alternative {
                             span: span,
                             expr: ExprSymbol { symbols: vec![] },
+                            annotations: vec![],
                             condition: None,
                             action: action("vec![]")
                         },
@@ -421,6 +424,7 @@ impl MacroExpander {
                                                 Symbol::new(span,
                                                             SymbolKind::Repeat(plus_repeat)))))],
                             },
+                            annotations: vec![],
                             condition: None,
                             action: action("v"),
                         }],
@@ -445,6 +449,7 @@ impl MacroExpander {
                             expr: ExprSymbol {
                                 symbols: vec![repeat.symbol.clone()]
                             },
+                            annotations: vec![],
                             condition: None,
                             action: action("vec![<>]"),
                         },
@@ -460,6 +465,7 @@ impl MacroExpander {
                                     Symbol::new(span, SymbolKind::Name(
                                         e, Box::new(repeat.symbol.clone())))]
                             },
+                            annotations: vec![],
                             condition: None,
                             action: action("{ let mut v = v; v.push(e); v }"),
                         }],
@@ -483,6 +489,7 @@ impl MacroExpander {
                                       expr: ExprSymbol {
                                           symbols: vec![repeat.symbol.clone()]
                                       },
+                                      annotations: vec![],
                                       condition: None,
                                       action: action("Some(<>)") },
 
@@ -491,6 +498,7 @@ impl MacroExpander {
                                       expr: ExprSymbol {
                                           symbols: vec![]
                                       },
+                                      annotations: vec![],
                                       condition: None,
                                       action: action("None") }]
                 }))
@@ -511,6 +519,7 @@ impl MacroExpander {
             alternatives: vec![
                 Alternative { span: span,
                               expr: ExprSymbol { symbols: vec![] },
+                              annotations: vec![],
                               condition: None,
                               action: Some(action) }]
         }))

--- a/lalrpop/src/normalize/macro_expand/mod.rs
+++ b/lalrpop/src/normalize/macro_expand/mod.rs
@@ -190,7 +190,7 @@ impl MacroExpander {
             alternatives.push(Alternative {
                 span: span,
                 expr: self.macro_expand_expr_symbol(&args, &alternative.expr),
-                annotations: vec![], // TODO nixpulvis
+                annotations: alternative.annotations.clone(),
                 condition: None,
                 action: alternative.action.clone(),
             });
@@ -368,7 +368,7 @@ impl MacroExpander {
             type_decl: Some(ty_ref),
             alternatives: vec![Alternative { span: span,
                                              expr: expr,
-                                             annotations: vec![],  // TODO nixpulvis
+                                             annotations: vec![],
                                              condition: None,
                                              action: action("(<>)") }]
         }))

--- a/lalrpop/src/normalize/macro_expand/mod.rs
+++ b/lalrpop/src/normalize/macro_expand/mod.rs
@@ -542,5 +542,6 @@ fn inline(span: Span) -> Vec<Annotation> {
     vec![Annotation {
                 id_span: span,
                 id: intern(INLINE),
+                parameters: vec![],
     }]
 }

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -123,6 +123,20 @@ impl<'grammar> Validator<'grammar> {
             }
             Symbols::Anon(_) => { }
         }
+        let precedence_annotation = intern(PRECEDENCE);
+        let known_annotations = vec![precedence_annotation];
+        let mut found_annotations = set();
+        for annotation in &alternative.annotations {
+            if !known_annotations.contains(&annotation.id) {
+                return_err!(annotation.id_span,
+                            "unrecognized annotation `{}`",
+                            annotation.id);
+            } else if !found_annotations.insert(annotation.id) {
+                return_err!(annotation.id_span,
+                            "duplicate annotation `{}`",
+                            annotation.id);
+            }
+        }
 
         Ok(())
     }

--- a/lalrpop/src/parser/lrgrammar.lalrpop
+++ b/lalrpop/src/parser/lrgrammar.lalrpop
@@ -83,7 +83,7 @@ Annotation: Annotation = {
             parameters: vec![],
         }
     },
-    "#" "[" <lo:@L> <id:Id> "(" <l:Comma<EqPair>> ")" <hi:@R> "]" => {
+    "#" "[" <lo:@L> <id:Id> "(" <l:Comma<AnnotationKeyValue>> ")" <hi:@R> "]" => {
         Annotation {
             id_span: Span(lo, hi),
             id: id,
@@ -92,8 +92,15 @@ Annotation: Annotation = {
     },
 };
 
-EqPair: (InternedString, InternedString) =
-    <l:Id> "=" <r:Id> => (l, r);
+AnnotationKeyValue: AnnotationKeyValue = {
+    <lo:@L> <key:Id> "=" <value:Id> <hi:@R> => {
+        AnnotationKeyValue {
+            span: Span(lo, hi),
+            key: key,
+            value: value,
+        }
+    }
+};
 
 NonterminalName: (NonterminalString, Vec<NonterminalString>) = {
     <MacroId> "<" <Comma<NotMacroId>> ">",

--- a/lalrpop/src/parser/lrgrammar.lalrpop
+++ b/lalrpop/src/parser/lrgrammar.lalrpop
@@ -96,6 +96,7 @@ Alternative: Alternative = {
         Alternative {
             span: Span(lo, hi),
             expr: ExprSymbol { symbols: s },
+            annotations: vec![],
             condition: c,
             action: a
         }
@@ -104,6 +105,7 @@ Alternative: Alternative = {
         Alternative {
             span: Span(lo, hi),
             expr: ExprSymbol { symbols: vec![] },
+            annotations: vec![],
             condition: c,
             action: Some(a)
         }
@@ -385,6 +387,3 @@ extern {
         "_" => Tok::Underscore,
     }
 }
-
-
-

--- a/lalrpop/src/parser/lrgrammar.lalrpop
+++ b/lalrpop/src/parser/lrgrammar.lalrpop
@@ -75,10 +75,25 @@ Nonterminal: GrammarItem =
                                                    alternatives: a })
     };
 
-Annotation: Annotation =
+Annotation: Annotation = {
     "#" "[" <lo:@L> <id:Id> <hi:@R> "]" => {
-        Annotation { id_span: Span(lo, hi), id: id }
-    };
+        Annotation {
+            id_span: Span(lo, hi),
+            id: id,
+            parameters: vec![],
+        }
+    },
+    "#" "[" <lo:@L> <id:Id> "(" <l:Comma<EqPair>> ")" <hi:@R> "]" => {
+        Annotation {
+            id_span: Span(lo, hi),
+            id: id,
+            parameters: l,
+        }
+    },
+};
+
+EqPair: (InternedString, InternedString) =
+    <l:Id> "=" <r:Id> => (l, r);
 
 NonterminalName: (NonterminalString, Vec<NonterminalString>) = {
     <MacroId> "<" <Comma<NotMacroId>> ">",

--- a/lalrpop/src/parser/lrgrammar.lalrpop
+++ b/lalrpop/src/parser/lrgrammar.lalrpop
@@ -92,20 +92,20 @@ Alternatives: Vec<Alternative> = {
 };
 
 Alternative: Alternative = {
-    <lo:@L> <s:Symbol+> <c:("if" <Cond>)?> <a:Action?> <hi:@R> => {
+    <lo:@L> <n:Annotation*> <s:Symbol+> <c:("if" <Cond>)?> <a:Action?> <hi:@R> => {
         Alternative {
             span: Span(lo, hi),
             expr: ExprSymbol { symbols: s },
-            annotations: vec![],
+            annotations: n,
             condition: c,
             action: a
         }
     },
-    <lo:@L> <c:("if" <Cond>)?> <a:Action> <hi:@R> => {
+    <lo:@L> <n:Annotation*> <c:("if" <Cond>)?> <a:Action> <hi:@R> => {
         Alternative {
             span: Span(lo, hi),
             expr: ExprSymbol { symbols: vec![] },
-            annotations: vec![],
+            annotations: n,
             condition: c,
             action: Some(a)
         }


### PR DESCRIPTION
This change is two fold, and inspired by #67. This lays the groundwork for allowing more annotations of new forms, and in new places. Regardless of the implementation of precedence rules more flexible annotations will open doors in the future.
- Change the grammar of an `Annotation` to allow key value pairs of arguments like Rust. For example `#[precedence(rank=1, assoc=left)]`.
- Add annotations to both `parse_tree::Alternative` and `repr::Production` to allow configurations on a more fine grained level.
### Open Questions
- [ ] Should we have annotations on the `repr` data structures. I think this could make sense, as it might be useful at some point. But that's not necessarily a good enough reason to do it now.
- [x] Can and should macros be able to include annotations, and if so how to do that.
- [ ] Tests
