### PR TITLE
Fix typo in report_error_suggest_inline

### DIFF
--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -328,7 +328,7 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
             .verbatimed()
             .punctuated(".")
             .text("For more information, see the section on inlining")
-            .text("in the LALROP manual.")
+            .text("in the LALRPOP manual.")
             .end()
             .end()
             .end()


### PR DESCRIPTION
LALROP -> LALRPOP

PS: The GitHub online editor is great for tiny fixes like this!