### PR TITLE
Make LR(1) less naive

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,8 @@ and in particular can support unicode character classes like `\p{Greek}`.
 Note that some regex features -- such as non-greedy repetition and
 named capture groups -- are still not supported (or just not meaningful).
 
+Optimized LR(1) construction time by approximately 5x.
+
 # Version 0.10
 
 Major update to LALRPOP error messages in cases of shift/reduce and

--- a/lalrpop/src/collections/map.rs
+++ b/lalrpop/src/collections/map.rs
@@ -1,0 +1,13 @@
+use std::collections::BTreeMap;
+
+/// In general, we avoid coding directly against any particular map,
+/// but rather build against `util::Map` (and `util::map` to construct
+/// an instance). This should be a deterministic map, such that two
+/// runs of LALRPOP produce the same output, but otherwise it doesn't
+/// matter much. I'd probably prefer to use `HashMap` with an
+/// alternative hasher, but that's not stable.
+pub type Map<K, V> = BTreeMap<K, V>;
+
+pub fn map<K: Ord, V>() -> Map<K, V> {
+    Map::<K, V>::default()
+}

--- a/lalrpop/src/collections/mod.rs
+++ b/lalrpop/src/collections/mod.rs
@@ -1,0 +1,7 @@
+mod map;
+mod multimap;
+mod set;
+
+pub use self::map::{map, Map};
+pub use self::multimap::Multimap;
+pub use self::set::{set, Set};

--- a/lalrpop/src/collections/multimap.rs
+++ b/lalrpop/src/collections/multimap.rs
@@ -1,0 +1,46 @@
+use std::collections::btree_map;
+use std::iter::FromIterator;
+
+use super::map::{map, Map};
+
+pub struct Multimap<K, V> {
+    map: Map<K, Vec<V>>,
+}
+
+impl<K: Ord, V> Multimap<K, V> {
+    pub fn new() -> Multimap<K, V> {
+        Multimap { map: map() }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn push(&mut self, key: K, value: V) {
+        self.map.entry(key).or_insert(vec![]).push(value);
+    }
+
+    pub fn into_iter(self) -> btree_map::IntoIter<K, Vec<V>> {
+        self.map.into_iter()
+    }
+}
+
+impl<K: Ord, V> IntoIterator for Multimap<K, V> {
+    type Item = (K, Vec<V>);
+    type IntoIter = btree_map::IntoIter<K, Vec<V>>;
+    fn into_iter(self) -> btree_map::IntoIter<K, Vec<V>> {
+        self.into_iter()
+    }
+}
+
+impl<K: Ord, V> FromIterator<(K, V)> for Multimap<K, V> {
+    fn from_iter<T>(iterator: T) -> Self
+        where T: IntoIterator<Item = (K, V)>
+    {
+        let mut map = Multimap::new();
+        for (key, value) in iterator {
+            map.push(key, value);
+        }
+        map
+    }
+}

--- a/lalrpop/src/collections/set.rs
+++ b/lalrpop/src/collections/set.rs
@@ -1,0 +1,8 @@
+use std::collections::BTreeSet;
+
+/// As `Map`, but for sets.
+pub type Set<K> = BTreeSet<K>;
+
+pub fn set<K: Ord>() -> Set<K> {
+    Set::<K>::default()
+}

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -8,7 +8,8 @@ use intern::{self, InternedString};
 use grammar::pattern::{Pattern};
 use message::Content;
 use std::fmt::{Debug, Display, Formatter, Error};
-use util::{map, Map, Sep};
+use collections::{map, Map};
+use util::Sep;
 
 // These concepts we re-use wholesale
 pub use grammar::parse_tree::{Annotation,

--- a/lalrpop/src/kernel_set.rs
+++ b/lalrpop/src/kernel_set.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::hash::Hash;
-use util::{map, Map};
+use collections::{map, Map};
 
 pub struct KernelSet<K: Kernel> {
     counter: usize,

--- a/lalrpop/src/lexer/dfa/mod.rs
+++ b/lalrpop/src/lexer/dfa/mod.rs
@@ -1,12 +1,12 @@
 //! Constructs a DFA which picks the longest matching regular
 //! expression from the input.
 
+use collections::Set;
 use kernel_set::{Kernel, KernelSet};
 use std::fmt::{Debug, Display, Formatter, Error};
 use std::rc::Rc;
 use lexer::re;
 use lexer::nfa::{self, NFA, NFAConstructionError, NFAStateIndex, Test};
-use util::Set;
 
 #[cfg(test)]
 mod test;

--- a/lalrpop/src/lexer/dfa/overlap.rs
+++ b/lalrpop/src/lexer/dfa/overlap.rs
@@ -17,9 +17,9 @@
 //! covered when we started, and that each of the input ranges is
 //! covered precisely by some set of ranges in the output.
 
+use collections::Set;
 use lexer::nfa::Test;
 use std::cmp;
-use util::Set;
 
 pub fn remove_overlap(ranges: &Set<Test>) -> Vec<Test> {
     // We will do this in the dumbest possible way to start. :)
@@ -98,9 +98,9 @@ fn add_range(range: Test,
 macro_rules! test {
     ($($range:expr,)*) => {
         {
+            use collections::set;
             use lexer::nfa::Test;
             use std::char;
-            use util::set;
             let mut s = set();
             $({ let r = $range; s.insert(Test::exclusive_range(r.start, r.end)); })*
             remove_overlap(&s).into_iter()

--- a/lalrpop/src/lib.rs
+++ b/lalrpop/src/lib.rs
@@ -33,6 +33,7 @@ mod log;
 
 mod ascii_canvas;
 mod build;
+mod collections;
 mod file_text;
 mod grammar;
 mod lexer;

--- a/lalrpop/src/log.rs
+++ b/lalrpop/src/log.rs
@@ -47,3 +47,17 @@ macro_rules! debug {
         log!(::tls::Tls::session(), Debug, $($args),*)
     }
 }
+
+macro_rules! profile {
+    ($session:expr, $phase_name:expr, $action:expr) => {
+        {
+            log!($session, Verbose, "Phase `{}` begun", $phase_name);
+            let time_stamp = $crate::time::precise_time_s();
+            let result = $action;
+            log!($session, Verbose, "Phase `{}` completed in {} seconds",
+                 $phase_name, $crate::time::precise_time_s() - time_stamp);
+            result
+        }
+    }
+}
+

--- a/lalrpop/src/lr1/ascent.rs
+++ b/lalrpop/src/lr1/ascent.rs
@@ -337,7 +337,7 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
         // now emit reduces. It frequently happens that many tokens
         // trigger the same reduction, so group these by the
         // production that we are going to be reducing.
-        let reductions: Multimap<_, _> =
+        let reductions: Multimap<_, Vec<_>> =
             this_state.tokens.iter()
                              .filter_map(|(&token, action)| action.reduce().map(|p| (p, token)))
                              .collect();

--- a/lalrpop/src/lr1/ascent.rs
+++ b/lalrpop/src/lr1/ascent.rs
@@ -2,6 +2,7 @@
 //!
 //! [recursive ascent]: https://en.wikipedia.org/wiki/Recursive_ascent_parser
 
+use collections::{Multimap, Set};
 use grammar::repr::{Grammar,
                     NonterminalString,
                     Symbol,
@@ -11,7 +12,7 @@ use lr1::lookahead::Lookahead;
 use rust::RustWrite;
 use std::io::{self, Write};
 use tls::Tls;
-use util::{Escape, Multimap, Set, Sep};
+use util::{Escape, Sep};
 
 pub fn compile<'grammar,W:Write>(
     grammar: &'grammar Grammar,

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -9,7 +9,8 @@ use lr1::lookahead::Lookahead;
 use std::rc::Rc;
 use tls::Tls;
 
-#[cfg(test)] mod test;
+#[cfg(test)]
+mod test;
 
 pub fn build_lr1_states<'grammar>(grammar: &'grammar Grammar,
                                   start: NonterminalString)
@@ -59,7 +60,7 @@ impl<'grammar> LR1<'grammar> {
 
             // group the items that we can transition into by shifting
             // over a term or nonterm
-            let transitions: Multimap<Symbol, Item<'grammar>> =
+            let transitions: Multimap<Symbol, Vec<Item<'grammar>>> =
                 items.vec
                      .iter()
                      .filter_map(|item| item.shifted_item())

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -49,7 +49,7 @@ impl<'grammar> LR1<'grammar> {
         while let Some(items) = kernel_set.next() {
             let index = StateIndex(states.len());
 
-            if index.0 % 10000 == 0 && index.0 > 0 {
+            if index.0 % 5000 == 0 && index.0 > 0 {
                 log!(session, Verbose, "{} states created so far.", index.0);
             }
 

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -1,5 +1,6 @@
 //! LR(1) state construction algorithm.
 
+use collections::{map, Multimap, Set};
 use kernel_set;
 use grammar::repr::*;
 use lr1::core::*;
@@ -7,7 +8,6 @@ use lr1::first;
 use lr1::lookahead::Lookahead;
 use std::rc::Rc;
 use tls::Tls;
-use util::{map, Multimap, Set};
 
 #[cfg(test)] mod test;
 

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -17,8 +17,14 @@ pub fn build_lr1_states<'grammar>(grammar: &'grammar Grammar,
                                   -> Result<Vec<State<'grammar>>,
                                             TableConstructionError<'grammar>>
 {
-    let lr1 = LR1::new(grammar);
-    lr1.build_states(start)
+    profile! {
+        &Tls::session(),
+        "LR(1) state construction",
+        {
+            let lr1 = LR1::new(grammar);
+            lr1.build_states(start)
+        }
+    }
 }
 
 struct LR1<'grammar> {

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -43,11 +43,10 @@ impl<'grammar> LR1<'grammar> {
         let mut errors = 0;
 
         // create the starting state
-        kernel_set.add_state(
-            self.transitive_closure(
-                self.items(start_nt, 0, Lookahead::EOF)));
+        kernel_set.add_state(Kernel::start(self.items(start_nt, 0, Lookahead::EOF)));
 
-        while let Some(items) = kernel_set.next() {
+        while let Some(Kernel { items: seed_items }) = kernel_set.next() {
+            let items = self.transitive_closure(seed_items);
             let index = StateIndex(states.len());
 
             if index.0 % 5000 == 0 && index.0 > 0 {
@@ -66,9 +65,13 @@ impl<'grammar> LR1<'grammar> {
                      .filter_map(|item| item.shifted_item())
                      .collect();
 
-            for (symbol, items) in transitions.into_iter() {
-                let items = self.transitive_closure(items);
-                let next_state = kernel_set.add_state(items);
+            for (symbol, shifted_items) in transitions.into_iter() {
+                // Not entirely obvious: if the original set of items
+                // is sorted to begin with (and it is), then this new
+                // set of shifted items is *also* sorted. This is
+                // because it is produced from the old items by simply
+                // incrementing the index by 1.
+                let next_state = kernel_set.add_state(Kernel::shifted(shifted_items));
 
                 match symbol {
                     Symbol::Terminal(s) => {
@@ -180,4 +183,51 @@ impl<'grammar> LR1<'grammar> {
     }
 }
 
+/// Except for the initial state, the kernel sets always contain
+/// a set of "seed" items where something has been pushed (that is,
+/// index > 0). In other words, items like this:
+///
+///    A = ...p (*) ...
+///
+/// where ...p is non-empty. We now have to expand to include any
+/// epsilon moves:
+///
+///    A = ... (*) B ...
+///    B = (*) ...        // added by transitive_closure algorithm
+///
+/// But note that the state is completely identified by its
+/// kernel set: the same kernel sets always expand to the
+/// same transitive closures, and different kernel sets
+/// always expand to different transitive closures. The
+/// first point is obvious, but the latter point follows
+/// because the transitive closure algorithm only adds
+/// items where `index == 0`, and hence it can never add an
+/// item found in a kernel set.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+struct Kernel<'grammar> {
+    items: Vec<Item<'grammar>>
+}
 
+impl<'grammar> Kernel<'grammar> {
+    pub fn start(items: Vec<Item<'grammar>>) -> Kernel<'grammar> {
+        // In start state, kernel should have only items with `index == 0`.
+        debug_assert!(items.iter().all(|item| item.index == 0));
+        Kernel { items: items }
+    }
+
+    pub fn shifted(items: Vec<Item<'grammar>>) -> Kernel<'grammar> {
+        // Assert that this kernel consists only of shifted items
+        // where `index > 0`. This assertion could cost real time to
+        // check so only do it in debug mode.
+        debug_assert!(items.iter().all(|item| item.index > 0));
+        Kernel { items: items }
+    }
+}
+
+impl<'grammar> kernel_set::Kernel for Kernel<'grammar> {
+    type Index = StateIndex;
+
+    fn index(c: usize) -> StateIndex {
+        StateIndex(c)
+    }
+}

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -7,7 +7,7 @@ use lr1::core::Action::{Reduce, Shift};
 use lr1::lookahead::Lookahead;
 use grammar::repr::*;
 use std::rc::Rc;
-use util::{map, Map};
+use collections::{map, Map};
 use util::map::Entry;
 
 #[cfg(test)]

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -1,5 +1,6 @@
 //! Mega naive LALR(1) generation algorithm.
 
+use collections::{map, Map};
 use itertools::Itertools;
 use lr1::build;
 use lr1::core::*;
@@ -7,7 +8,7 @@ use lr1::core::Action::{Reduce, Shift};
 use lr1::lookahead::Lookahead;
 use grammar::repr::*;
 use std::rc::Rc;
-use collections::{map, Map};
+use tls::Tls;
 use util::map::Entry;
 
 #[cfg(test)]
@@ -31,7 +32,12 @@ pub fn build_lalr_states<'grammar>(grammar: &'grammar Grammar,
 {
     // First build the LR(1) states
     let lr_states = try!(build::build_lr1_states(grammar, start));
-    collapse_to_lalr_states(&lr_states)
+
+    profile! {
+        &Tls::session(),
+        "LALR(1) state collapse",
+        collapse_to_lalr_states(&lr_states)
+    }
 }
 
 pub fn collapse_to_lalr_states<'grammar>(lr_states: &[State<'grammar>])

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -1,7 +1,6 @@
 //! Core LR(1) types.
 
 use collections::Map;
-use kernel_set;
 use grammar::repr::*;
 use std::fmt::{Debug, Formatter, Error};
 use std::rc::Rc;
@@ -93,14 +92,6 @@ pub struct StateIndex(pub usize);
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Items<'grammar> {
     pub vec: Rc<Vec<Item<'grammar>>>
-}
-
-impl<'grammar> kernel_set::Kernel for Items<'grammar> {
-    type Index = StateIndex;
-
-    fn index(c: usize) -> StateIndex {
-        StateIndex(c)
-    }
 }
 
 #[derive(Debug)]

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -1,10 +1,11 @@
 //! Core LR(1) types.
 
+use collections::Map;
 use kernel_set;
 use grammar::repr::*;
 use std::fmt::{Debug, Formatter, Error};
 use std::rc::Rc;
-use util::{Map, Prefix};
+use util::Prefix;
 
 use super::lookahead::Lookahead;
 

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -1,17 +1,16 @@
 //! Error reporting. For now very stupid and simplistic.
 
-use itertools::Itertools;
-use grammar::repr::*;
-use message::{Message};
-use message::builder::{Builder, BodyCharacter, Character, MessageBuilder};
-use util::{Map, map};
+use collections::{Map, map, set};
 use lr1::trace::Tracer;
 use lr1::core::*;
 use lr1::example::{Example, ExampleStyles, ExampleSymbol};
 use lr1::first::FirstSets;
 use lr1::lookahead::{Lookahead, LookaheadSet};
+use itertools::Itertools;
+use grammar::repr::*;
+use message::{Message};
+use message::builder::{Builder, BodyCharacter, Character, MessageBuilder};
 use tls::Tls;
-use util::set;
 
 #[cfg(test)] mod test;
 

--- a/lalrpop/src/lr1/first/mod.rs
+++ b/lalrpop/src/lr1/first/mod.rs
@@ -1,8 +1,8 @@
 //! First set construction and computation.
 
+use collections::{Map, map};
 use grammar::repr::*;
 use lr1::lookahead::{Lookahead, LookaheadSet};
-use util::{Map, map};
 
 #[cfg(test)]
 mod test;

--- a/lalrpop/src/lr1/trace/mod.rs
+++ b/lalrpop/src/lr1/trace/mod.rs
@@ -1,8 +1,8 @@
+use collections::{Set, set};
 use lr1::core::*;
 use lr1::first::FirstSets;
 use lr1::state_graph::StateGraph;
 use grammar::repr::*;
-use util::{Set, set};
 
 mod reduce;
 mod shift;

--- a/lalrpop/src/lr1/trace/trace_graph/mod.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/mod.rs
@@ -1,10 +1,10 @@
+use collections::{Map, map};
 use lr1::core::*;
 use lr1::example::*;
 use grammar::repr::*;
 use petgraph::{EdgeDirection, Graph};
 use petgraph::graph::{Edges, NodeIndex};
 use std::fmt::{Debug, Formatter, Error};
-use util::{Map, map};
 
 #[cfg(test)] mod test;
 

--- a/lalrpop/src/normalize/inline/graph/mod.rs
+++ b/lalrpop/src/normalize/inline/graph/mod.rs
@@ -5,7 +5,7 @@ use normalize::{NormError, NormResult};
 use petgraph::graph::{Graph, NodeIndex};
 use grammar::consts::INLINE;
 use grammar::repr::*;
-use util::{map, Map};
+use collections::{map, Map};
 
 #[cfg(test)]
 mod test;

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -10,7 +10,7 @@ use grammar::pattern::{Pattern, PatternKind};
 use grammar::parse_tree as pt;
 use grammar::parse_tree::{InternToken, NonterminalString, TerminalString};
 use grammar::repr as r;
-use util::{map, Map};
+use collections::{map, Map};
 
 pub fn lower(grammar: pt::Grammar, types: r::Types) -> NormResult<r::Grammar> {
     let state = LowerState::new(types, &grammar);

--- a/lalrpop/src/normalize/mod.rs
+++ b/lalrpop/src/normalize/mod.rs
@@ -35,19 +35,6 @@ pub fn normalize_without_validating(grammar: pt::Grammar) -> NormResult<r::Gramm
     normalize_helper(&Session::new(), grammar, false)
 }
 
-macro_rules! profile {
-    ($session:expr, $phase_name:expr, $action:expr) => {
-        {
-            log!($session, Verbose, "Phase `{}` begun", $phase_name);
-            let time_stamp = $crate::time::precise_time_s();
-            let result = $action;
-            log!($session, Verbose, "Phase `{}` completed in {} seconds",
-                 $phase_name, $crate::time::precise_time_s() - time_stamp);
-            result
-        }
-    }
-}
-
 fn normalize_helper(session: &Session,
                     grammar: pt::Grammar,
                     validate: bool)

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -143,7 +143,7 @@ impl<'grammar> Validator<'grammar> {
                         })
                         .collect();
 
-        let named: Multimap<InternedString, &Symbol> =
+        let named: Multimap<InternedString, Vec<&Symbol>> =
             expr.symbols.iter()
                         .filter_map(|sym| match sym.kind {
                             SymbolKind::Name(nt, _) => Some((nt, sym)),

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -7,7 +7,8 @@ use grammar::consts::*;
 use grammar::parse_tree::*;
 use grammar::repr;
 use intern::{intern, InternedString};
-use util::{Multimap, Sep, set};
+use collections::{Multimap, set};
+use util::Sep;
 
 #[cfg(test)]
 mod test;

--- a/lalrpop/src/normalize/resolve/mod.rs
+++ b/lalrpop/src/normalize/resolve/mod.rs
@@ -5,7 +5,7 @@ use super::{NormResult, NormError};
 
 use grammar::parse_tree::*;
 use intern::{InternedString};
-use util::{map, Map};
+use collections::{map, Map};
 
 #[cfg(test)]
 mod test;

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -13,8 +13,8 @@ use lexer::dfa::{self, DFAConstructionError, Precedence};
 use lexer::nfa::NFAConstructionError::*;
 use grammar::consts::*;
 use grammar::parse_tree::*;
-use util::{Set};
-use util::{map, Map};
+use collections::Set;
+use collections::{map, Map};
 
 #[cfg(test)]
 mod test;

--- a/lalrpop/src/util.rs
+++ b/lalrpop/src/util.rs
@@ -1,6 +1,4 @@
-use std::collections::{btree_map, BTreeMap, BTreeSet};
 use std::fmt::{Display, Formatter, Error};
-use std::iter::FromIterator;
 
 pub use std::collections::btree_map as map;
 pub struct Sep<S>(pub &'static str, pub S);
@@ -46,65 +44,6 @@ impl<'a,S:Display> Display for Prefix<&'a [S]> {
         }
         Ok(())
     }
-}
-
-pub struct Multimap<K,V> {
-    map: Map<K,Vec<V>>
-}
-
-impl<K:Ord,V> Multimap<K,V> {
-    pub fn new() -> Multimap<K,V> {
-        Multimap { map: map() }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
-    }
-
-    pub fn push(&mut self, key: K, value: V) {
-        self.map.entry(key).or_insert(vec![]).push(value);
-    }
-
-    pub fn into_iter(self) -> btree_map::IntoIter<K, Vec<V>> {
-        self.map.into_iter()
-    }
-}
-
-impl<K:Ord,V> IntoIterator for Multimap<K,V> {
-    type Item = (K, Vec<V>);
-    type IntoIter = btree_map::IntoIter<K, Vec<V>>;
-    fn into_iter(self) -> btree_map::IntoIter<K, Vec<V>> {
-        self.into_iter()
-    }
-}
-
-impl<K:Ord,V> FromIterator<(K,V)> for Multimap<K,V> {
-    fn from_iter<T>(iterator: T) -> Self where T: IntoIterator<Item=(K,V)> {
-        let mut map = Multimap::new();
-        for (key, value) in iterator {
-            map.push(key, value);
-        }
-        map
-    }
-}
-
-/// In general, we avoid coding directly against any particular map,
-/// but rather build against `util::Map` (and `util::map` to construct
-/// an instance). This should be a deterministic map, such that two
-/// runs of LALRPOP produce the same output, but otherwise it doesn't
-/// matter much. I'd probably prefer to use `HashMap` with an
-/// alternative hasher, but that's not stable.
-pub type Map<K,V> = BTreeMap<K,V>;
-
-pub fn map<K:Ord,V>() -> Map<K,V> {
-    Map::<K,V>::default()
-}
-
-/// As `Map`, but for sets.
-pub type Set<K> = BTreeSet<K>;
-
-pub fn set<K:Ord>() -> Set<K> {
-    Set::<K>::default()
 }
 
 /// Strip leading and trailing whitespace.


### PR DESCRIPTION
There is plenty of work left to do on improving the LR(1) construction code, but I just picked some low-hanging fruit. Instead of computing the transitive closure after analyzing the shift items, and using the TC to index the state, I now index the state just by the "kernel" set, which is the items that resulted after shifting, before we add the epsilon moves. I believe this is equivalent. The result is that we compute the TC once per state and not once per transition. This makes a MASSIVE difference for large grammars.

Here are some timing results from [rustypop](https://github.com/nikomatsakis/rustypop). Before:

```
Mr-Darcy-2. time ~/versioned/lalrpop/lalrpop/target/release/lalrpop -f parser-lalr.lalrpop
processing file `parser-lalr.lalrpop`

real    2m51.857s
user    2m51.462s
sys     0m0.311s
```

After:

```
Mr-Darcy-2. time ~/versioned/lalrpop/lalrpop/target/release/lalrpop -f parser-lalr.lalrpop
processing file `parser-lalr.lalrpop`

real    0m24.893s
user    0m24.512s
sys     0m0.297s
```