### PR TITLE
Add support for generating files into Cargo OUT_DIR

### DIFF
--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [dependencies]
 atty = "0.1.2"
-bit-set = "0.3.0"    
+bit-set = "0.3.0"
 bitflags = "0.4.0"
 diff = "0.1"
 docopt = "0.6"
@@ -25,7 +25,8 @@ rustc-serialize = "0.3"
 term = "0.4.4"
 time = "0.1"
 unicode-xid = "0.0.2"
-        
+walkdir = "0.1.5"
+
 [dev-dependencies]
 rand = "0.3"
 

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -18,6 +18,7 @@ use tls::Tls;
 use tok;
 use walkdir;
 
+use std::env;
 use std::env::current_dir;
 use std::fs;
 use std::io::{self, Write};
@@ -37,7 +38,7 @@ pub fn process() -> io::Result<()> {
 
     // The environment variable OUT_DIR is set by cargo, and specifies
     // a directory where generated code should be put.
-    process_dir(&session, &src_dir, Path::new(env!("OUT_DIR")))
+    process_dir(&session, &src_dir, Path::new(&env::var("OUT_DIR").unwrap()))
 }
 
 pub fn process_root() -> io::Result<()> {

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -16,6 +16,7 @@ use session::{ColorConfig, Session};
 use term;
 use tls::Tls;
 use tok;
+use walkdir;
 
 use std::env::current_dir;
 use std::fs;
@@ -29,32 +30,56 @@ mod fake_term;
 
 use self::fake_term::FakeTerminal;
 
+pub fn process() -> io::Result<()> {
+    let session = Session::new();
+
+    let src_dir = try!(current_dir()).join("src");
+
+    // The environment variable OUT_DIR is set by cargo, and specifies
+    // a directory where generated code should be put.
+    process_dir(&session, &src_dir, Path::new(env!("OUT_DIR")))
+}
+
 pub fn process_root() -> io::Result<()> {
     let session = Session::new();
-    process_dir(&session, try!(current_dir()))
+    let cwd = try!(current_dir());
+    process_dir(&session, &cwd, &cwd)
 }
 
 pub fn process_root_unconditionally() -> io::Result<()> {
     let mut session = Session::new();
     session.set_force_build();
-    process_dir(&session, try!(current_dir()))
+    let cwd = try!(current_dir());
+    process_dir(&session, &cwd, &cwd)
 }
 
-fn process_dir<P:AsRef<Path>>(session: &Session, root_dir: P) -> io::Result<()> {
-    let lalrpop_files = try!(lalrpop_files(root_dir));
-    for lalrpop_file in lalrpop_files {
-        try!(process_file(session, lalrpop_file));
+fn process_dir(session: &Session, in_dir: &Path, out_dir: &Path) -> io::Result<()> {
+    for relative_lalrpop_file in try!(lalrpop_files(in_dir)) {
+        let rs_file = out_dir.join(&relative_lalrpop_file).with_extension("rs");
+        let lalrpop_file = in_dir.join(&relative_lalrpop_file);
+        try!(process_file_to(session, &lalrpop_file, &rs_file));
     }
     Ok(())
 }
 
 pub fn process_file<P:AsRef<Path>>(session: &Session, lalrpop_file: P) -> io::Result<()> {
+    let rs_file = lalrpop_file.as_ref().with_extension("rs");
+    process_file_to(session, lalrpop_file.as_ref(), &rs_file)
+}
+
+pub fn process_file_to<InPath, OutPath>(session: &Session,
+                                        lalrpop_file: InPath,
+                                        rs_file: OutPath)
+                                        -> io::Result<()>
+    where InPath: AsRef<Path>,
+          OutPath: AsRef<Path>
+{
     // Promote the session to an Rc so that we can stick it in TLS. I
     // don't want this to be part of LALRPOP's "official" interface
     // yet so don't take an `Rc<Session>` as an argument.
     let session = Rc::new(session.clone());
-    let lalrpop_file: &Path = lalrpop_file.as_ref();
-    let rs_file = lalrpop_file.with_extension("rs");
+    let lalrpop_file = lalrpop_file.as_ref();
+    let rs_file = rs_file.as_ref();
     if session.force_build() || try!(needs_rebuild(&lalrpop_file, &rs_file)) {
         log!(session, Informative, "processing file `{}`", lalrpop_file.to_string_lossy());
         try!(make_read_only(&rs_file, false));
@@ -77,6 +102,11 @@ pub fn process_file<P:AsRef<Path>>(session: &Session, lalrpop_file: P) -> io::Re
         {
             let grammar = try!(parse_and_normalize_grammar(&session, &file_text));
             let buffer = try!(emit_recursive_ascent(&session, &grammar));
+
+            if let Some(parent) = rs_file.parent() {
+                try!(fs::create_dir_all(parent));
+            }
+
             let mut output_file = try!(fs::File::create(&rs_file));
             try!(output_file.write_all(&buffer));
         }
@@ -154,24 +184,32 @@ fn make_read_only(rs_file: &Path, ro: bool) -> io::Result<()> {
     }
 }
 
-fn lalrpop_files<P:AsRef<Path>>(root_dir: P) -> io::Result<Vec<PathBuf>> {
+fn lalrpop_files(root_dir: &Path) -> io::Result<Vec<PathBuf>> {
+    // Note: this function returns paths relative to root_dir
     let mut result = vec![];
-    for entry in try!(fs::read_dir(root_dir)) {
+    let depth = root_dir.components().count();
+    for entry in walkdir::WalkDir::new(root_dir).follow_links(true) {
         let entry = try!(entry);
-        let file_type = try!(entry.file_type());
-
+        let file_type = entry.file_type();
         let path = entry.path();
-
-        if file_type.is_dir() {
-            result.extend(try!(lalrpop_files(&path)));
-        }
 
         if
             file_type.is_file() &&
             path.extension().is_some() &&
             path.extension().unwrap() == "lalrpop"
         {
-            result.push(path);
+            // Ensure that we can safely do the component stripping
+            assert!(path.starts_with(root_dir));
+
+            let mut components = path.components();
+
+            // Can't use components.skip(depth) because then we can't
+            // call as_path() after
+            for _ in 0..depth {
+                components.next();
+            }
+
+            result.push(components.as_path().to_path_buf());
         }
     }
     Ok(result)

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -20,6 +20,7 @@ extern crate itertools;
 extern crate term;
 extern crate time;
 extern crate unicode_xid;
+extern crate walkdir;
 
 #[cfg(test)]
 extern crate rand;
@@ -49,6 +50,7 @@ mod util;
 #[cfg(test)] mod generate;
 #[cfg(test)] mod test_util;
 
+pub use build::process;
 pub use build::process_root;
 pub use build::process_root_unconditionally;
 pub use build::process_file;


### PR DESCRIPTION
When I started using this library, I was very surprised when it generated source files next to the `.lalrpop` files, so that the generated files were checked into source code management.  I would expect any tools that generate source code to behave like [the example in the Cargo documentation](http://doc.crates.io/build-script.html#case-study-code-generation) and put them in the Cargo `OUT_DIR` directory.

This PR tries to apply the principle of least astonishment and adds a `.process()` function that behaves like you would expect; a file `src/foo/bar.lalrpop` is processed into `$OUT_DIR/foo/bar.rs`.  It also adds a function called `process_file_to` that lets the user decide where to put the generated file.

I wanted to get this to work for one of my own projects so the code might not be perfect or matching this project's style, so feel free to criticize at leisure!