### PR TITLE
Default actions for `()`, make fewer options in recursive ascent code

### DIFF
--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pascal"
+version = "0.11.0"
+authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+build = "build.rs"
+
+[build-dependencies.lalrpop]
+path = "../../../lalrpop"
+
+[dependencies]
+docopt = "0.6"
+lalrpop-util = "0.11.0"
+rustc-serialize = "0.3"
+time = "0.1"

--- a/doc/pascal/lalrpop/build.rs
+++ b/doc/pascal/lalrpop/build.rs
@@ -1,0 +1,8 @@
+extern crate lalrpop;
+
+fn main() {
+    lalrpop::Configuration::new()
+        .emit_comments(true)
+        .process_current_dir()
+        .unwrap();
+}

--- a/doc/pascal/lalrpop/pascal.y
+++ b/doc/pascal/lalrpop/pascal.y
@@ -1,0 +1,523 @@
+%{
+%}
+
+%token AND ARRAY ASSIGNMENT CASE CHARACTER_STRING COLON COMMA CONST DIGSEQ
+%token DIV DO DOT DOTDOT DOWNTO ELSE END EQUAL EXTERNAL FOR FORWARD FUNCTION
+%token GE GOTO GT IDENTIFIER IF IN LABEL LBRAC LE LPAREN LT MINUS MOD NIL NOT
+%token NOTEQUAL OF OR OTHERWISE PACKED PBEGIN PFILE PLUS PROCEDURE PROGRAM RBRAC
+%token REALNUMBER RECORD REPEAT RPAREN SEMICOLON SET SLASH STAR STARSTAR THEN
+%token TO TYPE UNTIL UPARROW VAR WHILE WITH
+
+%%
+file : program
+ | module
+ ;
+
+program : program_heading semicolon block DOT
+ ;
+
+program_heading : PROGRAM identifier
+ | PROGRAM identifier LPAREN identifier_list RPAREN
+ ;
+
+identifier_list : identifier_list comma identifier
+ | identifier
+ ;
+
+block : label_declaration_part
+ constant_definition_part
+ type_definition_part
+ variable_declaration_part
+ procedure_and_function_declaration_part
+ statement_part
+ ;
+
+module : constant_definition_part
+ type_definition_part
+ variable_declaration_part
+ procedure_and_function_declaration_part
+ ;
+
+label_declaration_part : LABEL label_list semicolon
+ |
+ ;
+
+label_list : label_list comma label
+ | label
+ ;
+
+label : DIGSEQ
+ ;
+
+constant_definition_part : CONST constant_list
+ |
+ ;
+
+constant_list : constant_list constant_definition
+ | constant_definition
+ ;
+
+constant_definition : identifier EQUAL cexpression semicolon
+ ;
+
+cexpression : csimple_expression
+ | csimple_expression relop csimple_expression
+ ;
+
+csimple_expression : cterm
+ | csimple_expression addop cterm
+ ;
+
+cterm : cfactor
+ | cterm mulop cfactor
+ ;
+
+cfactor : sign cfactor
+ | cexponentiation
+ ;
+
+cexponentiation : cprimary
+ | cprimary STARSTAR cexponentiation
+ ;
+
+cprimary : identifier
+ | LPAREN cexpression RPAREN
+ | unsigned_constant
+ | NOT cprimary
+ ;
+
+constant : non_string
+ | sign non_string
+ | CHARACTER_STRING
+ ;
+
+sign : PLUS
+ | MINUS
+ ;
+
+non_string : DIGSEQ
+ | identifier
+ | REALNUMBER
+ ;
+
+type_definition_part : TYPE type_definition_list
+ |
+ ;
+
+type_definition_list : type_definition_list type_definition
+ | type_definition
+ ;
+
+type_definition : identifier EQUAL type_denoter semicolon
+ ;
+
+type_denoter : identifier
+ | new_type
+ ;
+
+new_type : new_ordinal_type
+ | new_structured_type
+ | new_pointer_type
+ ;
+
+new_ordinal_type : enumerated_type
+ | subrange_type
+ ;
+
+enumerated_type : LPAREN identifier_list RPAREN
+ ;
+
+subrange_type : constant DOTDOT constant
+ ;
+
+new_structured_type : structured_type
+ | PACKED structured_type
+ ;
+
+structured_type : array_type
+ | record_type
+ | set_type
+ | file_type
+ ;
+
+array_type : ARRAY LBRAC index_list RBRAC OF component_type
+ ;
+
+index_list : index_list comma index_type
+ | index_type
+ ;
+
+index_type : ordinal_type ;
+
+ordinal_type : new_ordinal_type
+ | identifier
+ ;
+
+component_type : type_denoter ;
+
+record_type : RECORD record_section_list END
+ | RECORD record_section_list semicolon variant_part END
+ | RECORD variant_part END
+ ;
+
+record_section_list : record_section_list semicolon record_section
+ | record_section
+ ;
+
+record_section : identifier_list COLON type_denoter
+ ;
+
+variant_part : CASE variant_selector OF variant_list semicolon
+ | CASE variant_selector OF variant_list
+ |
+ ;
+
+variant_selector : tag_field COLON tag_type
+ | tag_type
+ ;
+
+variant_list : variant_list semicolon variant
+ | variant
+ ;
+
+variant : case_constant_list COLON LPAREN record_section_list RPAREN
+ | case_constant_list COLON LPAREN record_section_list semicolon
+  variant_part RPAREN
+ | case_constant_list COLON LPAREN variant_part RPAREN
+ ;
+
+case_constant_list : case_constant_list comma case_constant
+ | case_constant
+ ;
+
+case_constant : constant
+ | constant DOTDOT constant
+ ;
+
+tag_field : identifier ;
+
+tag_type : identifier ;
+
+set_type : SET OF base_type
+ ;
+
+base_type : ordinal_type ;
+
+file_type : PFILE OF component_type
+ ;
+
+new_pointer_type : UPARROW domain_type
+ ;
+
+domain_type : identifier ;
+
+variable_declaration_part : VAR variable_declaration_list semicolon
+ |
+ ;
+
+variable_declaration_list :
+   variable_declaration_list semicolon variable_declaration
+ | variable_declaration
+ ;
+
+variable_declaration : identifier_list COLON type_denoter
+ ;
+
+procedure_and_function_declaration_part :
+  proc_or_func_declaration_list semicolon
+ |
+ ;
+
+proc_or_func_declaration_list :
+   proc_or_func_declaration_list semicolon proc_or_func_declaration
+ | proc_or_func_declaration
+ ;
+
+proc_or_func_declaration : procedure_declaration
+ | function_declaration
+ ;
+
+procedure_declaration : procedure_heading semicolon directive
+ | procedure_heading semicolon procedure_block
+ ;
+
+procedure_heading : procedure_identification
+ | procedure_identification formal_parameter_list
+ ;
+
+directive : FORWARD
+ | EXTERNAL
+ ;
+
+formal_parameter_list : LPAREN formal_parameter_section_list RPAREN ;
+
+formal_parameter_section_list : formal_parameter_section_list semicolon formal_parameter_section
+ | formal_parameter_section
+ ;
+
+formal_parameter_section : value_parameter_specification
+ | variable_parameter_specification
+ | procedural_parameter_specification
+ | functional_parameter_specification
+ ;
+
+value_parameter_specification : identifier_list COLON identifier
+ ;
+
+variable_parameter_specification : VAR identifier_list COLON identifier
+ ;
+
+procedural_parameter_specification : procedure_heading ;
+
+functional_parameter_specification : function_heading ;
+
+procedure_identification : PROCEDURE identifier ;
+
+procedure_block : block ;
+
+function_declaration : function_heading semicolon directive
+ | function_identification semicolon function_block
+ | function_heading semicolon function_block
+ ;
+
+function_heading : FUNCTION identifier COLON result_type
+ | FUNCTION identifier formal_parameter_list COLON result_type
+ ;
+
+result_type : identifier ;
+
+function_identification : FUNCTION identifier ;
+
+function_block : block ;
+
+statement_part : compound_statement ;
+
+compound_statement : PBEGIN statement_sequence END ;
+
+statement_sequence : statement_sequence semicolon statement
+ | statement
+ ;
+
+statement : open_statement
+ | closed_statement
+ ;
+
+open_statement : label COLON non_labeled_open_statement
+ | non_labeled_open_statement
+ ;
+
+closed_statement : label COLON non_labeled_closed_statement
+ | non_labeled_closed_statement
+ ;
+
+non_labeled_closed_statement : assignment_statement
+ | procedure_statement
+ | goto_statement
+ | compound_statement
+ | case_statement
+ | repeat_statement
+ | closed_with_statement
+ | closed_if_statement
+ | closed_while_statement
+ | closed_for_statement
+ |
+ ;
+
+non_labeled_open_statement : open_with_statement
+ | open_if_statement
+ | open_while_statement
+ | open_for_statement
+ ;
+
+repeat_statement : REPEAT statement_sequence UNTIL boolean_expression
+ ;
+
+open_while_statement : WHILE boolean_expression DO open_statement
+ ;
+
+closed_while_statement : WHILE boolean_expression DO closed_statement
+ ;
+
+open_for_statement : FOR control_variable ASSIGNMENT initial_value direction
+   final_value DO open_statement
+ ;
+
+closed_for_statement : FOR control_variable ASSIGNMENT initial_value direction
+   final_value DO closed_statement
+ ;
+
+open_with_statement : WITH record_variable_list DO open_statement
+ ;
+
+closed_with_statement : WITH record_variable_list DO closed_statement
+ ;
+
+open_if_statement : IF boolean_expression THEN statement
+ | IF boolean_expression THEN closed_statement ELSE open_statement
+ ;
+
+closed_if_statement : IF boolean_expression THEN closed_statement
+   ELSE closed_statement
+ ;
+
+assignment_statement : variable_access ASSIGNMENT expression
+ ;
+
+variable_access : identifier
+ | indexed_variable
+ | field_designator
+ | variable_access UPARROW
+ ;
+
+indexed_variable : variable_access LBRAC index_expression_list RBRAC
+ ;
+
+index_expression_list : index_expression_list comma index_expression
+ | index_expression
+ ;
+
+index_expression : expression ;
+
+field_designator : variable_access DOT identifier
+ ;
+
+procedure_statement : identifier params
+ | identifier
+ ;
+
+params : LPAREN actual_parameter_list RPAREN ;
+
+actual_parameter_list : actual_parameter_list comma actual_parameter
+ | actual_parameter
+ ;
+
+actual_parameter : expression
+ | expression COLON expression
+ | expression COLON expression COLON expression
+ ;
+
+goto_statement : GOTO label
+ ;
+
+case_statement : CASE case_index OF case_list_element_list END
+ | CASE case_index OF case_list_element_list SEMICOLON END
+ | CASE case_index OF case_list_element_list semicolon
+   otherwisepart statement END
+ | CASE case_index OF case_list_element_list semicolon
+   otherwisepart statement SEMICOLON END
+ ;
+
+case_index : expression ;
+
+case_list_element_list : case_list_element_list semicolon case_list_element
+ | case_list_element
+ ;
+
+case_list_element : case_constant_list COLON statement
+ ;
+
+otherwisepart : OTHERWISE
+ | OTHERWISE COLON
+ ;
+
+control_variable : identifier ;
+
+initial_value : expression ;
+
+direction : TO
+ | DOWNTO
+ ;
+
+final_value : expression ;
+
+record_variable_list : record_variable_list comma variable_access
+ | variable_access
+ ;
+
+boolean_expression : expression ;
+
+expression : simple_expression
+ | simple_expression relop simple_expression
+ ;
+
+simple_expression : term
+ | simple_expression addop term
+ ;
+
+term : factor
+ | term mulop factor
+ ;
+
+factor : sign factor
+ | exponentiation
+ ;
+
+exponentiation : primary
+ | primary STARSTAR exponentiation
+ ;
+
+primary : variable_access
+ | unsigned_constant
+ | function_designator
+ | set_constructor
+ | LPAREN expression RPAREN
+ | NOT primary
+ ;
+
+unsigned_constant : unsigned_number
+ | CHARACTER_STRING
+ | NIL
+ ;
+
+unsigned_number : unsigned_integer | unsigned_real ;
+
+unsigned_integer : DIGSEQ
+ ;
+
+unsigned_real : REALNUMBER
+ ;
+
+function_designator : identifier params
+ ;
+
+set_constructor : LBRAC member_designator_list RBRAC
+ | LBRAC RBRAC
+ ;
+
+member_designator_list : member_designator_list comma member_designator
+ | member_designator
+ ;
+
+member_designator : member_designator DOTDOT expression
+ | expression
+ ;
+
+addop: PLUS
+ | MINUS
+ | OR
+ ;
+
+mulop : STAR
+ | SLASH
+ | DIV
+ | MOD
+ | AND
+ ;
+
+relop : EQUAL
+ | NOTEQUAL
+ | LT
+ | GT
+ | LE
+ | GE
+ | IN
+ ;
+
+identifier : IDENTIFIER
+ ;
+
+semicolon : SEMICOLON
+ ;
+
+comma : COMMA
+ ;

--- a/doc/pascal/lalrpop/src/main.rs
+++ b/doc/pascal/lalrpop/src/main.rs
@@ -1,0 +1,45 @@
+extern crate docopt;
+extern crate rustc_serialize;
+extern crate time;
+
+use docopt::Docopt;
+use std::env;
+use std::io::Read;
+use std::fs::File;
+
+mod pascal;
+
+fn main() {
+    let args: Args = Docopt::new(USAGE)
+                         .and_then(|d| d.argv(env::args()).decode())
+                         .unwrap_or_else(|e| e.exit());
+
+    for input in &args.arg_inputs {
+        let mut s = String::new();
+        if let Err(err) = File::open(input).and_then(|mut f| f.read_to_string(&mut s)) {
+            println!("Input `{}`: I/O Error {}",
+                     input, err);
+            continue;
+        }
+
+        let time_stamp = time::precise_time_s();
+        let result = pascal::parse_file(&s);
+        let elapsed = time::precise_time_s() - time_stamp;
+
+        match result {
+            Ok(()) => println!("Input `{}` ({}s): OK", input, elapsed),
+            Err(err) => println!("Input `{}` ({}s): parse error {:?}", input, elapsed, err),
+        }
+    }
+}
+
+const USAGE: &'static str = "
+Usage: pascal <inputs>...
+
+Parses each input file.
+";
+
+#[derive(Debug, RustcDecodable)]
+struct Args {
+    arg_inputs: Vec<String>,
+}

--- a/doc/pascal/lalrpop/src/pascal.lalrpop
+++ b/doc/pascal/lalrpop/src/pascal.lalrpop
@@ -1,0 +1,656 @@
+grammar;
+
+pub file: () = {
+    program,
+    module,
+};
+
+program: () = {
+    program_heading semicolon block ".",
+};
+
+program_heading: () = {
+    "PROGRAM" identifier,
+    "PROGRAM" identifier "(" identifier_list ")",
+};
+
+identifier_list: () = {
+    identifier_list comma identifier,
+    identifier,
+};
+
+block: () = {
+    label_declaration_part constant_definition_part type_definition_part variable_declaration_part procedure_and_function_declaration_part statement_part,
+};
+
+module: () = {
+    constant_definition_part type_definition_part variable_declaration_part procedure_and_function_declaration_part,
+};
+
+label_declaration_part: () = {
+    "LABEL" label_list semicolon,
+    () ,
+};
+
+label_list: () = {
+    label_list comma label,
+    label,
+};
+
+label: () = {
+    r"\d+",
+};
+
+constant_definition_part: () = {
+    "CONST" constant_list,
+    () ,
+};
+
+constant_list: () = {
+    constant_list constant_definition,
+    constant_definition,
+};
+
+constant_definition: () = {
+    identifier "=" cexpression semicolon,
+};
+
+cexpression: () = {
+    csimple_expression,
+    csimple_expression relop csimple_expression,
+};
+
+csimple_expression: () = {
+    cterm,
+    csimple_expression addop cterm,
+};
+
+cterm: () = {
+    cfactor,
+    cterm mulop cfactor,
+};
+
+cfactor: () = {
+    sign cfactor,
+    cexponentiation,
+};
+
+cexponentiation: () = {
+    cprimary,
+    cprimary "**" cexponentiation,
+};
+
+cprimary: () = {
+    identifier,
+    "(" cexpression ")",
+    unsigned_constant,
+    "NOT" cprimary,
+};
+
+constant: () = {
+    non_string,
+    sign non_string,
+    r"'[^']*'",
+};
+
+sign: () = {
+    "+",
+    "-",
+};
+
+non_string: () = {
+    r"\d+",
+    identifier,
+    r"\d+\.\d+",
+};
+
+type_definition_part: () = {
+    "TYPE" type_definition_list,
+    () ,
+};
+
+type_definition_list: () = {
+    type_definition_list type_definition,
+    type_definition,
+};
+
+type_definition: () = {
+    identifier "=" type_denoter semicolon,
+};
+
+type_denoter: () = {
+    identifier,
+    new_type,
+};
+
+new_type: () = {
+    new_ordinal_type,
+    new_structured_type,
+    new_pointer_type,
+};
+
+new_ordinal_type: () = {
+    enumerated_type,
+    subrange_type,
+};
+
+enumerated_type: () = {
+    "(" identifier_list ")",
+};
+
+subrange_type: () = {
+    constant ".." constant,
+};
+
+new_structured_type: () = {
+    structured_type,
+    "PACKED" structured_type,
+};
+
+structured_type: () = {
+    array_type,
+    record_type,
+    set_type,
+    file_type,
+};
+
+array_type: () = {
+    "ARRAY" "[" index_list "]" "OF" component_type,
+};
+
+index_list: () = {
+    index_list comma index_type,
+    index_type,
+};
+
+index_type: () = {
+    ordinal_type,
+};
+
+ordinal_type: () = {
+    new_ordinal_type,
+    identifier,
+};
+
+component_type: () = {
+    type_denoter,
+};
+
+record_type: () = {
+    "RECORD" record_section_list "END",
+    "RECORD" record_section_list semicolon variant_part "END",
+    "RECORD" variant_part "END",
+};
+
+record_section_list: () = {
+    record_section_list semicolon record_section,
+    record_section,
+};
+
+record_section: () = {
+    identifier_list ":" type_denoter,
+};
+
+variant_part: () = {
+    "CASE" variant_selector "OF" variant_list semicolon,
+    "CASE" variant_selector "OF" variant_list,
+    () ,
+};
+
+variant_selector: () = {
+    tag_field ":" tag_type,
+    tag_type,
+};
+
+variant_list: () = {
+    variant_list semicolon variant,
+    variant,
+};
+
+variant: () = {
+    case_constant_list ":" "(" record_section_list ")",
+    case_constant_list ":" "(" record_section_list semicolon variant_part ")",
+    case_constant_list ":" "(" variant_part ")",
+};
+
+case_constant_list: () = {
+    case_constant_list comma case_constant,
+    case_constant,
+};
+
+case_constant: () = {
+    constant,
+    constant ".." constant,
+};
+
+tag_field: () = {
+    identifier,
+};
+
+tag_type: () = {
+    identifier,
+};
+
+set_type: () = {
+    "SET" "OF" base_type,
+};
+
+base_type: () = {
+    ordinal_type,
+};
+
+file_type: () = {
+    "PFILE" "OF" component_type,
+};
+
+new_pointer_type: () = {
+    "^" domain_type,
+};
+
+domain_type: () = {
+    identifier,
+};
+
+variable_declaration_part: () = {
+    "VAR" variable_declaration_list semicolon,
+    () ,
+};
+
+variable_declaration_list: () = {
+    variable_declaration_list semicolon variable_declaration,
+    variable_declaration,
+};
+
+variable_declaration: () = {
+    identifier_list ":" type_denoter,
+};
+
+procedure_and_function_declaration_part: () = {
+    proc_or_func_declaration_list semicolon,
+    () ,
+};
+
+proc_or_func_declaration_list: () = {
+    proc_or_func_declaration_list semicolon proc_or_func_declaration,
+    proc_or_func_declaration,
+};
+
+proc_or_func_declaration: () = {
+    procedure_declaration,
+    function_declaration,
+};
+
+procedure_declaration: () = {
+    procedure_heading semicolon directive,
+    procedure_heading semicolon procedure_block,
+};
+
+procedure_heading: () = {
+    procedure_identification,
+    procedure_identification formal_parameter_list,
+};
+
+directive: () = {
+    "FORWARD",
+    "EXTERNAL",
+};
+
+formal_parameter_list: () = {
+    "(" formal_parameter_section_list ")",
+};
+
+formal_parameter_section_list: () = {
+    formal_parameter_section_list semicolon formal_parameter_section,
+    formal_parameter_section,
+};
+
+formal_parameter_section: () = {
+    value_parameter_specification,
+    variable_parameter_specification,
+    procedural_parameter_specification,
+    functional_parameter_specification,
+};
+
+value_parameter_specification: () = {
+    identifier_list ":" identifier,
+};
+
+variable_parameter_specification: () = {
+    "VAR" identifier_list ":" identifier,
+};
+
+procedural_parameter_specification: () = {
+    procedure_heading,
+};
+
+functional_parameter_specification: () = {
+    function_heading,
+};
+
+procedure_identification: () = {
+    "PROCEDURE" identifier,
+};
+
+procedure_block: () = {
+    block,
+};
+
+function_declaration: () = {
+    function_heading semicolon directive,
+    function_identification semicolon function_block,
+    function_heading semicolon function_block,
+};
+
+function_heading: () = {
+    "FUNCTION" identifier ":" result_type,
+    "FUNCTION" identifier formal_parameter_list ":" result_type,
+};
+
+result_type: () = {
+    identifier,
+};
+
+function_identification: () = {
+    "FUNCTION" identifier,
+};
+
+function_block: () = {
+    block,
+};
+
+statement_part: () = {
+    compound_statement,
+};
+
+compound_statement: () = {
+    "BEGIN" statement_sequence "END",
+};
+
+statement_sequence: () = {
+    statement_sequence semicolon statement,
+    statement,
+};
+
+statement: () = {
+    open_statement,
+    closed_statement,
+};
+
+open_statement: () = {
+    label ":" non_labeled_open_statement,
+    non_labeled_open_statement,
+};
+
+closed_statement: () = {
+    label ":" non_labeled_closed_statement,
+    non_labeled_closed_statement,
+};
+
+non_labeled_closed_statement: () = {
+    assignment_statement,
+    procedure_statement,
+    goto_statement,
+    compound_statement,
+    case_statement,
+    repeat_statement,
+    closed_with_statement,
+    closed_if_statement,
+    closed_while_statement,
+    closed_for_statement,
+    () ,
+};
+
+non_labeled_open_statement: () = {
+    open_with_statement,
+    open_if_statement,
+    open_while_statement,
+    open_for_statement,
+};
+
+repeat_statement: () = {
+    "REPEAT" statement_sequence "UNTIL" boolean_expression,
+};
+
+open_while_statement: () = {
+    "WHILE" boolean_expression "DO" open_statement,
+};
+
+closed_while_statement: () = {
+    "WHILE" boolean_expression "DO" closed_statement,
+};
+
+open_for_statement: () = {
+    "FOR" control_variable ":=" initial_value direction final_value "DO" open_statement,
+};
+
+closed_for_statement: () = {
+    "FOR" control_variable ":=" initial_value direction final_value "DO" closed_statement,
+};
+
+open_with_statement: () = {
+    "WITH" record_variable_list "DO" open_statement,
+};
+
+closed_with_statement: () = {
+    "WITH" record_variable_list "DO" closed_statement,
+};
+
+open_if_statement: () = {
+    "IF" boolean_expression "THEN" statement,
+    "IF" boolean_expression "THEN" closed_statement "ELSE" open_statement,
+};
+
+closed_if_statement: () = {
+    "IF" boolean_expression "THEN" closed_statement "ELSE" closed_statement,
+};
+
+assignment_statement: () = {
+    variable_access ":=" expression,
+};
+
+variable_access: () = {
+    identifier,
+    indexed_variable,
+    field_designator,
+    variable_access "^",
+};
+
+indexed_variable: () = {
+    variable_access "[" index_expression_list "]",
+};
+
+index_expression_list: () = {
+    index_expression_list comma index_expression,
+    index_expression,
+};
+
+index_expression: () = {
+    expression,
+};
+
+field_designator: () = {
+    variable_access "." identifier,
+};
+
+procedure_statement: () = {
+    identifier params,
+    identifier,
+};
+
+params: () = {
+    "(" actual_parameter_list ")",
+};
+
+actual_parameter_list: () = {
+    actual_parameter_list comma actual_parameter,
+    actual_parameter,
+};
+
+actual_parameter: () = {
+    expression,
+    expression ":" expression,
+    expression ":" expression ":" expression,
+};
+
+goto_statement: () = {
+    "GOTO" label,
+};
+
+case_statement: () = {
+    "CASE" case_index "OF" case_list_element_list "END",
+    "CASE" case_index "OF" case_list_element_list ";" "END",
+    "CASE" case_index "OF" case_list_element_list semicolon otherwisepart statement "END",
+    "CASE" case_index "OF" case_list_element_list semicolon otherwisepart statement ";" "END",
+};
+
+case_index: () = {
+    expression,
+};
+
+case_list_element_list: () = {
+    case_list_element_list semicolon case_list_element,
+    case_list_element,
+};
+
+case_list_element: () = {
+    case_constant_list ":" statement,
+};
+
+otherwisepart: () = {
+    "OTHERWISE",
+    "OTHERWISE" ":",
+};
+
+control_variable: () = {
+    identifier,
+};
+
+initial_value: () = {
+    expression,
+};
+
+direction: () = {
+    "TO",
+    "DOWNTO",
+};
+
+final_value: () = {
+    expression,
+};
+
+record_variable_list: () = {
+    record_variable_list comma variable_access,
+    variable_access,
+};
+
+boolean_expression: () = {
+    expression,
+};
+
+expression: () = {
+    simple_expression,
+    simple_expression relop simple_expression,
+};
+
+simple_expression: () = {
+    term,
+    simple_expression addop term,
+};
+
+term: () = {
+    factor,
+    term mulop factor,
+};
+
+factor: () = {
+    sign factor,
+    exponentiation,
+};
+
+exponentiation: () = {
+    primary,
+    primary "**" exponentiation,
+};
+
+primary: () = {
+    variable_access,
+    unsigned_constant,
+    function_designator,
+    set_constructor,
+    "(" expression ")",
+    "NOT" primary,
+};
+
+unsigned_constant: () = {
+    unsigned_number,
+    r"'[^']*'",
+    "NIL",
+};
+
+unsigned_number: () = {
+    unsigned_integer,
+    unsigned_real,
+};
+
+unsigned_integer: () = {
+    r"\d+",
+};
+
+unsigned_real: () = {
+    r"\d+\.\d+",
+};
+
+function_designator: () = {
+    identifier params,
+};
+
+set_constructor: () = {
+    "[" member_designator_list "]",
+    "[" "]",
+};
+
+member_designator_list: () = {
+    member_designator_list comma member_designator,
+    member_designator,
+};
+
+member_designator: () = {
+    member_designator ".." expression,
+    expression,
+};
+
+addop: () = {
+    "+",
+    "-",
+    "OR",
+};
+
+mulop: () = {
+    "*",
+    "/",
+    "DIV",
+    "MOD",
+    "AND",
+};
+
+relop: () = {
+    "=",
+    "<>",
+    "<",
+    ">",
+    "<=",
+    ">=",
+    "IN",
+};
+
+identifier: () = {
+    r"[a-zA-Z][a-zA-Z0-9]*",
+};
+
+semicolon: () = {
+    ";",
+};
+
+comma: () = {
+    ",",
+};

--- a/doc/pascal/sched.pas
+++ b/doc/pascal/sched.pas
@@ -1,0 +1,367 @@
+PROGRAM a1 (input,output);
+    CONST 
+	NotScheduled = '        ';
+
+	EmployeeMaxLen = 8;
+
+	
+	FirstHour = 8;
+	LastHour = 17;		
+	PastLastHour = 18;	
+
+	
+	TableDayWidth = 9;
+    TYPE 
+	
+	EmployeeType = ARRAY [EmployeeMaxLen] OF string;
+
+	
+	
+	HourType = 8..17;
+	ScheduleType = ARRAY [HourType, DayType] OF EmployeeType;
+	
+	HourScanType = 8..18;
+
+    VAR
+	
+	Schedule: ScheduleType;
+
+	
+	KeepRunning: boolean;
+
+        
+        Command: string;
+
+    
+    PROCEDURE ReadString(VAR Str: string);
+	VAR
+	    Ch: char;
+	BEGIN
+	    Ch := ' ';
+	    WHILE (Ch = ' ') AND NOT eoln DO 
+		read(Ch);
+
+	    IF Ch = ' ' THEN
+		
+		Str := ''
+	    ELSE
+		BEGIN 
+		    
+		    Str := '';
+		    WHILE (Ch <> ' ') AND NOT eoln DO
+			BEGIN
+			    Str := Str + Ch;
+			    read(Ch)
+			END;
+
+		    IF Ch <> ' ' THEN
+			
+			Str := Str + Ch
+		END
+	END; 
+
+    
+    PROCEDURE ReadSchedClrArgs(
+	    VAR StartDay, EndDay: DayType;	
+	    VAR StartHour, EndHour: HourType;	
+	    VAR Error: boolean);		
+	VAR
+	    InputHour: integer;			
+
+	
+	FUNCTION MapTo24(Hour: integer): HourType;
+	    CONST
+		
+		LastPM = 5;
+	    BEGIN
+		IF Hour <= LastPM THEN
+		    MapTo24 := Hour + 12
+		ELSE
+		    MapTo24 := Hour
+	    END;
+
+	BEGIN 
+	    
+	    ReadDay(input, StartDay);
+	    ReadDay(input, EndDay);
+
+	    
+	    IF (StartDay <> BadDay) AND (EndDay <> BadDay) THEN 
+		BEGIN
+		    
+		    read(InputHour);
+		    StartHour := MapTo24(InputHour);
+		    read(InputHour);
+		    EndHour := MapTo24(InputHour);
+
+		    
+		    Error := FALSE 
+		END
+	    ELSE
+		
+		Error := TRUE;
+
+	    
+	    readln
+	END; 
+
+    
+    PROCEDURE WriteDaysHeader;
+	CONST
+
+	    
+	    DaysHeadMoveOver = 6;
+
+	    
+	    AllowForDay = 3;
+	VAR
+	    Day: DayType;
+	BEGIN
+	    write(' ': DaysHeadMoveOver);
+
+	    FOR Day := Sun TO Sat DO
+		BEGIN
+		    write('[ ');
+		    WriteDay(output, Day);
+		    write(' ]', ' ': TableDayWidth - AllowForDay - 4)
+		END;
+	    writeln
+	END; 
+
+    
+    FUNCTION SchedLegal(
+	    VAR Schedule: ScheduleType;	    
+		StartDay, EndDay: DayType;  
+		FirstHour, LastHour: 	    
+			HourType): boolean;
+	VAR
+	    ConflictFound: boolean;	    
+	    DayScan: DayType;		    
+	    HourScan: HourScanType;	    
+	BEGIN
+	    
+	    DayScan := StartDay;
+	    ConflictFound := FALSE;
+	    REPEAT
+		
+		HourScan := FirstHour;
+		WHILE NOT ConflictFound AND
+				(HourScan <= LastHour) DO BEGIN
+		    
+		    ConflictFound :=
+			    Schedule[HourScan, DayScan] <> NotScheduled;
+
+		    
+		    HourScan := HourScan + 1
+		END;
+
+		
+		DayScan := succ(DayScan)
+	    UNTIL ConflictFound OR (DayScan > EndDay);
+
+	    
+	    SchedLegal := NOT ConflictFound
+	END; 
+
+    
+    PROCEDURE SetSchedPart(
+	    VAR Schedule: ScheduleType;	    
+		Employee: EmployeeType;	    
+		StartDay, EndDay: DayType;  
+		FirstHour, LastHour:	    
+				HourType);
+	VAR
+	    DayScan: DayType;		    
+	    HourScan: HourType;		    
+	BEGIN
+	    FOR DayScan := StartDay TO EndDay DO
+		FOR HourScan := FirstHour TO LastHour DO
+		    Schedule[HourScan, DayScan] := Employee
+	END; 
+
+    
+    PROCEDURE DoSched(
+	    VAR Schedule: ScheduleType);    
+	VAR
+	    Employee: EmployeeType;	    
+	    StartDay, EndDay: DayType;	    
+	    StartHour, EndHour: HourType;   
+	    Error: boolean;		    
+	BEGIN
+	    
+	    ReadString(Employee);
+
+	    
+	    ReadSchedClrArgs(StartDay, EndDay, StartHour, EndHour, Error);
+
+	    
+	    IF Error THEN
+		writeln('*** Un-recognized day code.  ',
+		    'Command not performed. ***')
+	    ELSE 
+		
+		IF SchedLegal(Schedule, StartDay, EndDay,
+					StartHour, EndHour) THEN
+		    BEGIN
+			
+			SetSchedPart(Schedule, Employee,
+				StartDay, EndDay, StartHour, EndHour);
+			writeln('>>> ', Employee, ' scheduled. <<<')
+		    END
+		ELSE 
+		    
+		    writeln('*** Conflicts with existing schedule.  ',
+			'Command not performed. ***')
+	END; 
+
+    
+    PROCEDURE DoClear(
+	    VAR Schedule: ScheduleType);    
+	VAR
+	    StartDay, EndDay: DayType;	    
+	    StartHour, EndHour: HourType;   
+	    Error: boolean;		    
+	BEGIN
+	    
+	    ReadSchedClrArgs(StartDay, EndDay, StartHour, EndHour, Error);
+
+	    
+	    IF Error THEN
+		writeln('*** Un-recognized day code.  ',
+		    'Command not performed. ***')
+	    ELSE 
+		BEGIN
+		    SetSchedPart(Schedule, NotScheduled, StartDay, EndDay,
+			StartHour, EndHour);
+		    writeln('>>> Clear performed. <<<');
+		END 
+	END;
+
+    
+    PROCEDURE DoUnsched(
+	    VAR Schedule: ScheduleType);	
+	VAR
+	    Employee: EmployeeType;		
+	    Day: DayType;			
+	    Hour: integer;			
+	    Found: boolean;			
+	BEGIN
+	    
+	    readln(Employee);
+
+	    
+	    Found := FALSE;
+	    FOR Day := Sun TO Sat DO
+		FOR Hour := FirstHour TO LastHour DO
+		    IF Schedule[Hour, Day] = Employee THEN 
+			BEGIN
+			    
+			    Schedule[Hour, Day] := NotScheduled;
+
+			    
+			    Found := TRUE 
+			END;
+
+	    
+	    IF Found THEN 
+		write('>>> ', Employee, ' removed from schedule. <<<')
+	    ELSE
+		write('>>> ', Employee, 
+				    ' was not on the schedule. <<<')
+	END; 
+
+    
+    PROCEDURE DoPrint(
+	    VAR Schedule: ScheduleType);	
+	VAR
+	    Hour: HourType;			
+	    Day: DayType;			
+
+	
+	FUNCTION Map24to12(HourType: HourType): integer;
+	    BEGIN
+		IF Hour < 13 THEN
+		    Map24to12 := Hour
+		ELSE
+		    Map24to12 := Hour - 12
+	    END;
+	BEGIN
+	    readln;
+	    WriteDaysHeader;
+
+	    FOR Hour := FirstHour TO LastHour DO
+		BEGIN
+		    write(Map24to12(Hour):2, ':00 ');
+		    FOR Day := Sun TO Sat DO
+			write(Schedule[Hour, Day], 
+			    ' ': TableDayWidth - length(Schedule[Hour, Day]));
+		    writeln
+		END
+	END;
+
+    
+    PROCEDURE DoTotal(
+	    VAR Schedule: ScheduleType);	
+	VAR
+	    Employee: EmployeeType;		
+	    Day: DayType;			
+	    Hour: integer;			
+	    Total: integer;			
+	BEGIN
+	    
+	    readln(Employee);
+
+	    
+	    Total := 0;
+	    FOR Day := Sun TO Sat DO
+		FOR Hour := FirstHour TO LastHour DO
+		    IF Schedule[Hour, Day] = Employee THEN
+			Total := Total + 1;
+
+	    
+	    writeln('>>> ', Employee,
+		' is scheduled for ', Total:1, ' hours. <<<<')
+	END; 
+
+    
+
+    BEGIN
+        
+        SetSchedPart(Schedule, NotScheduled, Sun, Sat, FirstHour, LastHour);
+ 
+        
+	write('==> ');
+    	ReadString(Command);
+	KeepRunning := TRUE;
+        WHILE KeepRunning DO
+	    BEGIN
+		IF Command = 'sched' THEN 
+            	    DoSched(Schedule)
+		ELSE IF Command = 'clear' THEN
+		    DoClear(Schedule)
+		ELSE IF Command = 'unsched' THEN
+		    DoUnsched(Schedule)
+		ELSE IF Command = 'print' THEN
+         	    DoPrint(Schedule)
+		ELSE IF Command = 'total' THEN
+		    DoTotal(Schedule)
+		ELSE IF Command = 'quit' THEN 
+		    BEGIN
+			writeln;
+			writeln('>>> Program terminating. <<<');
+			KeepRunning := FALSE
+		    END
+		ELSE
+		    
+		    BEGIN
+			readln;
+			writeln;
+			writeln('*** Command ', Command, 
+						    ' not recognized. ***');
+		    END;
+
+		
+		write('==> ');
+		ReadString(Command)
+	    END
+    END.

--- a/doc/pascal/yacc/pascal.l
+++ b/doc/pascal/yacc/pascal.l
@@ -1,0 +1,157 @@
+%{
+/*
+ * scan.l
+ *
+ * lex input file for pascal scanner
+ *
+ * extensions: to ways to spell "external" and "->" ok for "^".
+ */
+
+#include <stdio.h>
+#include "y.tab.h"
+int line_no = 1;
+
+%}
+
+A [aA]
+B [bB]
+C [cC]
+D [dD]
+E [eE]
+F [fF]
+G [gG]
+H [hH]
+I [iI]
+J [jJ]
+K [kK]
+L [lL]
+M [mM]
+N [nN]
+O [oO]
+P [pP]
+Q [qQ]
+R [rR]
+S [sS]
+T [tT]
+U [uU]
+V [vV]
+W [wW]
+X [xX]
+Y [yY]
+Z [zZ]
+NQUOTE [^']
+
+%%
+
+{A}{N}{D}   return(AND);
+{A}{R}{R}{A}{Y}   return(ARRAY);
+{C}{A}{S}{E}   return(CASE);
+{C}{O}{N}{S}{T}   return(CONST);
+{D}{I}{V}   return(DIV);
+{D}{O}    return(DO);
+{D}{O}{W}{N}{T}{O}  return(DOWNTO);
+{E}{L}{S}{E}   return(ELSE);
+{E}{N}{D}   return(END);
+{E}{X}{T}{E}{R}{N} |
+{E}{X}{T}{E}{R}{N}{A}{L} return(EXTERNAL);
+{F}{O}{R}   return(FOR);
+{F}{O}{R}{W}{A}{R}{D}  return(FORWARD);
+{F}{U}{N}{C}{T}{I}{O}{N} return(FUNCTION);
+{G}{O}{T}{O}   return(GOTO);
+{I}{F}    return(IF);
+{I}{N}    return(IN);
+{L}{A}{B}{E}{L}   return(LABEL);
+{M}{O}{D}   return(MOD);
+{N}{I}{L}   return(NIL);
+{N}{O}{T}   return(NOT);
+{O}{F}    return(OF);
+{O}{R}    return(OR);
+{O}{T}{H}{E}{R}{W}{I}{S}{E} return(OTHERWISE);
+{P}{A}{C}{K}{E}{D}  return(PACKED);
+{B}{E}{G}{I}{N}   return(PBEGIN);
+{F}{I}{L}{E}   return(PFILE);
+{P}{R}{O}{C}{E}{D}{U}{R}{E} return(PROCEDURE);
+{P}{R}{O}{G}{R}{A}{M}  return(PROGRAM);
+{R}{E}{C}{O}{R}{D}  return(RECORD);
+{R}{E}{P}{E}{A}{T}  return(REPEAT);
+{S}{E}{T}   return(SET);
+{T}{H}{E}{N}   return(THEN);
+{T}{O}    return(TO);
+{T}{Y}{P}{E}   return(TYPE);
+{U}{N}{T}{I}{L}   return(UNTIL);
+{V}{A}{R}   return(VAR);
+{W}{H}{I}{L}{E}   return(WHILE);
+{W}{I}{T}{H}   return(WITH);
+[a-zA-Z]([a-zA-Z0-9])+  return(IDENTIFIER);
+
+":="    return(ASSIGNMENT);
+'({NQUOTE}|'')+'  return(CHARACTER_STRING);
+":"    return(COLON);
+","    return(COMMA);
+[0-9]+    return(DIGSEQ);
+"."    return(DOT);
+".."    return(DOTDOT);
+"="    return(EQUAL);
+">="    return(GE);
+">"    return(GT);
+"["    return(LBRAC);
+"<="    return(LE);
+"("    return(LPAREN);
+"<"    return(LT);
+"-"    return(MINUS);
+"<>"    return(NOTEQUAL);
+"+"    return(PLUS);
+"]"    return(RBRAC);
+[0-9]+"."[0-9]+   return(REALNUMBER);
+")"    return(RPAREN);
+";"    return(SEMICOLON);
+"/"    return(SLASH);
+"*"    return(STAR);
+"**"    return(STARSTAR);
+"->"   |
+"^"    return(UPARROW);
+
+"(*"   |
+"{"    { register int c;
+     while ((c = input()))
+     {
+      if (c == '}')
+       break;
+      else if (c == '*')
+      {
+       if ((c = input()) == ')')
+        break;
+       else
+        unput (c);
+      }
+      else if (c == '\n')
+       line_no++;
+      else if (c == 0)
+       commenteof();
+     }
+    }
+
+[ \t\f]    ;
+
+\n    line_no++;
+
+.    { fprintf (stderr,
+    "'%c' (0%o): illegal charcter at line %d\n",
+     yytext[0], yytext[0], line_no);
+    }
+
+%%
+
+commenteof()
+{
+ fprintf (stderr, "unexpected EOF inside comment at line %d\n",
+  line_no);
+ exit (1);
+}
+
+yywrap ()
+{
+ return (1);
+}
+
+

--- a/doc/pascal/yacc/pascal.y
+++ b/doc/pascal/yacc/pascal.y
@@ -1,0 +1,547 @@
+%{
+/*
+ * grammar.y
+ *
+ * Pascal grammar in Yacc format, based originally on BNF given
+ * in "Standard Pascal -- User Reference Manual", by Doug Cooper.
+ * This in turn is the BNF given by the ANSI and ISO Pascal standards,
+ * and so, is PUBLIC DOMAIN. The grammar is for ISO Level 0 Pascal.
+ * The grammar has been massaged somewhat to make it LALR, and added
+ * the following extensions.
+ *
+ * constant expressions
+ * otherwise statement in a case
+ * productions to correctly match else's with if's
+ * beginnings of a separate compilation facility
+ */
+
+%}
+
+%token AND ARRAY ASSIGNMENT CASE CHARACTER_STRING COLON COMMA CONST DIGSEQ
+%token DIV DO DOT DOTDOT DOWNTO ELSE END EQUAL EXTERNAL FOR FORWARD FUNCTION
+%token GE GOTO GT IDENTIFIER IF IN LABEL LBRAC LE LPAREN LT MINUS MOD NIL NOT
+%token NOTEQUAL OF OR OTHERWISE PACKED PBEGIN PFILE PLUS PROCEDURE PROGRAM RBRAC
+%token REALNUMBER RECORD REPEAT RPAREN SEMICOLON SET SLASH STAR STARSTAR THEN
+%token TO TYPE UNTIL UPARROW VAR WHILE WITH
+
+%%
+file : program
+ | module
+ ;
+
+program : program_heading semicolon block DOT
+ ;
+
+program_heading : PROGRAM identifier
+ | PROGRAM identifier LPAREN identifier_list RPAREN
+ ;
+
+identifier_list : identifier_list comma identifier
+ | identifier
+ ;
+
+block : label_declaration_part
+ constant_definition_part
+ type_definition_part
+ variable_declaration_part
+ procedure_and_function_declaration_part
+ statement_part
+ ;
+
+module : constant_definition_part
+ type_definition_part
+ variable_declaration_part
+ procedure_and_function_declaration_part
+ ;
+
+label_declaration_part : LABEL label_list semicolon
+ |
+ ;
+
+label_list : label_list comma label
+ | label
+ ;
+
+label : DIGSEQ
+ ;
+
+constant_definition_part : CONST constant_list
+ |
+ ;
+
+constant_list : constant_list constant_definition
+ | constant_definition
+ ;
+
+constant_definition : identifier EQUAL cexpression semicolon
+ ;
+
+/*constant : cexpression ;  /* good stuff! */
+
+cexpression : csimple_expression
+ | csimple_expression relop csimple_expression
+ ;
+
+csimple_expression : cterm
+ | csimple_expression addop cterm
+ ;
+
+cterm : cfactor
+ | cterm mulop cfactor
+ ;
+
+cfactor : sign cfactor
+ | cexponentiation
+ ;
+
+cexponentiation : cprimary
+ | cprimary STARSTAR cexponentiation
+ ;
+
+cprimary : identifier
+ | LPAREN cexpression RPAREN
+ | unsigned_constant
+ | NOT cprimary
+ ;
+
+constant : non_string
+ | sign non_string
+ | CHARACTER_STRING
+ ;
+
+sign : PLUS
+ | MINUS
+ ;
+
+non_string : DIGSEQ
+ | identifier
+ | REALNUMBER
+ ;
+
+type_definition_part : TYPE type_definition_list
+ |
+ ;
+
+type_definition_list : type_definition_list type_definition
+ | type_definition
+ ;
+
+type_definition : identifier EQUAL type_denoter semicolon
+ ;
+
+type_denoter : identifier
+ | new_type
+ ;
+
+new_type : new_ordinal_type
+ | new_structured_type
+ | new_pointer_type
+ ;
+
+new_ordinal_type : enumerated_type
+ | subrange_type
+ ;
+
+enumerated_type : LPAREN identifier_list RPAREN
+ ;
+
+subrange_type : constant DOTDOT constant
+ ;
+
+new_structured_type : structured_type
+ | PACKED structured_type
+ ;
+
+structured_type : array_type
+ | record_type
+ | set_type
+ | file_type
+ ;
+
+array_type : ARRAY LBRAC index_list RBRAC OF component_type
+ ;
+
+index_list : index_list comma index_type
+ | index_type
+ ;
+
+index_type : ordinal_type ;
+
+ordinal_type : new_ordinal_type
+ | identifier
+ ;
+
+component_type : type_denoter ;
+
+record_type : RECORD record_section_list END
+ | RECORD record_section_list semicolon variant_part END
+ | RECORD variant_part END
+ ;
+
+record_section_list : record_section_list semicolon record_section
+ | record_section
+ ;
+
+record_section : identifier_list COLON type_denoter
+ ;
+
+variant_part : CASE variant_selector OF variant_list semicolon
+ | CASE variant_selector OF variant_list
+ |
+ ;
+
+variant_selector : tag_field COLON tag_type
+ | tag_type
+ ;
+
+variant_list : variant_list semicolon variant
+ | variant
+ ;
+
+variant : case_constant_list COLON LPAREN record_section_list RPAREN
+ | case_constant_list COLON LPAREN record_section_list semicolon
+  variant_part RPAREN
+ | case_constant_list COLON LPAREN variant_part RPAREN
+ ;
+
+case_constant_list : case_constant_list comma case_constant
+ | case_constant
+ ;
+
+case_constant : constant
+ | constant DOTDOT constant
+ ;
+
+tag_field : identifier ;
+
+tag_type : identifier ;
+
+set_type : SET OF base_type
+ ;
+
+base_type : ordinal_type ;
+
+file_type : PFILE OF component_type
+ ;
+
+new_pointer_type : UPARROW domain_type
+ ;
+
+domain_type : identifier ;
+
+variable_declaration_part : VAR variable_declaration_list semicolon
+ |
+ ;
+
+variable_declaration_list :
+   variable_declaration_list semicolon variable_declaration
+ | variable_declaration
+ ;
+
+variable_declaration : identifier_list COLON type_denoter
+ ;
+
+procedure_and_function_declaration_part :
+  proc_or_func_declaration_list semicolon
+ |
+ ;
+
+proc_or_func_declaration_list :
+   proc_or_func_declaration_list semicolon proc_or_func_declaration
+ | proc_or_func_declaration
+ ;
+
+proc_or_func_declaration : procedure_declaration
+ | function_declaration
+ ;
+
+procedure_declaration : procedure_heading semicolon directive
+ | procedure_heading semicolon procedure_block
+ ;
+
+procedure_heading : procedure_identification
+ | procedure_identification formal_parameter_list
+ ;
+
+directive : FORWARD
+ | EXTERNAL
+ ;
+
+formal_parameter_list : LPAREN formal_parameter_section_list RPAREN ;
+
+formal_parameter_section_list : formal_parameter_section_list semicolon formal_parameter_section
+ | formal_parameter_section
+ ;
+
+formal_parameter_section : value_parameter_specification
+ | variable_parameter_specification
+ | procedural_parameter_specification
+ | functional_parameter_specification
+ ;
+
+value_parameter_specification : identifier_list COLON identifier
+ ;
+
+variable_parameter_specification : VAR identifier_list COLON identifier
+ ;
+
+procedural_parameter_specification : procedure_heading ;
+
+functional_parameter_specification : function_heading ;
+
+procedure_identification : PROCEDURE identifier ;
+
+procedure_block : block ;
+
+function_declaration : function_heading semicolon directive
+ | function_identification semicolon function_block
+ | function_heading semicolon function_block
+ ;
+
+function_heading : FUNCTION identifier COLON result_type
+ | FUNCTION identifier formal_parameter_list COLON result_type
+ ;
+
+result_type : identifier ;
+
+function_identification : FUNCTION identifier ;
+
+function_block : block ;
+
+statement_part : compound_statement ;
+
+compound_statement : PBEGIN statement_sequence END ;
+
+statement_sequence : statement_sequence semicolon statement
+ | statement
+ ;
+
+statement : open_statement
+ | closed_statement
+ ;
+
+open_statement : label COLON non_labeled_open_statement
+ | non_labeled_open_statement
+ ;
+
+closed_statement : label COLON non_labeled_closed_statement
+ | non_labeled_closed_statement
+ ;
+
+non_labeled_closed_statement : assignment_statement
+ | procedure_statement
+ | goto_statement
+ | compound_statement
+ | case_statement
+ | repeat_statement
+ | closed_with_statement
+ | closed_if_statement
+ | closed_while_statement
+ | closed_for_statement
+ |
+ ;
+
+non_labeled_open_statement : open_with_statement
+ | open_if_statement
+ | open_while_statement
+ | open_for_statement
+ ;
+
+repeat_statement : REPEAT statement_sequence UNTIL boolean_expression
+ ;
+
+open_while_statement : WHILE boolean_expression DO open_statement
+ ;
+
+closed_while_statement : WHILE boolean_expression DO closed_statement
+ ;
+
+open_for_statement : FOR control_variable ASSIGNMENT initial_value direction
+   final_value DO open_statement
+ ;
+
+closed_for_statement : FOR control_variable ASSIGNMENT initial_value direction
+   final_value DO closed_statement
+ ;
+
+open_with_statement : WITH record_variable_list DO open_statement
+ ;
+
+closed_with_statement : WITH record_variable_list DO closed_statement
+ ;
+
+open_if_statement : IF boolean_expression THEN statement
+ | IF boolean_expression THEN closed_statement ELSE open_statement
+ ;
+
+closed_if_statement : IF boolean_expression THEN closed_statement
+   ELSE closed_statement
+ ;
+
+assignment_statement : variable_access ASSIGNMENT expression
+ ;
+
+variable_access : identifier
+ | indexed_variable
+ | field_designator
+ | variable_access UPARROW
+ ;
+
+indexed_variable : variable_access LBRAC index_expression_list RBRAC
+ ;
+
+index_expression_list : index_expression_list comma index_expression
+ | index_expression
+ ;
+
+index_expression : expression ;
+
+field_designator : variable_access DOT identifier
+ ;
+
+procedure_statement : identifier params
+ | identifier
+ ;
+
+params : LPAREN actual_parameter_list RPAREN ;
+
+actual_parameter_list : actual_parameter_list comma actual_parameter
+ | actual_parameter
+ ;
+
+/*
+ * this forces you to check all this to be sure that only write and
+ * writeln use the 2nd and 3rd forms, you really can't do it easily in
+ * the grammar, especially since write and writeln aren't reserved
+ */
+actual_parameter : expression
+ | expression COLON expression
+ | expression COLON expression COLON expression
+ ;
+
+goto_statement : GOTO label
+ ;
+
+case_statement : CASE case_index OF case_list_element_list END
+ | CASE case_index OF case_list_element_list SEMICOLON END
+ | CASE case_index OF case_list_element_list semicolon
+   otherwisepart statement END
+ | CASE case_index OF case_list_element_list semicolon
+   otherwisepart statement SEMICOLON END
+ ;
+
+case_index : expression ;
+
+case_list_element_list : case_list_element_list semicolon case_list_element
+ | case_list_element
+ ;
+
+case_list_element : case_constant_list COLON statement
+ ;
+
+otherwisepart : OTHERWISE
+ | OTHERWISE COLON
+ ;
+
+control_variable : identifier ;
+
+initial_value : expression ;
+
+direction : TO
+ | DOWNTO
+ ;
+
+final_value : expression ;
+
+record_variable_list : record_variable_list comma variable_access
+ | variable_access
+ ;
+
+boolean_expression : expression ;
+
+expression : simple_expression
+ | simple_expression relop simple_expression
+ ;
+
+simple_expression : term
+ | simple_expression addop term
+ ;
+
+term : factor
+ | term mulop factor
+ ;
+
+factor : sign factor
+ | exponentiation
+ ;
+
+exponentiation : primary
+ | primary STARSTAR exponentiation
+ ;
+
+primary : variable_access
+ | unsigned_constant
+ | function_designator
+ | set_constructor
+ | LPAREN expression RPAREN
+ | NOT primary
+ ;
+
+unsigned_constant : unsigned_number
+ | CHARACTER_STRING
+ | NIL
+ ;
+
+unsigned_number : unsigned_integer | unsigned_real ;
+
+unsigned_integer : DIGSEQ
+ ;
+
+unsigned_real : REALNUMBER
+ ;
+
+/* functions with no params will be handled by plain identifier */
+function_designator : identifier params
+ ;
+
+set_constructor : LBRAC member_designator_list RBRAC
+ | LBRAC RBRAC
+ ;
+
+member_designator_list : member_designator_list comma member_designator
+ | member_designator
+ ;
+
+member_designator : member_designator DOTDOT expression
+ | expression
+ ;
+
+addop: PLUS
+ | MINUS
+ | OR
+ ;
+
+mulop : STAR
+ | SLASH
+ | DIV
+ | MOD
+ | AND
+ ;
+
+relop : EQUAL
+ | NOTEQUAL
+ | LT
+ | GT
+ | LE
+ | GE
+ | IN
+ ;
+
+identifier : IDENTIFIER
+ ;
+
+semicolon : SEMICOLON
+ ;
+
+comma : COMMA
+ ;

--- a/lalrpop-test/src/error.rs
+++ b/lalrpop-test/src/error.rs
@@ -44,22 +44,30 @@ mod __parse__Items {
     }
 
     // State 0
-    //   Items = (*) [EOF]
-    //   Items = (*) ["+"]
-    //   Items = (*) ["-"]
-    //   Items = (*) Items "+" [EOF]
-    //   Items = (*) Items "+" ["+"]
-    //   Items = (*) Items "+" ["-"]
-    //   Items = (*) Items "-" [EOF]
-    //   Items = (*) Items "-" ["+"]
-    //   Items = (*) Items "-" ["-"]
-    //   __Items = (*) Items [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Items =  => ActionFn(1);)
-    //   "+" -> Reduce(Items =  => ActionFn(1);)
-    //   "-" -> Reduce(Items =  => ActionFn(1);)
+    //     Items = (*) [EOF]
+    //     Items = (*) ["+"]
+    //     Items = (*) ["-"]
+    //     Items = (*) Items "+" [EOF]
+    //     Items = (*) Items "+" ["+"]
+    //     Items = (*) Items "+" ["-"]
+    //     Items = (*) Items "-" [EOF]
+    //     Items = (*) Items "-" ["+"]
+    //     Items = (*) Items "-" ["-"]
+    //     __Items = (*) Items [EOF]
     //
-    //   Items -> S1
+    //     EOF -> Reduce(Items =  => ActionFn(1);)
+    //     "+" -> Reduce(Items =  => ActionFn(1);)
+    //     "-" -> Reduce(Items =  => ActionFn(1);)
+    //
+    //     Items -> S1
     pub fn __state0<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
     >(
@@ -92,8 +100,7 @@ mod __parse__Items {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Items(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Items(__sym0) => {
                     __result = try!(__state1(__tokens, __lookahead, __sym0));
                 }
                 _ => {
@@ -104,38 +111,47 @@ mod __parse__Items {
     }
 
     // State 1
-    //   Items = Items (*) "+" [EOF]
-    //   Items = Items (*) "+" ["+"]
-    //   Items = Items (*) "+" ["-"]
-    //   Items = Items (*) "-" [EOF]
-    //   Items = Items (*) "-" ["+"]
-    //   Items = Items (*) "-" ["-"]
-    //   __Items = Items (*) [EOF]
+    //     Kind = None
+    //     AllInputs = [Items]
+    //     OptionalInputs = []
+    //     FixedInputs = [Items]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(__Items = Items => ActionFn(0);)
-    //   "+" -> Shift(S2)
-    //   "-" -> Shift(S3)
+    //     Items = Items (*) "+" [EOF]
+    //     Items = Items (*) "+" ["+"]
+    //     Items = Items (*) "+" ["-"]
+    //     Items = Items (*) "-" [EOF]
+    //     Items = Items (*) "-" ["+"]
+    //     Items = Items (*) "-" ["-"]
+    //     __Items = Items (*) [EOF]
+    //
+    //     EOF -> Reduce(__Items = Items => ActionFn(0);)
+    //     "+" -> Shift(S2)
+    //     "-" -> Shift(S3)
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
     >(
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, Vec<(usize, usize)>, usize)>,
+        __sym0: (usize, Vec<(usize, usize)>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __ParseError<usize,Tok,char>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state2(__tokens, __sym0, __sym1));
+                let __sym1 = (__loc1, (__tok), __loc2);
+                __result = try!(__custom0(__tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state3(__tokens, __sym0, __sym1));
+                let __sym1 = (__loc1, (__tok), __loc2);
+                __result = try!(__custom1(__tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action0(__sym0);
@@ -144,7 +160,8 @@ mod __parse__Items {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -153,24 +170,44 @@ mod __parse__Items {
                 });
             }
         }
+    }
+
+    // Custom 0
+    //    Reduce Items = Items, "+" => ActionFn(2);
+    pub fn __custom0<
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, Vec<(usize, usize)>, usize),
+        __sym1: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __ParseError<usize,Tok,char>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = try!(super::__action2(__sym0, __sym1));
+        let __nt = __Nonterminal::Items((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
         return Ok(__result);
     }
 
-    // State 2
-    //   Items = Items "+" (*) [EOF]
-    //   Items = Items "+" (*) ["+"]
-    //   Items = Items "+" (*) ["-"]
-    //
-    //   EOF -> Reduce(Items = Items, "+" => ActionFn(2);)
-    //   "+" -> Reduce(Items = Items, "+" => ActionFn(2);)
-    //   "-" -> Reduce(Items = Items, "+" => ActionFn(2);)
-    //
-    pub fn __state2<
+    // Custom 1
+    //    Reduce Items = Items, "-" => ActionFn(3);
+    pub fn __custom1<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Vec<(usize, usize)>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Vec<(usize, usize)>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __ParseError<usize,Tok,char>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
@@ -179,77 +216,16 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        match __lookahead {
-            None |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = try!(super::__action2(__sym0, __sym1));
-                let __nt = __Nonterminal::Items((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 3
-    //   Items = Items "-" (*) [EOF]
-    //   Items = Items "-" (*) ["+"]
-    //   Items = Items "-" (*) ["-"]
-    //
-    //   EOF -> Reduce(Items = Items, "-" => ActionFn(3);)
-    //   "+" -> Reduce(Items = Items, "-" => ActionFn(3);)
-    //   "-" -> Reduce(Items = Items, "-" => ActionFn(3);)
-    //
-    pub fn __state3<
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Vec<(usize, usize)>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __ParseError<usize,Tok,char>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            None |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = try!(super::__action3(__sym0, __sym1));
-                let __nt = __Nonterminal::Items((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = try!(super::__action3(__sym0, __sym1));
+        let __nt = __Nonterminal::Items((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__Items::parse_Items;

--- a/lalrpop-test/src/expr.rs
+++ b/lalrpop-test/src/expr.rs
@@ -46,48 +46,56 @@ mod __parse__Expr {
     }
 
     // State 0
-    //   Expr = (*) Expr "+" Factor [EOF]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [EOF]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [EOF]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   __Expr = (*) Expr [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Expr = (*) Expr "+" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     __Expr = (*) Expr [EOF]
     //
-    //   Expr -> S1
-    //   Factor -> S2
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Expr -> S1
+    //     Factor -> S2
+    //     Term -> S3
     pub fn __state0<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
@@ -99,12 +107,12 @@ mod __parse__Expr {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym0 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym0));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym0));
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -116,17 +124,14 @@ mod __parse__Expr {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym0) => {
                     __result = try!(__state1(scale, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym0) => {
                     __result = try!(__state2(scale, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state3(scale, __tokens, __lookahead, __sym0));
+                __Nonterminal::Term(__sym0) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -136,17 +141,25 @@ mod __parse__Expr {
     }
 
     // State 1
-    //   Expr = Expr (*) "+" Factor [EOF]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [EOF]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   __Expr = Expr (*) [EOF]
+    //     Kind = None
+    //     AllInputs = [Expr]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //   "+" -> Shift(S6)
-    //   "-" -> Shift(S7)
+    //     Expr = Expr (*) "+" Factor [EOF]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [EOF]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     __Expr = Expr (*) [EOF]
+    //
+    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
+    //     "+" -> Shift(S6)
+    //     "-" -> Shift(S7)
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -154,21 +167,22 @@ mod __parse__Expr {
         scale: i32,
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
+        __sym0: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state6(scale, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state7(scale, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action0(scale, __sym0);
@@ -177,7 +191,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -186,29 +201,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 2
-    //   Expr = Factor (*) [EOF]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "*" -> Shift(S8)
-    //   "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "/" -> Shift(S9)
+    //     Expr = Factor (*) [EOF]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S9)
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -216,23 +238,24 @@ mod __parse__Expr {
         scale: i32,
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
+        __sym0: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state8(scale, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(scale, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(scale, __sym0);
@@ -241,57 +264,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 3
-    //   Factor = Term (*) [EOF]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Term => ActionFn(6);)
-    //   "*" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "+" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "-" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "/" -> Reduce(Factor = Term => ActionFn(6);)
-    //
-    pub fn __state3<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action6(scale, __sym0);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -303,58 +277,66 @@ mod __parse__Expr {
     }
 
     // State 4
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [EOF]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
     //
-    //   "(" -> Shift(S13)
-    //   Num -> Shift(S14)
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [EOF]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Expr -> S10
-    //   Factor -> S11
-    //   Term -> S12
+    //     "(" -> Shift(S13)
+    //     Num -> Shift(S14)
+    //
+    //     Expr -> S10
+    //     Factor -> S11
+    //     Term -> S12
     pub fn __state4<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
+        __sym0: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -363,14 +345,15 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state13(scale, __tokens, __sym1));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(scale, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -379,124 +362,78 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state10(scale, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state11(scale, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state12(scale, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 5
-    //   Term = Num (*) [EOF]
-    //   Term = Num (*) ["*"]
-    //   Term = Num (*) ["+"]
-    //   Term = Num (*) ["-"]
-    //   Term = Num (*) ["/"]
-    //
-    //   EOF -> Reduce(Term = Num => ActionFn(7);)
-    //   "*" -> Reduce(Term = Num => ActionFn(7);)
-    //   "+" -> Reduce(Term = Num => ActionFn(7);)
-    //   "-" -> Reduce(Term = Num => ActionFn(7);)
-    //   "/" -> Reduce(Term = Num => ActionFn(7);)
-    //
-    pub fn __state5<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action7(scale, __sym0);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
             }
         }
     }
 
     // State 6
-    //   Expr = Expr "+" (*) Factor [EOF]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Expr = Expr "+" (*) Factor [EOF]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S15
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Factor -> S15
+    //     Term -> S3
     pub fn __state6<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -505,14 +442,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -521,67 +460,75 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state15(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 7
-    //   Expr = Expr "-" (*) Factor [EOF]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Expr = Expr "-" (*) Factor [EOF]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S16
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Factor -> S16
+    //     Term -> S3
     pub fn __state7<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -590,14 +537,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -606,53 +555,61 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state16(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 8
-    //   Factor = Factor "*" (*) Term [EOF]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Factor = Factor "*" (*) Term [EOF]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S17
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Term -> S17
     pub fn __state8<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -663,12 +620,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -677,49 +634,56 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state17(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom2(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 9
-    //   Factor = Factor "/" (*) Term [EOF]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Factor = Factor "/" (*) Term [EOF]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S18
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Term -> S18
     pub fn __state9<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -730,12 +694,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -744,37 +708,44 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state18(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 10
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [EOF]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S19)
-    //   "+" -> Shift(S20)
-    //   "-" -> Shift(S21)
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [EOF]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S19)
+    //     "+" -> Shift(S20)
+    //     "-" -> Shift(S21)
     //
     pub fn __state10<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -783,22 +754,26 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), i32, ())>,
+        __sym1: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state19(scale, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(scale, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state20(scale, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state21(scale, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -807,29 +782,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 11
-    //   Expr = Factor (*) [")"]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "*" -> Shift(S22)
-    //   "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "/" -> Shift(S23)
+    //     Expr = Factor (*) [")"]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S22)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S23)
     //
     pub fn __state11<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -837,23 +819,24 @@ mod __parse__Expr {
         scale: i32,
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
+        __sym0: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state22(scale, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state23(scale, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(scale, __sym0);
@@ -862,57 +845,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 12
-    //   Factor = Term (*) [")"]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "*" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "+" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "-" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "/" -> Reduce(Factor = Term => ActionFn(6);)
-    //
-    pub fn __state12<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action6(scale, __sym0);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -924,58 +858,66 @@ mod __parse__Expr {
     }
 
     // State 13
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [")"]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
     //
-    //   "(" -> Shift(S13)
-    //   Num -> Shift(S14)
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")"]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Expr -> S24
-    //   Factor -> S11
-    //   Term -> S12
+    //     "(" -> Shift(S13)
+    //     Num -> Shift(S14)
+    //
+    //     Expr -> S24
+    //     Factor -> S11
+    //     Term -> S12
     pub fn __state13<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
+        __sym0: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -984,14 +926,15 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state13(scale, __tokens, __sym1));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(scale, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1000,102 +943,56 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state24(scale, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state11(scale, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state12(scale, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 14
-    //   Term = Num (*) [")"]
-    //   Term = Num (*) ["*"]
-    //   Term = Num (*) ["+"]
-    //   Term = Num (*) ["-"]
-    //   Term = Num (*) ["/"]
-    //
-    //   ")" -> Reduce(Term = Num => ActionFn(7);)
-    //   "*" -> Reduce(Term = Num => ActionFn(7);)
-    //   "+" -> Reduce(Term = Num => ActionFn(7);)
-    //   "-" -> Reduce(Term = Num => ActionFn(7);)
-    //   "/" -> Reduce(Term = Num => ActionFn(7);)
-    //
-    pub fn __state14<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action7(scale, __sym0);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 15
-    //   Expr = Expr "+" Factor (*) [EOF]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "*" -> Shift(S8)
-    //   "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "/" -> Shift(S9)
+    //     Expr = Expr "+" Factor (*) [EOF]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S9)
     //
     pub fn __state15<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1105,25 +1002,26 @@ mod __parse__Expr {
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), i32, ())>,
         __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
+        __sym2: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state8(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             None |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(scale, __sym0, __sym1, __sym2);
@@ -1132,7 +1030,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1141,29 +1040,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 16
-    //   Expr = Expr "-" Factor (*) [EOF]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "*" -> Shift(S8)
-    //   "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "/" -> Shift(S9)
+    //     Expr = Expr "-" Factor (*) [EOF]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S9)
     //
     pub fn __state16<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1173,25 +1079,26 @@ mod __parse__Expr {
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), i32, ())>,
         __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
+        __sym2: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state8(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             None |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action1(scale, __sym0, __sym1, __sym2);
@@ -1200,171 +1107,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 17
-    //   Factor = Factor "*" Term (*) [EOF]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "*" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "+" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "-" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "/" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //
-    pub fn __state17<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 18
-    //   Factor = Factor "/" Term (*) [EOF]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "*" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "+" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "-" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "/" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //
-    pub fn __state18<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 19
-    //   Term = "(" Expr ")" (*) [EOF]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //
-    //   EOF -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "*" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "+" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "-" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "/" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //
-    pub fn __state19<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), i32, ())>,
-        __sym2: &mut Option<((), Tok, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1376,47 +1120,55 @@ mod __parse__Expr {
     }
 
     // State 20
-    //   Expr = Expr "+" (*) Factor [")"]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S13)
-    //   Num -> Shift(S14)
+    //     Expr = Expr "+" (*) Factor [")"]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S25
-    //   Term -> S12
+    //     "(" -> Shift(S13)
+    //     Num -> Shift(S14)
+    //
+    //     Factor -> S25
+    //     Term -> S12
     pub fn __state20<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1425,14 +1177,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state13(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1441,67 +1195,75 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state25(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state12(scale, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 21
-    //   Expr = Expr "-" (*) Factor [")"]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S13)
-    //   Num -> Shift(S14)
+    //     Expr = Expr "-" (*) Factor [")"]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S26
-    //   Term -> S12
+    //     "(" -> Shift(S13)
+    //     Num -> Shift(S14)
+    //
+    //     Factor -> S26
+    //     Term -> S12
     pub fn __state21<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1510,14 +1272,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state13(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1526,53 +1290,61 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state26(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state12(scale, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 22
-    //   Factor = Factor "*" (*) Term [")"]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S13)
-    //   Num -> Shift(S14)
+    //     Factor = Factor "*" (*) Term [")"]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S27
+    //     "(" -> Shift(S13)
+    //     Num -> Shift(S14)
+    //
+    //     Term -> S27
     pub fn __state22<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1583,12 +1355,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state13(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1597,49 +1369,56 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state27(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom2(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 23
-    //   Factor = Factor "/" (*) Term [")"]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S13)
-    //   Num -> Shift(S14)
+    //     Factor = Factor "/" (*) Term [")"]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S28
+    //     "(" -> Shift(S13)
+    //     Num -> Shift(S14)
+    //
+    //     Term -> S28
     pub fn __state23<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1650,12 +1429,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state13(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1664,37 +1443,44 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state28(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 24
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [")"]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S29)
-    //   "+" -> Shift(S20)
-    //   "-" -> Shift(S21)
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [")"]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S29)
+    //     "+" -> Shift(S20)
+    //     "-" -> Shift(S21)
     //
     pub fn __state24<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1703,22 +1489,26 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), i32, ())>,
+        __sym1: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state29(scale, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(scale, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state20(scale, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state21(scale, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1727,29 +1517,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 25
-    //   Expr = Expr "+" Factor (*) [")"]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "*" -> Shift(S22)
-    //   "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "/" -> Shift(S23)
+    //     Expr = Expr "+" Factor (*) [")"]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S22)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S23)
     //
     pub fn __state25<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1759,25 +1556,26 @@ mod __parse__Expr {
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), i32, ())>,
         __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
+        __sym2: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state22(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state23(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(scale, __sym0, __sym1, __sym2);
@@ -1786,7 +1584,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1795,29 +1594,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 26
-    //   Expr = Expr "-" Factor (*) [")"]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "*" -> Shift(S22)
-    //   "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "/" -> Shift(S23)
+    //     Expr = Expr "-" Factor (*) [")"]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S22)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S23)
     //
     pub fn __state26<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1827,25 +1633,26 @@ mod __parse__Expr {
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), i32, ())>,
         __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
+        __sym2: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state22(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state23(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action1(scale, __sym0, __sym1, __sym2);
@@ -1854,7 +1661,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1863,136 +1671,40 @@ mod __parse__Expr {
                 });
             }
         }
+    }
+
+    // Custom 0
+    //    Reduce Factor = Term => ActionFn(6);
+    pub fn __custom0<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action6(scale, __sym0);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
         return Ok(__result);
     }
 
-    // State 27
-    //   Factor = Factor "*" Term (*) [")"]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "*" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "+" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "-" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "/" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //
-    pub fn __state27<
+    // Custom 1
+    //    Reduce Term = Num => ActionFn(7);
+    pub fn __custom1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 28
-    //   Factor = Factor "/" Term (*) [")"]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "*" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "+" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "-" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "/" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //
-    pub fn __state28<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 29
-    //   Term = "(" Expr ")" (*) [")"]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //
-    //   ")" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "*" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "+" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "-" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "/" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //
-    pub fn __state29<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), i32, ())>,
-        __sym2: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -2001,32 +1713,98 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action7(scale, __sym0);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 2
+    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
+    pub fn __custom2<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
+        __sym2: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 3
+    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
+    pub fn __custom3<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
+        __sym2: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 4
+    //    Reduce Term = "(", Expr, ")" => ActionFn(8);
+    pub fn __custom4<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __sym0: ((), Tok, ()),
+        __sym1: ((), i32, ()),
+        __sym2: ((), Tok, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/expr_arena.lalrpop
+++ b/lalrpop-test/src/expr_arena.lalrpop
@@ -36,7 +36,7 @@ Factor = {
     Term,
 };
 
-Term = {
+Term: &'ast Node<'ast> = {
     <n:Num> => arena.alloc(Node::Value(n)),
-    "(" <Expr> ")",
+    "(" <Expr> ")" => arena.alloc(Node::Paren(<>)),
 };

--- a/lalrpop-test/src/expr_arena.rs
+++ b/lalrpop-test/src/expr_arena.rs
@@ -54,54 +54,62 @@ mod __parse__Expr {
     }
 
     // State 0
-    //   Expr = (*) Expr "+" Factor [EOF]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [EOF]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [EOF]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [EOF]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   __Expr = (*) Expr [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   "(" -> Shift(S4)
-    //   "*" -> Shift(S5)
-    //   Num -> Shift(S6)
+    //     Expr = (*) Expr "+" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [EOF]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     __Expr = (*) Expr [EOF]
     //
-    //   Expr -> S1
-    //   Factor -> S2
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     "*" -> Shift(S5)
+    //     Num -> Shift(S6)
+    //
+    //     Expr -> S1
+    //     Factor -> S2
+    //     Term -> S3
     pub fn __state0<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
@@ -114,16 +122,16 @@ mod __parse__Expr {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym0 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(arena, __tokens, __sym0));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym0 = (__loc1, (__tok), __loc2);
                 __result = try!(__state5(arena, __tokens, __sym0));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(arena, __tokens, __sym0));
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -135,17 +143,14 @@ mod __parse__Expr {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym0) => {
                     __result = try!(__state1(arena, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym0) => {
                     __result = try!(__state2(arena, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state3(arena, __tokens, __lookahead, __sym0));
+                __Nonterminal::Term(__sym0) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -155,17 +160,25 @@ mod __parse__Expr {
     }
 
     // State 1
-    //   Expr = Expr (*) "+" Factor [EOF]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [EOF]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   __Expr = Expr (*) [EOF]
+    //     Kind = None
+    //     AllInputs = [Expr]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //   "+" -> Shift(S7)
-    //   "-" -> Shift(S8)
+    //     Expr = Expr (*) "+" Factor [EOF]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [EOF]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     __Expr = Expr (*) [EOF]
+    //
+    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
+    //     "+" -> Shift(S7)
+    //     "-" -> Shift(S8)
     //
     pub fn __state1<
         'ast,
@@ -174,21 +187,22 @@ mod __parse__Expr {
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state7(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state8(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action0(arena, __sym0);
@@ -197,7 +211,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -206,29 +221,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 2
-    //   Expr = Factor (*) [EOF]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "*" -> Shift(S9)
-    //   "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "/" -> Shift(S10)
+    //     Expr = Factor (*) [EOF]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S9)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S10)
     //
     pub fn __state2<
         'ast,
@@ -237,23 +259,24 @@ mod __parse__Expr {
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state10(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(arena, __sym0);
@@ -262,58 +285,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 3
-    //   Factor = Term (*) [EOF]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Term => ActionFn(7);)
-    //   "*" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "+" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "-" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "/" -> Reduce(Factor = Term => ActionFn(7);)
-    //
-    pub fn __state3<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action7(arena, __sym0);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -325,65 +298,73 @@ mod __parse__Expr {
     }
 
     // State 4
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [EOF]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
     //
-    //   "(" -> Shift(S14)
-    //   "*" -> Shift(S15)
-    //   Num -> Shift(S16)
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [EOF]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Expr -> S11
-    //   Factor -> S12
-    //   Term -> S13
+    //     "(" -> Shift(S14)
+    //     "*" -> Shift(S15)
+    //     Num -> Shift(S16)
+    //
+    //     Expr -> S11
+    //     Factor -> S12
+    //     Term -> S13
     pub fn __state4<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -392,18 +373,19 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state14(arena, __tokens, __sym1));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state15(arena, __tokens, __sym1));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(arena, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -412,37 +394,44 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state11(arena, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state12(arena, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state13(arena, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 5
-    //   Factor = "*" (*) "(" Comma<Expr> ")" [EOF]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["*"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["+"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["*"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*"]
+    //     WillPushLen = 3
+    //     WillPush = ["(", Comma<Expr>, ")"]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S17)
+    //     Factor = "*" (*) "(" Comma<Expr> ")" [EOF]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["*"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["+"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
+    //
+    //     "(" -> Shift(S17)
     //
     pub fn __state5<
         'ast,
@@ -450,7 +439,7 @@ mod __parse__Expr {
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -461,63 +450,9 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state17(arena, __tokens, __sym0, __sym1));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 6
-    //   Term = Num (*) [EOF]
-    //   Term = Num (*) ["*"]
-    //   Term = Num (*) ["+"]
-    //   Term = Num (*) ["-"]
-    //   Term = Num (*) ["/"]
-    //
-    //   EOF -> Reduce(Term = Num => ActionFn(8);)
-    //   "*" -> Reduce(Term = Num => ActionFn(8);)
-    //   "+" -> Reduce(Term = Num => ActionFn(8);)
-    //   "-" -> Reduce(Term = Num => ActionFn(8);)
-    //   "/" -> Reduce(Term = Num => ActionFn(8);)
-    //
-    pub fn __state6<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action8(arena, __sym0);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -529,54 +464,62 @@ mod __parse__Expr {
     }
 
     // State 7
-    //   Expr = Expr "+" (*) Factor [EOF]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [EOF]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S4)
-    //   "*" -> Shift(S5)
-    //   Num -> Shift(S6)
+    //     Expr = Expr "+" (*) Factor [EOF]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [EOF]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S18
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     "*" -> Shift(S5)
+    //     Num -> Shift(S6)
+    //
+    //     Factor -> S18
+    //     Term -> S3
     pub fn __state7<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -585,18 +528,20 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(arena, __tokens, __sym2));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state5(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -605,74 +550,82 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state18(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(arena, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 8
-    //   Expr = Expr "-" (*) Factor [EOF]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [EOF]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S4)
-    //   "*" -> Shift(S5)
-    //   Num -> Shift(S6)
+    //     Expr = Expr "-" (*) Factor [EOF]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [EOF]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S19
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     "*" -> Shift(S5)
+    //     Num -> Shift(S6)
+    //
+    //     Factor -> S19
+    //     Term -> S3
     pub fn __state8<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -681,18 +634,20 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(arena, __tokens, __sym2));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state5(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -701,54 +656,62 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state19(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(arena, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 9
-    //   Factor = Factor "*" (*) Term [EOF]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S6)
+    //     Factor = Factor "*" (*) Term [EOF]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S20
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S6)
+    //
+    //     Term -> S20
     pub fn __state9<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -759,12 +722,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -773,50 +736,57 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state20(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom2(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 10
-    //   Factor = Factor "/" (*) Term [EOF]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S6)
+    //     Factor = Factor "/" (*) Term [EOF]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S21
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S6)
+    //
+    //     Term -> S21
     pub fn __state10<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -827,12 +797,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -841,37 +811,44 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state21(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 11
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [EOF]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S22)
-    //   "+" -> Shift(S23)
-    //   "-" -> Shift(S24)
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [EOF]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S22)
+    //     "+" -> Shift(S23)
+    //     "-" -> Shift(S24)
     //
     pub fn __state11<
         'ast,
@@ -881,22 +858,26 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
         __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym1: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state22(arena, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(arena, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state23(arena, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state24(arena, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -905,29 +886,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 12
-    //   Expr = Factor (*) [")"]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "*" -> Shift(S25)
-    //   "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "/" -> Shift(S26)
+    //     Expr = Factor (*) [")"]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S25)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S26)
     //
     pub fn __state12<
         'ast,
@@ -936,23 +924,24 @@ mod __parse__Expr {
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state25(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state26(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(arena, __sym0);
@@ -961,58 +950,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 13
-    //   Factor = Term (*) [")"]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "*" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "+" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "-" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "/" -> Reduce(Factor = Term => ActionFn(7);)
-    //
-    pub fn __state13<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action7(arena, __sym0);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1024,65 +963,73 @@ mod __parse__Expr {
     }
 
     // State 14
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [")"]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
     //
-    //   "(" -> Shift(S14)
-    //   "*" -> Shift(S15)
-    //   Num -> Shift(S16)
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")"]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Expr -> S27
-    //   Factor -> S12
-    //   Term -> S13
+    //     "(" -> Shift(S14)
+    //     "*" -> Shift(S15)
+    //     Num -> Shift(S16)
+    //
+    //     Expr -> S27
+    //     Factor -> S12
+    //     Term -> S13
     pub fn __state14<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1091,18 +1038,19 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state14(arena, __tokens, __sym1));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state15(arena, __tokens, __sym1));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(arena, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1111,37 +1059,44 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state27(arena, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state12(arena, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state13(arena, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 15
-    //   Factor = "*" (*) "(" Comma<Expr> ")" [")"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["*"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["+"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["*"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*"]
+    //     WillPushLen = 3
+    //     WillPush = ["(", Comma<Expr>, ")"]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S28)
+    //     Factor = "*" (*) "(" Comma<Expr> ")" [")"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["*"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["+"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
+    //
+    //     "(" -> Shift(S28)
     //
     pub fn __state15<
         'ast,
@@ -1149,7 +1104,7 @@ mod __parse__Expr {
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1160,63 +1115,9 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state28(arena, __tokens, __sym0, __sym1));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 16
-    //   Term = Num (*) [")"]
-    //   Term = Num (*) ["*"]
-    //   Term = Num (*) ["+"]
-    //   Term = Num (*) ["-"]
-    //   Term = Num (*) ["/"]
-    //
-    //   ")" -> Reduce(Term = Num => ActionFn(8);)
-    //   "*" -> Reduce(Term = Num => ActionFn(8);)
-    //   "+" -> Reduce(Term = Num => ActionFn(8);)
-    //   "-" -> Reduce(Term = Num => ActionFn(8);)
-    //   "/" -> Reduce(Term = Num => ActionFn(8);)
-    //
-    pub fn __state16<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action8(arena, __sym0);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1228,90 +1129,98 @@ mod __parse__Expr {
     }
 
     // State 17
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["("]
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [")"]
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["*"]
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [Num]
-    //   (<Expr> ",")+ = (*) Expr "," ["("]
-    //   (<Expr> ",")+ = (*) Expr "," [")"]
-    //   (<Expr> ",")+ = (*) Expr "," ["*"]
-    //   (<Expr> ",")+ = (*) Expr "," [Num]
-    //   Comma<Expr> = (*) [")"]
-    //   Comma<Expr> = (*) (<Expr> ",")+ [")"]
-    //   Comma<Expr> = (*) (<Expr> ",")+ Expr [")"]
-    //   Comma<Expr> = (*) Expr [")"]
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor [","]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor [","]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor [","]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term [","]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term [","]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term [","]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [","]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" [EOF]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["*"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["+"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["-"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" [","]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num [","]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = ["*", "("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*", "("]
+    //     WillPushLen = 2
+    //     WillPush = [Comma<Expr>, ")"]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S34)
-    //   ")" -> Reduce(Comma<Expr> =  => ActionFn(23);)
-    //   "*" -> Shift(S35)
-    //   Num -> Shift(S36)
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["("]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [")"]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["*"]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [Num]
+    //     (<Expr> ",")+ = (*) Expr "," ["("]
+    //     (<Expr> ",")+ = (*) Expr "," [")"]
+    //     (<Expr> ",")+ = (*) Expr "," ["*"]
+    //     (<Expr> ",")+ = (*) Expr "," [Num]
+    //     Comma<Expr> = (*) [")"]
+    //     Comma<Expr> = (*) (<Expr> ",")+ [")"]
+    //     Comma<Expr> = (*) (<Expr> ",")+ Expr [")"]
+    //     Comma<Expr> = (*) Expr [")"]
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor [","]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor [","]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor [","]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term [","]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term [","]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term [","]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" [EOF]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["*"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["+"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["-"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" [","]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num [","]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   (<Expr> ",")+ -> S29
-    //   Comma<Expr> -> S30
-    //   Expr -> S31
-    //   Factor -> S32
-    //   Term -> S33
+    //     "(" -> Shift(S34)
+    //     ")" -> Reduce(Comma<Expr> =  => ActionFn(23);)
+    //     "*" -> Shift(S35)
+    //     Num -> Shift(S36)
+    //
+    //     (<Expr> ",")+ -> S29
+    //     Comma<Expr> -> S30
+    //     Expr -> S31
+    //     Factor -> S32
+    //     Term -> S33
     pub fn __state17<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1322,19 +1231,19 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state34(arena, __tokens, __sym2));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state35(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state36(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             Some((_, Tok::RParen, _)) => {
-                let __start = __sym1.as_ref().unwrap().2.clone();
+                let __start = __sym1.2.clone();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action23(arena, &__start, &__end);
                 let __nt = __Nonterminal::Comma_3cExpr_3e((
@@ -1351,57 +1260,60 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b(__sym2) => {
                     __result = try!(__state29(arena, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Comma_3cExpr_3e(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Comma_3cExpr_3e(__sym2) => {
                     __result = try!(__state30(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
-                __Nonterminal::Expr(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym2) => {
                     __result = try!(__state31(arena, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state32(arena, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 18
-    //   Expr = Expr "+" Factor (*) [EOF]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "*" -> Shift(S9)
-    //   "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "/" -> Shift(S10)
+    //     Expr = Expr "+" Factor (*) [EOF]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S9)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S10)
     //
     pub fn __state18<
         'ast,
@@ -1412,25 +1324,26 @@ mod __parse__Expr {
         __lookahead: Option<(usize, Tok, usize)>,
         __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
         __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym2: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state10(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             None |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(arena, __sym0, __sym1, __sym2);
@@ -1439,7 +1352,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1448,29 +1362,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 19
-    //   Expr = Expr "-" Factor (*) [EOF]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "*" -> Shift(S9)
-    //   "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "/" -> Shift(S10)
+    //     Expr = Expr "-" Factor (*) [EOF]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S9)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S10)
     //
     pub fn __state19<
         'ast,
@@ -1481,25 +1402,26 @@ mod __parse__Expr {
         __lookahead: Option<(usize, Tok, usize)>,
         __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
         __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym2: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state10(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             None |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action1(arena, __sym0, __sym1, __sym2);
@@ -1508,174 +1430,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 20
-    //   Factor = Factor "*" Term (*) [EOF]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "*" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "+" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "-" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "/" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //
-    pub fn __state20<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action4(arena, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 21
-    //   Factor = Factor "/" Term (*) [EOF]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "*" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "+" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "-" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "/" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //
-    pub fn __state21<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(arena, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 22
-    //   Term = "(" Expr ")" (*) [EOF]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //
-    //   EOF -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "*" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "+" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "-" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "/" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //
-    pub fn __state22<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym2: &mut Option<(usize, Tok, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action9(arena, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1687,54 +1443,62 @@ mod __parse__Expr {
     }
 
     // State 23
-    //   Expr = Expr "+" (*) Factor [")"]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S14)
-    //   "*" -> Shift(S15)
-    //   Num -> Shift(S16)
+    //     Expr = Expr "+" (*) Factor [")"]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S37
-    //   Term -> S13
+    //     "(" -> Shift(S14)
+    //     "*" -> Shift(S15)
+    //     Num -> Shift(S16)
+    //
+    //     Factor -> S37
+    //     Term -> S13
     pub fn __state23<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1743,18 +1507,20 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state14(arena, __tokens, __sym2));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state15(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1763,74 +1529,82 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state37(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state13(arena, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 24
-    //   Expr = Expr "-" (*) Factor [")"]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S14)
-    //   "*" -> Shift(S15)
-    //   Num -> Shift(S16)
+    //     Expr = Expr "-" (*) Factor [")"]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S38
-    //   Term -> S13
+    //     "(" -> Shift(S14)
+    //     "*" -> Shift(S15)
+    //     Num -> Shift(S16)
+    //
+    //     Factor -> S38
+    //     Term -> S13
     pub fn __state24<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1839,18 +1613,20 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state14(arena, __tokens, __sym2));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state15(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1859,54 +1635,62 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state38(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state13(arena, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 25
-    //   Factor = Factor "*" (*) Term [")"]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S14)
-    //   Num -> Shift(S16)
+    //     Factor = Factor "*" (*) Term [")"]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S39
+    //     "(" -> Shift(S14)
+    //     Num -> Shift(S16)
+    //
+    //     Term -> S39
     pub fn __state25<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1917,12 +1701,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state14(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1931,50 +1715,57 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state39(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom2(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 26
-    //   Factor = Factor "/" (*) Term [")"]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S14)
-    //   Num -> Shift(S16)
+    //     Factor = Factor "/" (*) Term [")"]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S40
+    //     "(" -> Shift(S14)
+    //     Num -> Shift(S16)
+    //
+    //     Term -> S40
     pub fn __state26<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1985,12 +1776,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state14(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1999,37 +1790,44 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state40(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 27
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [")"]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S41)
-    //   "+" -> Shift(S23)
-    //   "-" -> Shift(S24)
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [")"]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S41)
+    //     "+" -> Shift(S23)
+    //     "-" -> Shift(S24)
     //
     pub fn __state27<
         'ast,
@@ -2039,22 +1837,26 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
         __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym1: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state41(arena, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(arena, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state23(arena, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state24(arena, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2063,94 +1865,101 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 28
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["("]
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [")"]
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["*"]
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [Num]
-    //   (<Expr> ",")+ = (*) Expr "," ["("]
-    //   (<Expr> ",")+ = (*) Expr "," [")"]
-    //   (<Expr> ",")+ = (*) Expr "," ["*"]
-    //   (<Expr> ",")+ = (*) Expr "," [Num]
-    //   Comma<Expr> = (*) [")"]
-    //   Comma<Expr> = (*) (<Expr> ",")+ [")"]
-    //   Comma<Expr> = (*) (<Expr> ",")+ Expr [")"]
-    //   Comma<Expr> = (*) Expr [")"]
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor [","]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor [","]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor [","]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term [","]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term [","]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term [","]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [","]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" [")"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["*"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["+"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["-"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" [","]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num [","]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = ["*", "("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*", "("]
+    //     WillPushLen = 2
+    //     WillPush = [Comma<Expr>, ")"]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S34)
-    //   ")" -> Reduce(Comma<Expr> =  => ActionFn(23);)
-    //   "*" -> Shift(S35)
-    //   Num -> Shift(S36)
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["("]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [")"]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["*"]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [Num]
+    //     (<Expr> ",")+ = (*) Expr "," ["("]
+    //     (<Expr> ",")+ = (*) Expr "," [")"]
+    //     (<Expr> ",")+ = (*) Expr "," ["*"]
+    //     (<Expr> ",")+ = (*) Expr "," [Num]
+    //     Comma<Expr> = (*) [")"]
+    //     Comma<Expr> = (*) (<Expr> ",")+ [")"]
+    //     Comma<Expr> = (*) (<Expr> ",")+ Expr [")"]
+    //     Comma<Expr> = (*) Expr [")"]
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor [","]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor [","]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor [","]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term [","]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term [","]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term [","]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" [")"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["*"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["+"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["-"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" [","]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num [","]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   (<Expr> ",")+ -> S29
-    //   Comma<Expr> -> S42
-    //   Expr -> S31
-    //   Factor -> S32
-    //   Term -> S33
+    //     "(" -> Shift(S34)
+    //     ")" -> Reduce(Comma<Expr> =  => ActionFn(23);)
+    //     "*" -> Shift(S35)
+    //     Num -> Shift(S36)
+    //
+    //     (<Expr> ",")+ -> S29
+    //     Comma<Expr> -> S42
+    //     Expr -> S31
+    //     Factor -> S32
+    //     Term -> S33
     pub fn __state28<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2161,19 +1970,19 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state34(arena, __tokens, __sym2));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state35(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state36(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             Some((_, Tok::RParen, _)) => {
-                let __start = __sym1.as_ref().unwrap().2.clone();
+                let __start = __sym1.2.clone();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action23(arena, &__start, &__end);
                 let __nt = __Nonterminal::Comma_3cExpr_3e((
@@ -2190,101 +1999,104 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b(__sym2) => {
                     __result = try!(__state29(arena, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Comma_3cExpr_3e(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Comma_3cExpr_3e(__sym2) => {
                     __result = try!(__state42(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
-                __Nonterminal::Expr(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym2) => {
                     __result = try!(__state31(arena, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state32(arena, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 29
-    //   (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," ["("]
-    //   (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," [")"]
-    //   (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," ["*"]
-    //   (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," [Num]
-    //   Comma<Expr> = (<Expr> ",")+ (*) [")"]
-    //   Comma<Expr> = (<Expr> ",")+ (*) Expr [")"]
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor [","]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor [","]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor [","]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term [","]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term [","]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term [","]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [","]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" [","]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num [","]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [(<Expr> ",")+]
+    //     OptionalInputs = []
+    //     FixedInputs = [(<Expr> ",")+]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   "(" -> Shift(S34)
-    //   ")" -> Reduce(Comma<Expr> = (<Expr> ",")+ => ActionFn(25);)
-    //   "*" -> Shift(S35)
-    //   Num -> Shift(S36)
+    //     (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," ["("]
+    //     (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," [")"]
+    //     (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," ["*"]
+    //     (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," [Num]
+    //     Comma<Expr> = (<Expr> ",")+ (*) [")"]
+    //     Comma<Expr> = (<Expr> ",")+ (*) Expr [")"]
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor [","]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor [","]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor [","]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term [","]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term [","]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term [","]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" [","]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num [","]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Expr -> S43
-    //   Factor -> S32
-    //   Term -> S33
+    //     "(" -> Shift(S34)
+    //     ")" -> Reduce(Comma<Expr> = (<Expr> ",")+ => ActionFn(25);)
+    //     "*" -> Shift(S35)
+    //     Num -> Shift(S36)
+    //
+    //     Expr -> S43
+    //     Factor -> S32
+    //     Term -> S33
     pub fn __state29<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
@@ -2292,22 +2104,23 @@ mod __parse__Expr {
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, ::std::vec::Vec<&'ast Node<'ast>>, usize)>,
+        __sym0: (usize, ::std::vec::Vec<&'ast Node<'ast>>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state34(arena, __tokens, __sym1));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state35(arena, __tokens, __sym1));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state36(arena, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym1));
             }
             Some((_, Tok::RParen, _)) => {
                 let __sym0 = __sym0.take().unwrap();
@@ -2319,7 +2132,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2328,37 +2142,44 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state43(arena, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state32(arena, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state33(arena, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 30
-    //   Factor = "*" "(" Comma<Expr> (*) ")" [EOF]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["*"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["+"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["*", "(", Comma<Expr>]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*", "(", Comma<Expr>]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = Some(Factor)
     //
-    //   ")" -> Shift(S44)
+    //     Factor = "*" "(" Comma<Expr> (*) ")" [EOF]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["*"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["+"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S44)
     //
     pub fn __state30<
         'ast,
@@ -2367,16 +2188,17 @@ mod __parse__Expr {
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, Vec<&'ast Node<'ast>>, usize)>,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state44(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                let __sym3 = (__loc1, (__tok), __loc2);
+                __result = try!(__custom5(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2385,28 +2207,35 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 31
-    //   (<Expr> ",")+ = Expr (*) "," ["("]
-    //   (<Expr> ",")+ = Expr (*) "," [")"]
-    //   (<Expr> ",")+ = Expr (*) "," ["*"]
-    //   (<Expr> ",")+ = Expr (*) "," [Num]
-    //   Comma<Expr> = Expr (*) [")"]
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor [","]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor [","]
-    //   Expr = Expr (*) "-" Factor ["-"]
+    //     Kind = None
+    //     AllInputs = [Expr]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Comma<Expr> = Expr => ActionFn(22);)
-    //   "+" -> Shift(S45)
-    //   "," -> Shift(S46)
-    //   "-" -> Shift(S47)
+    //     (<Expr> ",")+ = Expr (*) "," ["("]
+    //     (<Expr> ",")+ = Expr (*) "," [")"]
+    //     (<Expr> ",")+ = Expr (*) "," ["*"]
+    //     (<Expr> ",")+ = Expr (*) "," [Num]
+    //     Comma<Expr> = Expr (*) [")"]
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor [","]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor [","]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //
+    //     ")" -> Reduce(Comma<Expr> = Expr => ActionFn(22);)
+    //     "+" -> Shift(S45)
+    //     "," -> Shift(S46)
+    //     "-" -> Shift(S47)
     //
     pub fn __state31<
         'ast,
@@ -2415,25 +2244,27 @@ mod __parse__Expr {
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state45(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Comma, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state46(arena, __tokens, __sym0, __sym1));
+                let __sym1 = (__loc1, (__tok), __loc2);
+                __result = try!(__custom6(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state47(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action22(arena, __sym0);
@@ -2442,7 +2273,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2451,33 +2283,40 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 32
-    //   Expr = Factor (*) [")"]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) [","]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term [","]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term [","]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "*" -> Shift(S48)
-    //   "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "," -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "/" -> Shift(S49)
+    //     Expr = Factor (*) [")"]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) [","]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term [","]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term [","]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S48)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "," -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S49)
     //
     pub fn __state32<
         'ast,
@@ -2486,24 +2325,25 @@ mod __parse__Expr {
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state48(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state49(arena, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Comma, _)) |
             Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(arena, __sym0);
@@ -2512,61 +2352,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 33
-    //   Factor = Term (*) [")"]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) [","]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "*" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "+" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "," -> Reduce(Factor = Term => ActionFn(7);)
-    //   "-" -> Reduce(Factor = Term => ActionFn(7);)
-    //   "/" -> Reduce(Factor = Term => ActionFn(7);)
-    //
-    pub fn __state33<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Comma, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action7(arena, __sym0);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2578,66 +2365,74 @@ mod __parse__Expr {
     }
 
     // State 34
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [")"]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" [","]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
     //
-    //   "(" -> Shift(S14)
-    //   "*" -> Shift(S15)
-    //   Num -> Shift(S16)
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")"]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" [","]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Expr -> S50
-    //   Factor -> S12
-    //   Term -> S13
+    //     "(" -> Shift(S14)
+    //     "*" -> Shift(S15)
+    //     Num -> Shift(S16)
+    //
+    //     Expr -> S50
+    //     Factor -> S12
+    //     Term -> S13
     pub fn __state34<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2646,18 +2441,19 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state14(arena, __tokens, __sym1));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state15(arena, __tokens, __sym1));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(arena, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2666,38 +2462,45 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state50(arena, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state12(arena, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state13(arena, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 35
-    //   Factor = "*" (*) "(" Comma<Expr> ")" [")"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["*"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["+"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" [","]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
-    //   Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["*"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*"]
+    //     WillPushLen = 3
+    //     WillPush = ["(", Comma<Expr>, ")"]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S51)
+    //     Factor = "*" (*) "(" Comma<Expr> ")" [")"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["*"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["+"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" [","]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
+    //
+    //     "(" -> Shift(S51)
     //
     pub fn __state35<
         'ast,
@@ -2705,7 +2508,7 @@ mod __parse__Expr {
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2716,66 +2519,9 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state51(arena, __tokens, __sym0, __sym1));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 36
-    //   Term = Num (*) [")"]
-    //   Term = Num (*) ["*"]
-    //   Term = Num (*) ["+"]
-    //   Term = Num (*) [","]
-    //   Term = Num (*) ["-"]
-    //   Term = Num (*) ["/"]
-    //
-    //   ")" -> Reduce(Term = Num => ActionFn(8);)
-    //   "*" -> Reduce(Term = Num => ActionFn(8);)
-    //   "+" -> Reduce(Term = Num => ActionFn(8);)
-    //   "," -> Reduce(Term = Num => ActionFn(8);)
-    //   "-" -> Reduce(Term = Num => ActionFn(8);)
-    //   "/" -> Reduce(Term = Num => ActionFn(8);)
-    //
-    pub fn __state36<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Comma, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action8(arena, __sym0);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2787,25 +2533,33 @@ mod __parse__Expr {
     }
 
     // State 37
-    //   Expr = Expr "+" Factor (*) [")"]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "*" -> Shift(S25)
-    //   "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "/" -> Shift(S26)
+    //     Expr = Expr "+" Factor (*) [")"]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S25)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S26)
     //
     pub fn __state37<
         'ast,
@@ -2816,25 +2570,26 @@ mod __parse__Expr {
         __lookahead: Option<(usize, Tok, usize)>,
         __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
         __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym2: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state25(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state26(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(arena, __sym0, __sym1, __sym2);
@@ -2843,7 +2598,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2852,29 +2608,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 38
-    //   Expr = Expr "-" Factor (*) [")"]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "*" -> Shift(S25)
-    //   "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "/" -> Shift(S26)
+    //     Expr = Expr "-" Factor (*) [")"]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S25)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S26)
     //
     pub fn __state38<
         'ast,
@@ -2885,25 +2648,26 @@ mod __parse__Expr {
         __lookahead: Option<(usize, Tok, usize)>,
         __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
         __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym2: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state25(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state26(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action1(arena, __sym0, __sym1, __sym2);
@@ -2912,174 +2676,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 39
-    //   Factor = Factor "*" Term (*) [")"]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "*" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "+" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "-" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "/" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //
-    pub fn __state39<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action4(arena, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 40
-    //   Factor = Factor "/" Term (*) [")"]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "*" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "+" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "-" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "/" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //
-    pub fn __state40<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(arena, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 41
-    //   Term = "(" Expr ")" (*) [")"]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //
-    //   ")" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "*" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "+" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "-" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "/" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //
-    pub fn __state41<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym2: &mut Option<(usize, Tok, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action9(arena, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3091,13 +2689,21 @@ mod __parse__Expr {
     }
 
     // State 42
-    //   Factor = "*" "(" Comma<Expr> (*) ")" [")"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["*"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["+"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["*", "(", Comma<Expr>]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*", "(", Comma<Expr>]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = Some(Factor)
     //
-    //   ")" -> Shift(S52)
+    //     Factor = "*" "(" Comma<Expr> (*) ")" [")"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["*"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["+"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S52)
     //
     pub fn __state42<
         'ast,
@@ -3106,16 +2712,17 @@ mod __parse__Expr {
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, Vec<&'ast Node<'ast>>, usize)>,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state52(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                let __sym3 = (__loc1, (__tok), __loc2);
+                __result = try!(__custom5(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3124,28 +2731,35 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 43
-    //   (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," ["("]
-    //   (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," [")"]
-    //   (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," ["*"]
-    //   (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," [Num]
-    //   Comma<Expr> = (<Expr> ",")+ Expr (*) [")"]
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor [","]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor [","]
-    //   Expr = Expr (*) "-" Factor ["-"]
+    //     Kind = None
+    //     AllInputs = [(<Expr> ",")+, Expr]
+    //     OptionalInputs = [(<Expr> ",")+]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Comma<Expr> = (<Expr> ",")+, Expr => ActionFn(24);)
-    //   "+" -> Shift(S45)
-    //   "," -> Shift(S53)
-    //   "-" -> Shift(S47)
+    //     (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," ["("]
+    //     (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," [")"]
+    //     (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," ["*"]
+    //     (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," [Num]
+    //     Comma<Expr> = (<Expr> ",")+ Expr (*) [")"]
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor [","]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor [","]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //
+    //     ")" -> Reduce(Comma<Expr> = (<Expr> ",")+, Expr => ActionFn(24);)
+    //     "+" -> Shift(S45)
+    //     "," -> Shift(S53)
+    //     "-" -> Shift(S47)
     //
     pub fn __state43<
         'ast,
@@ -3155,26 +2769,29 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
         __sym0: &mut Option<(usize, ::std::vec::Vec<&'ast Node<'ast>>, usize)>,
-        __sym1: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym1: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state45(arena, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Comma, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state53(arena, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom7(arena, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state47(arena, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) => {
                 let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym1.2.clone();
                 let __nt = super::__action24(arena, __sym0, __sym1);
@@ -3183,68 +2800,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 44
-    //   Factor = "*" "(" Comma<Expr> ")" (*) [EOF]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["*"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["+"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["-"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "*" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "+" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "-" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "/" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //
-    pub fn __state44<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, Vec<&'ast Node<'ast>>, usize)>,
-        __sym3: &mut Option<(usize, Tok, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            None |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __sym3 = __sym3.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym3.2.clone();
-                let __nt = super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3256,61 +2813,69 @@ mod __parse__Expr {
     }
 
     // State 45
-    //   Expr = Expr "+" (*) Factor [")"]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor [","]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term [","]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term [","]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term [","]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [","]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" [","]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num [","]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S34)
-    //   "*" -> Shift(S35)
-    //   Num -> Shift(S36)
+    //     Expr = Expr "+" (*) Factor [")"]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor [","]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term [","]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term [","]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term [","]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" [","]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num [","]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S54
-    //   Term -> S33
+    //     "(" -> Shift(S34)
+    //     "*" -> Shift(S35)
+    //     Num -> Shift(S36)
+    //
+    //     Factor -> S54
+    //     Term -> S33
     pub fn __state45<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3319,18 +2884,20 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state34(arena, __tokens, __sym2));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state35(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state36(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3339,134 +2906,89 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state54(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 46
-    //   (<Expr> ",")+ = Expr "," (*) ["("]
-    //   (<Expr> ",")+ = Expr "," (*) [")"]
-    //   (<Expr> ",")+ = Expr "," (*) ["*"]
-    //   (<Expr> ",")+ = Expr "," (*) [Num]
-    //
-    //   "(" -> Reduce((<Expr> ",")+ = Expr, "," => ActionFn(18);)
-    //   ")" -> Reduce((<Expr> ",")+ = Expr, "," => ActionFn(18);)
-    //   "*" -> Reduce((<Expr> ",")+ = Expr, "," => ActionFn(18);)
-    //   Num -> Reduce((<Expr> ",")+ = Expr, "," => ActionFn(18);)
-    //
-    pub fn __state46<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            Some((_, Tok::LParen, _)) |
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Num(_), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action18(arena, __sym0, __sym1);
-                let __nt = __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 47
-    //   Expr = Expr "-" (*) Factor [")"]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor [","]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term [","]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term [","]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term [","]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [","]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" [","]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num [","]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S34)
-    //   "*" -> Shift(S35)
-    //   Num -> Shift(S36)
+    //     Expr = Expr "-" (*) Factor [")"]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor [","]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term [","]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term [","]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term [","]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" [","]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num [","]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S55
-    //   Term -> S33
+    //     "(" -> Shift(S34)
+    //     "*" -> Shift(S35)
+    //     Num -> Shift(S36)
+    //
+    //     Factor -> S55
+    //     Term -> S33
     pub fn __state47<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3475,18 +2997,20 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state34(arena, __tokens, __sym2));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state35(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state36(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3495,57 +3019,65 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state55(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 48
-    //   Factor = Factor "*" (*) Term [")"]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term [","]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" [","]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num [","]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S34)
-    //   Num -> Shift(S36)
+    //     Factor = Factor "*" (*) Term [")"]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term [","]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" [","]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num [","]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S56
+    //     "(" -> Shift(S34)
+    //     Num -> Shift(S36)
+    //
+    //     Term -> S56
     pub fn __state48<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3556,12 +3088,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state34(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state36(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3570,53 +3102,60 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state56(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom2(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 49
-    //   Factor = Factor "/" (*) Term [")"]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term [","]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" [","]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num [","]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S34)
-    //   Num -> Shift(S36)
+    //     Factor = Factor "/" (*) Term [")"]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term [","]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" [","]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num [","]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S57
+    //     "(" -> Shift(S34)
+    //     Num -> Shift(S36)
+    //
+    //     Term -> S57
     pub fn __state49<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3627,12 +3166,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state34(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state36(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3641,38 +3180,45 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state57(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 50
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [")"]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" [","]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S58)
-    //   "+" -> Shift(S23)
-    //   "-" -> Shift(S24)
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [")"]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" [","]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S58)
+    //     "+" -> Shift(S23)
+    //     "-" -> Shift(S24)
     //
     pub fn __state50<
         'ast,
@@ -3682,22 +3228,26 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
         __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym1: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state58(arena, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(arena, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state23(arena, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state24(arena, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3706,95 +3256,102 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 51
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["("]
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [")"]
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["*"]
-    //   (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [Num]
-    //   (<Expr> ",")+ = (*) Expr "," ["("]
-    //   (<Expr> ",")+ = (*) Expr "," [")"]
-    //   (<Expr> ",")+ = (*) Expr "," ["*"]
-    //   (<Expr> ",")+ = (*) Expr "," [Num]
-    //   Comma<Expr> = (*) [")"]
-    //   Comma<Expr> = (*) (<Expr> ",")+ [")"]
-    //   Comma<Expr> = (*) (<Expr> ",")+ Expr [")"]
-    //   Comma<Expr> = (*) Expr [")"]
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor [","]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor [","]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor [","]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term [","]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term [","]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term [","]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [")"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" [","]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
-    //   Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" [")"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["*"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["+"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" [","]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["-"]
-    //   Factor = "*" "(" (*) Comma<Expr> ")" ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" [","]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num [","]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = ["*", "("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*", "("]
+    //     WillPushLen = 2
+    //     WillPush = [Comma<Expr>, ")"]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S34)
-    //   ")" -> Reduce(Comma<Expr> =  => ActionFn(23);)
-    //   "*" -> Shift(S35)
-    //   Num -> Shift(S36)
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["("]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [")"]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["*"]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [Num]
+    //     (<Expr> ",")+ = (*) Expr "," ["("]
+    //     (<Expr> ",")+ = (*) Expr "," [")"]
+    //     (<Expr> ",")+ = (*) Expr "," ["*"]
+    //     (<Expr> ",")+ = (*) Expr "," [Num]
+    //     Comma<Expr> = (*) [")"]
+    //     Comma<Expr> = (*) (<Expr> ",")+ [")"]
+    //     Comma<Expr> = (*) (<Expr> ",")+ Expr [")"]
+    //     Comma<Expr> = (*) Expr [")"]
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor [","]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor [","]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor [","]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term [","]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term [","]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term [","]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" [")"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["*"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["+"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" [","]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["-"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" [","]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num [","]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   (<Expr> ",")+ -> S29
-    //   Comma<Expr> -> S59
-    //   Expr -> S31
-    //   Factor -> S32
-    //   Term -> S33
+    //     "(" -> Shift(S34)
+    //     ")" -> Reduce(Comma<Expr> =  => ActionFn(23);)
+    //     "*" -> Shift(S35)
+    //     Num -> Shift(S36)
+    //
+    //     (<Expr> ",")+ -> S29
+    //     Comma<Expr> -> S59
+    //     Expr -> S31
+    //     Factor -> S32
+    //     Term -> S33
     pub fn __state51<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3805,19 +3362,19 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state34(arena, __tokens, __sym2));
             }
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state35(arena, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state36(arena, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(arena, __tokens, __sym2));
             }
             Some((_, Tok::RParen, _)) => {
-                let __start = __sym1.as_ref().unwrap().2.clone();
+                let __start = __sym1.2.clone();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action23(arena, &__start, &__end);
                 let __nt = __Nonterminal::Comma_3cExpr_3e((
@@ -3834,176 +3391,64 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b(__sym2) => {
                     __result = try!(__state29(arena, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Comma_3cExpr_3e(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Comma_3cExpr_3e(__sym2) => {
                     __result = try!(__state59(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
-                __Nonterminal::Expr(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym2) => {
                     __result = try!(__state31(arena, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state32(arena, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 52
-    //   Factor = "*" "(" Comma<Expr> ")" (*) [")"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["*"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["+"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["-"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "*" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "+" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "-" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "/" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //
-    pub fn __state52<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, Vec<&'ast Node<'ast>>, usize)>,
-        __sym3: &mut Option<(usize, Tok, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __sym3 = __sym3.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym3.2.clone();
-                let __nt = super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 53
-    //   (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) ["("]
-    //   (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) [")"]
-    //   (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) ["*"]
-    //   (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) [Num]
-    //
-    //   "(" -> Reduce((<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);)
-    //   ")" -> Reduce((<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);)
-    //   "*" -> Reduce((<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);)
-    //   Num -> Reduce((<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);)
-    //
-    pub fn __state53<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, ::std::vec::Vec<&'ast Node<'ast>>, usize)>,
-        __sym1: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym2: &mut Option<(usize, Tok, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            Some((_, Tok::LParen, _)) |
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Num(_), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action19(arena, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 54
-    //   Expr = Expr "+" Factor (*) [")"]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) [","]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term [","]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term [","]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "*" -> Shift(S48)
-    //   "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "," -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "/" -> Shift(S49)
+    //     Expr = Expr "+" Factor (*) [")"]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) [","]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term [","]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term [","]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S48)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "," -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S49)
     //
     pub fn __state54<
         'ast,
@@ -4014,18 +3459,20 @@ mod __parse__Expr {
         __lookahead: Option<(usize, Tok, usize)>,
         __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
         __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym2: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state48(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state49(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
@@ -4033,7 +3480,6 @@ mod __parse__Expr {
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(arena, __sym0, __sym1, __sym2);
@@ -4042,7 +3488,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -4051,33 +3498,40 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 55
-    //   Expr = Expr "-" Factor (*) [")"]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) [","]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term [","]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term [","]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "*" -> Shift(S48)
-    //   "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "," -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "/" -> Shift(S49)
+    //     Expr = Expr "-" Factor (*) [")"]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) [","]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term [","]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term [","]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S48)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "," -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S49)
     //
     pub fn __state55<
         'ast,
@@ -4088,18 +3542,20 @@ mod __parse__Expr {
         __lookahead: Option<(usize, Tok, usize)>,
         __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
         __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
+        __sym2: (usize, &'ast Node<'ast>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state48(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state49(arena, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
@@ -4107,7 +3563,6 @@ mod __parse__Expr {
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action1(arena, __sym0, __sym1, __sym2);
@@ -4116,183 +3571,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 56
-    //   Factor = Factor "*" Term (*) [")"]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) [","]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "*" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "+" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "," -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "-" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "/" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //
-    pub fn __state56<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Comma, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action4(arena, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 57
-    //   Factor = Factor "/" Term (*) [")"]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) [","]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "*" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "+" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "," -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "-" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "/" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //
-    pub fn __state57<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Comma, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(arena, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 58
-    //   Term = "(" Expr ")" (*) [")"]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) [","]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //
-    //   ")" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "*" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "+" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "," -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "-" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //   "/" -> Reduce(Term = "(", Expr, ")" => ActionFn(9);)
-    //
-    pub fn __state58<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, &'ast Node<'ast>, usize)>,
-        __sym2: &mut Option<(usize, Tok, usize)>,
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Comma, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action9(arena, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -4304,14 +3584,22 @@ mod __parse__Expr {
     }
 
     // State 59
-    //   Factor = "*" "(" Comma<Expr> (*) ")" [")"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["*"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["+"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" [","]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
-    //   Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["*", "(", Comma<Expr>]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*", "(", Comma<Expr>]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = Some(Factor)
     //
-    //   ")" -> Shift(S60)
+    //     Factor = "*" "(" Comma<Expr> (*) ")" [")"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["*"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["+"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" [","]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S60)
     //
     pub fn __state59<
         'ast,
@@ -4320,16 +3608,17 @@ mod __parse__Expr {
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, Vec<&'ast Node<'ast>>, usize)>,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state60(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                let __sym3 = (__loc1, (__tok), __loc2);
+                __result = try!(__custom5(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -4338,34 +3627,42 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
-    // State 60
-    //   Factor = "*" "(" Comma<Expr> ")" (*) [")"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["*"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["+"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) [","]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["-"]
-    //   Factor = "*" "(" Comma<Expr> ")" (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "*" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "+" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "," -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "-" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //   "/" -> Reduce(Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);)
-    //
-    pub fn __state60<
+    // Custom 0
+    //    Reduce Factor = Term => ActionFn(7);
+    pub fn __custom0<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         arena: &'ast Arena<'ast>,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
-        __sym2: &mut Option<(usize, Vec<&'ast Node<'ast>>, usize)>,
-        __sym3: &mut Option<(usize, Tok, usize)>,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action7(arena, __sym0);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 1
+    //    Reduce Term = Num => ActionFn(8);
+    pub fn __custom1<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, i32, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -4374,34 +3671,194 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Comma, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __sym3 = __sym3.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym3.2.clone();
-                let __nt = super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action8(arena, __sym0);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 2
+    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
+    pub fn __custom2<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action4(arena, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 3
+    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
+    pub fn __custom3<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action5(arena, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 4
+    //    Reduce Term = "(", Expr, ")" => ActionFn(9);
+    pub fn __custom4<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, &'ast Node<'ast>, usize),
+        __sym2: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action9(arena, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 5
+    //    Reduce Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    pub fn __custom5<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
+        __sym3: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym3.2.clone();
+        let __nt = super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 6
+    //    Reduce (<Expr> ",")+ = Expr, "," => ActionFn(18);
+    pub fn __custom6<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = super::__action18(arena, __sym0, __sym1);
+        let __nt = __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 7
+    //    Reduce (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
+    pub fn __custom7<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, ::std::vec::Vec<&'ast Node<'ast>>, usize),
+        __sym1: (usize, &'ast Node<'ast>, usize),
+        __sym2: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action19(arena, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__Expr::parse_Expr;
@@ -4516,7 +3973,7 @@ pub fn __action9<
     (_, _, _): (usize, Tok, usize),
 ) -> &'ast Node<'ast>
 {
-    (__0)
+    arena.alloc(Node::Paren(__0))
 }
 
 pub fn __action10<

--- a/lalrpop-test/src/expr_arena_ast.rs
+++ b/lalrpop-test/src/expr_arena_ast.rs
@@ -10,6 +10,7 @@ pub enum Node<'ast> {
     Value(i32),
     Binary(Op, &'ast Node<'ast>, &'ast Node<'ast>),
     Reduce(Op, Vec<&'ast Node<'ast>>),
+    Paren(&'ast Node<'ast>),
 }
 
 pub struct Arena<'ast> {

--- a/lalrpop-test/src/expr_generic.rs
+++ b/lalrpop-test/src/expr_generic.rs
@@ -50,48 +50,56 @@ mod __parse__Expr {
     }
 
     // State 0
-    //   Expr = (*) Expr "+" Factor [EOF]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [EOF]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [EOF]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [EOF]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
-    //   __Expr = (*) Expr [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   "(" -> Shift(S4)
-    //   r#"[0-9]+"# -> Shift(S5)
+    //     Expr = (*) Expr "+" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [EOF]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
+    //     __Expr = (*) Expr [EOF]
     //
-    //   Expr -> S1
-    //   Factor -> S2
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     r#"[0-9]+"# -> Shift(S5)
+    //
+    //     Expr -> S1
+    //     Factor -> S2
+    //     Term -> S3
     pub fn __state0<
         'input,
         F,
@@ -106,12 +114,12 @@ mod __parse__Expr {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym0 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state4(input, __tokens, __sym0));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(input, __tokens, __sym0));
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -123,17 +131,14 @@ mod __parse__Expr {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym0) => {
                     __result = try!(__state1(input, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym0) => {
                     __result = try!(__state2(input, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state3(input, __tokens, __lookahead, __sym0));
+                __Nonterminal::Term(__sym0) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -143,17 +148,25 @@ mod __parse__Expr {
     }
 
     // State 1
-    //   Expr = Expr (*) "+" Factor [EOF]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [EOF]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   __Expr = Expr (*) [EOF]
+    //     Kind = None
+    //     AllInputs = [Expr]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //   "+" -> Shift(S6)
-    //   "-" -> Shift(S7)
+    //     Expr = Expr (*) "+" Factor [EOF]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [EOF]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     __Expr = Expr (*) [EOF]
+    //
+    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
+    //     "+" -> Shift(S6)
+    //     "-" -> Shift(S7)
     //
     pub fn __state1<
         'input,
@@ -163,22 +176,23 @@ mod __parse__Expr {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, F, usize)>,
+        __sym0: (usize, F, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
             Some((__loc1, (3, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state6(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, (4, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state7(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action0(input, __sym0);
@@ -187,7 +201,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -196,29 +211,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 2
-    //   Expr = Factor (*) [EOF]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "*" -> Shift(S8)
-    //   "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "/" -> Shift(S9)
+    //     Expr = Factor (*) [EOF]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S9)
     //
     pub fn __state2<
         'input,
@@ -228,24 +250,25 @@ mod __parse__Expr {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, F, usize)>,
+        __sym0: (usize, F, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state8(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state9(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(input, __sym0);
@@ -254,60 +277,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 3
-    //   Factor = Term (*) [EOF]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Term => ActionFn(6);)
-    //   "*" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "+" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "-" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "/" -> Reduce(Factor = Term => ActionFn(6);)
-    //
-    pub fn __state3<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, F, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action6(input, __sym0);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -319,52 +290,60 @@ mod __parse__Expr {
     }
 
     // State 4
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [EOF]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [")"]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
     //
-    //   "(" -> Shift(S13)
-    //   r#"[0-9]+"# -> Shift(S14)
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [EOF]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [")"]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //   Expr -> S10
-    //   Factor -> S11
-    //   Term -> S12
+    //     "(" -> Shift(S13)
+    //     r#"[0-9]+"# -> Shift(S14)
+    //
+    //     Expr -> S10
+    //     Factor -> S11
+    //     Term -> S12
     pub fn __state4<
         'input,
         F,
@@ -372,7 +351,7 @@ mod __parse__Expr {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -382,14 +361,15 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state13(input, __tokens, __sym1));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(input, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -398,120 +378,71 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state10(input, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state11(input, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state12(input, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 5
-    //   Term = r#"[0-9]+"# (*) [EOF]
-    //   Term = r#"[0-9]+"# (*) ["*"]
-    //   Term = r#"[0-9]+"# (*) ["+"]
-    //   Term = r#"[0-9]+"# (*) ["-"]
-    //   Term = r#"[0-9]+"# (*) ["/"]
-    //
-    //   EOF -> Reduce(Term = r#"[0-9]+"# => ActionFn(7);)
-    //   "*" -> Reduce(Term = r#"[0-9]+"# => ActionFn(7);)
-    //   "+" -> Reduce(Term = r#"[0-9]+"# => ActionFn(7);)
-    //   "-" -> Reduce(Term = r#"[0-9]+"# => ActionFn(7);)
-    //   "/" -> Reduce(Term = r#"[0-9]+"# => ActionFn(7);)
-    //
-    pub fn __state5<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action7(input, __sym0);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 6
-    //   Expr = Expr "+" (*) Factor [EOF]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [EOF]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S4)
-    //   r#"[0-9]+"# -> Shift(S5)
+    //     Expr = Expr "+" (*) Factor [EOF]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [EOF]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //   Factor -> S15
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     r#"[0-9]+"# -> Shift(S5)
+    //
+    //     Factor -> S15
+    //     Term -> S3
     pub fn __state6<
         'input,
         F,
@@ -519,8 +450,8 @@ mod __parse__Expr {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -530,14 +461,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state4(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -546,60 +479,68 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state15(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 7
-    //   Expr = Expr "-" (*) Factor [EOF]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [EOF]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S4)
-    //   r#"[0-9]+"# -> Shift(S5)
+    //     Expr = Expr "-" (*) Factor [EOF]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [EOF]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //   Factor -> S16
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     r#"[0-9]+"# -> Shift(S5)
+    //
+    //     Factor -> S16
+    //     Term -> S3
     pub fn __state7<
         'input,
         F,
@@ -607,8 +548,8 @@ mod __parse__Expr {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -618,14 +559,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state4(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -634,46 +577,54 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state16(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 8
-    //   Factor = Factor "*" (*) Term [EOF]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [EOF]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S4)
-    //   r#"[0-9]+"# -> Shift(S5)
+    //     Factor = Factor "*" (*) Term [EOF]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [EOF]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //   Term -> S17
+    //     "(" -> Shift(S4)
+    //     r#"[0-9]+"# -> Shift(S5)
+    //
+    //     Term -> S17
     pub fn __state8<
         'input,
         F,
@@ -681,8 +632,8 @@ mod __parse__Expr {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -694,12 +645,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state4(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -708,42 +659,49 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state17(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom2(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 9
-    //   Factor = Factor "/" (*) Term [EOF]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [EOF]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S4)
-    //   r#"[0-9]+"# -> Shift(S5)
+    //     Factor = Factor "/" (*) Term [EOF]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [EOF]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //   Term -> S18
+    //     "(" -> Shift(S4)
+    //     r#"[0-9]+"# -> Shift(S5)
+    //
+    //     Term -> S18
     pub fn __state9<
         'input,
         F,
@@ -751,8 +709,8 @@ mod __parse__Expr {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -764,12 +722,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state4(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -778,37 +736,44 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state18(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 10
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [EOF]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S19)
-    //   "+" -> Shift(S20)
-    //   "-" -> Shift(S21)
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [EOF]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S19)
+    //     "+" -> Shift(S20)
+    //     "-" -> Shift(S21)
     //
     pub fn __state10<
         'input,
@@ -819,23 +784,27 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, F, usize)>,
+        __sym1: (usize, F, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state19(input, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(input, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state20(input, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, (4, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state21(input, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -844,29 +813,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 11
-    //   Expr = Factor (*) [")"]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "*" -> Shift(S22)
-    //   "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "/" -> Shift(S23)
+    //     Expr = Factor (*) [")"]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S22)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S23)
     //
     pub fn __state11<
         'input,
@@ -876,24 +852,25 @@ mod __parse__Expr {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, F, usize)>,
+        __sym0: (usize, F, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state22(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state23(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((_, (1, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(input, __sym0);
@@ -902,60 +879,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 12
-    //   Factor = Term (*) [")"]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "*" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "+" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "-" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "/" -> Reduce(Factor = Term => ActionFn(6);)
-    //
-    pub fn __state12<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, F, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action6(input, __sym0);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -967,52 +892,60 @@ mod __parse__Expr {
     }
 
     // State 13
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [")"]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [")"]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
     //
-    //   "(" -> Shift(S13)
-    //   r#"[0-9]+"# -> Shift(S14)
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")"]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [")"]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //   Expr -> S24
-    //   Factor -> S11
-    //   Term -> S12
+    //     "(" -> Shift(S13)
+    //     r#"[0-9]+"# -> Shift(S14)
+    //
+    //     Expr -> S24
+    //     Factor -> S11
+    //     Term -> S12
     pub fn __state13<
         'input,
         F,
@@ -1020,7 +953,7 @@ mod __parse__Expr {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -1030,14 +963,15 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state13(input, __tokens, __sym1));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(input, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1046,105 +980,56 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state24(input, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state11(input, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state12(input, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 14
-    //   Term = r#"[0-9]+"# (*) [")"]
-    //   Term = r#"[0-9]+"# (*) ["*"]
-    //   Term = r#"[0-9]+"# (*) ["+"]
-    //   Term = r#"[0-9]+"# (*) ["-"]
-    //   Term = r#"[0-9]+"# (*) ["/"]
-    //
-    //   ")" -> Reduce(Term = r#"[0-9]+"# => ActionFn(7);)
-    //   "*" -> Reduce(Term = r#"[0-9]+"# => ActionFn(7);)
-    //   "+" -> Reduce(Term = r#"[0-9]+"# => ActionFn(7);)
-    //   "-" -> Reduce(Term = r#"[0-9]+"# => ActionFn(7);)
-    //   "/" -> Reduce(Term = r#"[0-9]+"# => ActionFn(7);)
-    //
-    pub fn __state14<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action7(input, __sym0);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 15
-    //   Expr = Expr "+" Factor (*) [EOF]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "*" -> Shift(S8)
-    //   "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "/" -> Shift(S9)
+    //     Expr = Expr "+" Factor (*) [EOF]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S9)
     //
     pub fn __state15<
         'input,
@@ -1156,26 +1041,27 @@ mod __parse__Expr {
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, F, usize)>,
         __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, F, usize)>,
+        __sym2: (usize, F, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state8(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state9(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             None |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(input, __sym0, __sym1, __sym2);
@@ -1184,7 +1070,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1193,29 +1080,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 16
-    //   Expr = Expr "-" Factor (*) [EOF]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "*" -> Shift(S8)
-    //   "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "/" -> Shift(S9)
+    //     Expr = Expr "-" Factor (*) [EOF]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S9)
     //
     pub fn __state16<
         'input,
@@ -1227,26 +1121,27 @@ mod __parse__Expr {
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, F, usize)>,
         __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, F, usize)>,
+        __sym2: (usize, F, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state8(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state9(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             None |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action1(input, __sym0, __sym1, __sym2);
@@ -1255,180 +1150,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 17
-    //   Factor = Factor "*" Term (*) [EOF]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "*" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "+" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "-" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "/" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //
-    pub fn __state17<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, F, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action4(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 18
-    //   Factor = Factor "/" Term (*) [EOF]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "*" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "+" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "-" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "/" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //
-    pub fn __state18<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, F, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 19
-    //   Term = "(" Expr ")" (*) [EOF]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //
-    //   EOF -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "*" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "+" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "-" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "/" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //
-    pub fn __state19<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, F, usize)>,
-        __sym2: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action8(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1440,40 +1163,48 @@ mod __parse__Expr {
     }
 
     // State 20
-    //   Expr = Expr "+" (*) Factor [")"]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [")"]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S13)
-    //   r#"[0-9]+"# -> Shift(S14)
+    //     Expr = Expr "+" (*) Factor [")"]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [")"]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //   Factor -> S25
-    //   Term -> S12
+    //     "(" -> Shift(S13)
+    //     r#"[0-9]+"# -> Shift(S14)
+    //
+    //     Factor -> S25
+    //     Term -> S12
     pub fn __state20<
         'input,
         F,
@@ -1481,8 +1212,8 @@ mod __parse__Expr {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -1492,14 +1223,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state13(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1508,60 +1241,68 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state25(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state12(input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 21
-    //   Expr = Expr "-" (*) Factor [")"]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [")"]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S13)
-    //   r#"[0-9]+"# -> Shift(S14)
+    //     Expr = Expr "-" (*) Factor [")"]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [")"]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //   Factor -> S26
-    //   Term -> S12
+    //     "(" -> Shift(S13)
+    //     r#"[0-9]+"# -> Shift(S14)
+    //
+    //     Factor -> S26
+    //     Term -> S12
     pub fn __state21<
         'input,
         F,
@@ -1569,8 +1310,8 @@ mod __parse__Expr {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -1580,14 +1321,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state13(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1596,46 +1339,54 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state26(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state12(input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 22
-    //   Factor = Factor "*" (*) Term [")"]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [")"]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S13)
-    //   r#"[0-9]+"# -> Shift(S14)
+    //     Factor = Factor "*" (*) Term [")"]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [")"]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //   Term -> S27
+    //     "(" -> Shift(S13)
+    //     r#"[0-9]+"# -> Shift(S14)
+    //
+    //     Term -> S27
     pub fn __state22<
         'input,
         F,
@@ -1643,8 +1394,8 @@ mod __parse__Expr {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -1656,12 +1407,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state13(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1670,42 +1421,49 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state27(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom2(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 23
-    //   Factor = Factor "/" (*) Term [")"]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) r#"[0-9]+"# [")"]
-    //   Term = (*) r#"[0-9]+"# ["*"]
-    //   Term = (*) r#"[0-9]+"# ["+"]
-    //   Term = (*) r#"[0-9]+"# ["-"]
-    //   Term = (*) r#"[0-9]+"# ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S13)
-    //   r#"[0-9]+"# -> Shift(S14)
+    //     Factor = Factor "/" (*) Term [")"]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"[0-9]+"# [")"]
+    //     Term = (*) r#"[0-9]+"# ["*"]
+    //     Term = (*) r#"[0-9]+"# ["+"]
+    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //   Term -> S28
+    //     "(" -> Shift(S13)
+    //     r#"[0-9]+"# -> Shift(S14)
+    //
+    //     Term -> S28
     pub fn __state23<
         'input,
         F,
@@ -1713,8 +1471,8 @@ mod __parse__Expr {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -1726,12 +1484,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state13(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state14(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1740,37 +1498,44 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 24
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [")"]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S29)
-    //   "+" -> Shift(S20)
-    //   "-" -> Shift(S21)
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [")"]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S29)
+    //     "+" -> Shift(S20)
+    //     "-" -> Shift(S21)
     //
     pub fn __state24<
         'input,
@@ -1781,23 +1546,27 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, F, usize)>,
+        __sym1: (usize, F, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state29(input, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(input, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state20(input, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, (4, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state21(input, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1806,29 +1575,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 25
-    //   Expr = Expr "+" Factor (*) [")"]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "*" -> Shift(S22)
-    //   "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "/" -> Shift(S23)
+    //     Expr = Expr "+" Factor (*) [")"]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S22)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S23)
     //
     pub fn __state25<
         'input,
@@ -1840,26 +1616,27 @@ mod __parse__Expr {
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, F, usize)>,
         __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, F, usize)>,
+        __sym2: (usize, F, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state22(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state23(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((_, (1, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(input, __sym0, __sym1, __sym2);
@@ -1868,7 +1645,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1877,29 +1655,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 26
-    //   Expr = Expr "-" Factor (*) [")"]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "*" -> Shift(S22)
-    //   "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "/" -> Shift(S23)
+    //     Expr = Expr "-" Factor (*) [")"]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S22)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S23)
     //
     pub fn __state26<
         'input,
@@ -1911,26 +1696,27 @@ mod __parse__Expr {
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, F, usize)>,
         __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, F, usize)>,
+        __sym2: (usize, F, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state22(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state23(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((_, (1, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action1(input, __sym0, __sym1, __sym2);
@@ -1939,7 +1725,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1948,144 +1735,45 @@ mod __parse__Expr {
                 });
             }
         }
+    }
+
+    // Custom 0
+    //    Reduce Factor = Term => ActionFn(6);
+    pub fn __custom0<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, F, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action6(input, __sym0);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
         return Ok(__result);
     }
 
-    // State 27
-    //   Factor = Factor "*" Term (*) [")"]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "*" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "+" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "-" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "/" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //
-    pub fn __state27<
+    // Custom 1
+    //    Reduce Term = r#"[0-9]+"# => ActionFn(7);
+    pub fn __custom1<
         'input,
         F,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, F, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action4(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 28
-    //   Factor = Factor "/" Term (*) [")"]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "*" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "+" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "-" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "/" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //
-    pub fn __state28<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, F, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, F, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 29
-    //   Term = "(" Expr ")" (*) [")"]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //
-    //   ")" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "*" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "+" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "-" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "/" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //
-    pub fn __state29<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, F, usize)>,
-        __sym2: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
@@ -2095,32 +1783,107 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action8(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action7(input, __sym0);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 2
+    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
+    pub fn __custom2<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, F, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action4(input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 3
+    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
+    pub fn __custom3<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, F, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action5(input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 4
+    //    Reduce Term = "(", Expr, ")" => ActionFn(8);
+    pub fn __custom4<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, F, usize),
+        __sym2: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action8(input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/expr_intern_tok.rs
+++ b/lalrpop-test/src/expr_intern_tok.rs
@@ -46,54 +46,62 @@ mod __parse__Expr {
     }
 
     // State 0
-    //   Expr = (*) Expr "+" Factor [EOF]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [EOF]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [EOF]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [EOF]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   __Expr = (*) Expr [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   "(" -> Shift(S5)
-    //   r#"[0-9]+"# -> Shift(S6)
+    //     Expr = (*) Expr "+" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [EOF]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     __Expr = (*) Expr [EOF]
     //
-    //   Expr -> S1
-    //   Factor -> S2
-    //   Num -> S3
-    //   Term -> S4
+    //     "(" -> Shift(S5)
+    //     r#"[0-9]+"# -> Shift(S6)
+    //
+    //     Expr -> S1
+    //     Factor -> S2
+    //     Num -> S3
+    //     Term -> S4
     pub fn __state0<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -107,12 +115,12 @@ mod __parse__Expr {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym0 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state5(scale, input, __tokens, __sym0));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(scale, input, __tokens, __sym0));
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -124,21 +132,17 @@ mod __parse__Expr {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym0) => {
                     __result = try!(__state1(scale, input, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym0) => {
                     __result = try!(__state2(scale, input, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Num(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state3(scale, input, __tokens, __lookahead, __sym0));
+                __Nonterminal::Num(__sym0) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state4(scale, input, __tokens, __lookahead, __sym0));
+                __Nonterminal::Term(__sym0) => {
+                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -148,17 +152,25 @@ mod __parse__Expr {
     }
 
     // State 1
-    //   Expr = Expr (*) "+" Factor [EOF]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [EOF]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   __Expr = Expr (*) [EOF]
+    //     Kind = None
+    //     AllInputs = [Expr]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //   "+" -> Shift(S7)
-    //   "-" -> Shift(S8)
+    //     Expr = Expr (*) "+" Factor [EOF]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [EOF]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     __Expr = Expr (*) [EOF]
+    //
+    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
+    //     "+" -> Shift(S7)
+    //     "-" -> Shift(S8)
     //
     pub fn __state1<
         'input,
@@ -168,21 +180,22 @@ mod __parse__Expr {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
+        __sym0: (usize, i32, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (3, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state7(scale, input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, (4, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state8(scale, input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action0(scale, input, __sym0);
@@ -191,7 +204,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -200,29 +214,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 2
-    //   Expr = Factor (*) [EOF]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "*" -> Shift(S9)
-    //   "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "/" -> Shift(S10)
+    //     Expr = Factor (*) [EOF]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S9)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S10)
     //
     pub fn __state2<
         'input,
@@ -232,23 +253,24 @@ mod __parse__Expr {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
+        __sym0: (usize, i32, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state9(scale, input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state10(scale, input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(scale, input, __sym0);
@@ -257,110 +279,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 3
-    //   Term = Num (*) [EOF]
-    //   Term = Num (*) ["*"]
-    //   Term = Num (*) ["+"]
-    //   Term = Num (*) ["-"]
-    //   Term = Num (*) ["/"]
-    //
-    //   EOF -> Reduce(Term = Num => ActionFn(7);)
-    //   "*" -> Reduce(Term = Num => ActionFn(7);)
-    //   "+" -> Reduce(Term = Num => ActionFn(7);)
-    //   "-" -> Reduce(Term = Num => ActionFn(7);)
-    //   "/" -> Reduce(Term = Num => ActionFn(7);)
-    //
-    pub fn __state3<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action7(scale, input, __sym0);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 4
-    //   Factor = Term (*) [EOF]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Term => ActionFn(6);)
-    //   "*" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "+" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "-" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "/" -> Reduce(Factor = Term => ActionFn(6);)
-    //
-    pub fn __state4<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action6(scale, input, __sym0);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -372,58 +292,66 @@ mod __parse__Expr {
     }
 
     // State 5
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [")"]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [EOF]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
     //
-    //   "(" -> Shift(S15)
-    //   r#"[0-9]+"# -> Shift(S16)
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [")"]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [EOF]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
     //
-    //   Expr -> S11
-    //   Factor -> S12
-    //   Num -> S13
-    //   Term -> S14
+    //     "(" -> Shift(S15)
+    //     r#"[0-9]+"# -> Shift(S16)
+    //
+    //     Expr -> S11
+    //     Factor -> S12
+    //     Num -> S13
+    //     Term -> S14
     pub fn __state5<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -431,7 +359,7 @@ mod __parse__Expr {
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -440,14 +368,15 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state15(scale, input, __tokens, __sym1));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(scale, input, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -456,129 +385,80 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state11(scale, input, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state12(scale, input, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Num(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym1));
+                __Nonterminal::Num(__sym1) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state14(scale, input, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 6
-    //   Num = r#"[0-9]+"# (*) [EOF]
-    //   Num = r#"[0-9]+"# (*) ["*"]
-    //   Num = r#"[0-9]+"# (*) ["+"]
-    //   Num = r#"[0-9]+"# (*) ["-"]
-    //   Num = r#"[0-9]+"# (*) ["/"]
-    //
-    //   EOF -> Reduce(Num = r#"[0-9]+"# => ActionFn(9);)
-    //   "*" -> Reduce(Num = r#"[0-9]+"# => ActionFn(9);)
-    //   "+" -> Reduce(Num = r#"[0-9]+"# => ActionFn(9);)
-    //   "-" -> Reduce(Num = r#"[0-9]+"# => ActionFn(9);)
-    //   "/" -> Reduce(Num = r#"[0-9]+"# => ActionFn(9);)
-    //
-    pub fn __state6<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action9(scale, input, __sym0);
-                let __nt = __Nonterminal::Num((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 7
-    //   Expr = Expr "+" (*) Factor [EOF]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [EOF]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S5)
-    //   r#"[0-9]+"# -> Shift(S6)
+    //     Expr = Expr "+" (*) Factor [EOF]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [EOF]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
     //
-    //   Factor -> S17
-    //   Num -> S3
-    //   Term -> S4
+    //     "(" -> Shift(S5)
+    //     r#"[0-9]+"# -> Shift(S6)
+    //
+    //     Factor -> S17
+    //     Num -> S3
+    //     Term -> S4
     pub fn __state7<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -586,8 +466,8 @@ mod __parse__Expr {
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -596,14 +476,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state5(scale, input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(scale, input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -612,70 +494,77 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state17(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Num(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Num(__sym2) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state4(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 8
-    //   Expr = Expr "-" (*) Factor [EOF]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [EOF]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S5)
-    //   r#"[0-9]+"# -> Shift(S6)
+    //     Expr = Expr "-" (*) Factor [EOF]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [EOF]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
     //
-    //   Factor -> S18
-    //   Num -> S3
-    //   Term -> S4
+    //     "(" -> Shift(S5)
+    //     r#"[0-9]+"# -> Shift(S6)
+    //
+    //     Factor -> S18
+    //     Num -> S3
+    //     Term -> S4
     pub fn __state8<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -683,8 +572,8 @@ mod __parse__Expr {
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -693,14 +582,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state5(scale, input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(scale, input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -709,56 +600,63 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state18(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Num(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Num(__sym2) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state4(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 9
-    //   Factor = Factor "*" (*) Term [EOF]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [EOF]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S5)
-    //   r#"[0-9]+"# -> Shift(S6)
+    //     Factor = Factor "*" (*) Term [EOF]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [EOF]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
     //
-    //   Num -> S3
-    //   Term -> S19
+    //     "(" -> Shift(S5)
+    //     r#"[0-9]+"# -> Shift(S6)
+    //
+    //     Num -> S3
+    //     Term -> S19
     pub fn __state9<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -766,8 +664,8 @@ mod __parse__Expr {
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -778,12 +676,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state5(scale, input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(scale, input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -792,52 +690,58 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Num(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Num(__sym2) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state19(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 10
-    //   Factor = Factor "/" (*) Term [EOF]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [EOF]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S5)
-    //   r#"[0-9]+"# -> Shift(S6)
+    //     Factor = Factor "/" (*) Term [EOF]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [EOF]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
     //
-    //   Num -> S3
-    //   Term -> S20
+    //     "(" -> Shift(S5)
+    //     r#"[0-9]+"# -> Shift(S6)
+    //
+    //     Num -> S3
+    //     Term -> S20
     pub fn __state10<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -845,8 +749,8 @@ mod __parse__Expr {
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -857,12 +761,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state5(scale, input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(scale, input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -871,41 +775,47 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Num(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Num(__sym2) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state20(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom4(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 11
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [EOF]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S21)
-    //   "+" -> Shift(S22)
-    //   "-" -> Shift(S23)
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [EOF]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S21)
+    //     "+" -> Shift(S22)
+    //     "-" -> Shift(S23)
     //
     pub fn __state11<
         'input,
@@ -916,22 +826,26 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, i32, usize)>,
+        __sym1: (usize, i32, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state21(scale, input, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom5(scale, input, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state22(scale, input, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, (4, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state23(scale, input, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -940,29 +854,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 12
-    //   Expr = Factor (*) [")"]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "*" -> Shift(S24)
-    //   "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "/" -> Shift(S25)
+    //     Expr = Factor (*) [")"]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S24)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S25)
     //
     pub fn __state12<
         'input,
@@ -972,23 +893,24 @@ mod __parse__Expr {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
+        __sym0: (usize, i32, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state24(scale, input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state25(scale, input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((_, (1, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(scale, input, __sym0);
@@ -997,110 +919,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 13
-    //   Term = Num (*) [")"]
-    //   Term = Num (*) ["*"]
-    //   Term = Num (*) ["+"]
-    //   Term = Num (*) ["-"]
-    //   Term = Num (*) ["/"]
-    //
-    //   ")" -> Reduce(Term = Num => ActionFn(7);)
-    //   "*" -> Reduce(Term = Num => ActionFn(7);)
-    //   "+" -> Reduce(Term = Num => ActionFn(7);)
-    //   "-" -> Reduce(Term = Num => ActionFn(7);)
-    //   "/" -> Reduce(Term = Num => ActionFn(7);)
-    //
-    pub fn __state13<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action7(scale, input, __sym0);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 14
-    //   Factor = Term (*) [")"]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "*" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "+" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "-" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "/" -> Reduce(Factor = Term => ActionFn(6);)
-    //
-    pub fn __state14<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action6(scale, input, __sym0);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1112,58 +932,66 @@ mod __parse__Expr {
     }
 
     // State 15
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [")"]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [")"]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
     //
-    //   "(" -> Shift(S15)
-    //   r#"[0-9]+"# -> Shift(S16)
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [")"]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")"]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
     //
-    //   Expr -> S26
-    //   Factor -> S12
-    //   Num -> S13
-    //   Term -> S14
+    //     "(" -> Shift(S15)
+    //     r#"[0-9]+"# -> Shift(S16)
+    //
+    //     Expr -> S26
+    //     Factor -> S12
+    //     Num -> S13
+    //     Term -> S14
     pub fn __state15<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1171,7 +999,7 @@ mod __parse__Expr {
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1180,14 +1008,15 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state15(scale, input, __tokens, __sym1));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(scale, input, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1196,108 +1025,59 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state26(scale, input, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state12(scale, input, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Num(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym1));
+                __Nonterminal::Num(__sym1) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state14(scale, input, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 16
-    //   Num = r#"[0-9]+"# (*) [")"]
-    //   Num = r#"[0-9]+"# (*) ["*"]
-    //   Num = r#"[0-9]+"# (*) ["+"]
-    //   Num = r#"[0-9]+"# (*) ["-"]
-    //   Num = r#"[0-9]+"# (*) ["/"]
-    //
-    //   ")" -> Reduce(Num = r#"[0-9]+"# => ActionFn(9);)
-    //   "*" -> Reduce(Num = r#"[0-9]+"# => ActionFn(9);)
-    //   "+" -> Reduce(Num = r#"[0-9]+"# => ActionFn(9);)
-    //   "-" -> Reduce(Num = r#"[0-9]+"# => ActionFn(9);)
-    //   "/" -> Reduce(Num = r#"[0-9]+"# => ActionFn(9);)
-    //
-    pub fn __state16<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action9(scale, input, __sym0);
-                let __nt = __Nonterminal::Num((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 17
-    //   Expr = Expr "+" Factor (*) [EOF]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "*" -> Shift(S9)
-    //   "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "/" -> Shift(S10)
+    //     Expr = Expr "+" Factor (*) [EOF]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S9)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S10)
     //
     pub fn __state17<
         'input,
@@ -1309,25 +1089,26 @@ mod __parse__Expr {
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, i32, usize)>,
         __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, i32, usize)>,
+        __sym2: (usize, i32, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state9(scale, input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state10(scale, input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             None |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(scale, input, __sym0, __sym1, __sym2);
@@ -1336,7 +1117,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1345,29 +1127,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 18
-    //   Expr = Expr "-" Factor (*) [EOF]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "*" -> Shift(S9)
-    //   "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "/" -> Shift(S10)
+    //     Expr = Expr "-" Factor (*) [EOF]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S9)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S10)
     //
     pub fn __state18<
         'input,
@@ -1379,25 +1168,26 @@ mod __parse__Expr {
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, i32, usize)>,
         __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, i32, usize)>,
+        __sym2: (usize, i32, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state9(scale, input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state10(scale, input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             None |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action1(scale, input, __sym0, __sym1, __sym2);
@@ -1406,177 +1196,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 19
-    //   Factor = Factor "*" Term (*) [EOF]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "*" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "+" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "-" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "/" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //
-    pub fn __state19<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, i32, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action4(scale, input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 20
-    //   Factor = Factor "/" Term (*) [EOF]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "*" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "+" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "-" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "/" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //
-    pub fn __state20<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, i32, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(scale, input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 21
-    //   Term = "(" Expr ")" (*) [EOF]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //
-    //   EOF -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "*" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "+" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "-" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "/" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //
-    pub fn __state21<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, i32, usize)>,
-        __sym2: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            None |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action8(scale, input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1588,46 +1209,54 @@ mod __parse__Expr {
     }
 
     // State 22
-    //   Expr = Expr "+" (*) Factor [")"]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [")"]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S15)
-    //   r#"[0-9]+"# -> Shift(S16)
+    //     Expr = Expr "+" (*) Factor [")"]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [")"]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
     //
-    //   Factor -> S27
-    //   Num -> S13
-    //   Term -> S14
+    //     "(" -> Shift(S15)
+    //     r#"[0-9]+"# -> Shift(S16)
+    //
+    //     Factor -> S27
+    //     Num -> S13
+    //     Term -> S14
     pub fn __state22<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1635,8 +1264,8 @@ mod __parse__Expr {
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1645,14 +1274,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state15(scale, input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(scale, input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1661,70 +1292,77 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state27(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Num(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Num(__sym2) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state14(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 23
-    //   Expr = Expr "-" (*) Factor [")"]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [")"]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S15)
-    //   r#"[0-9]+"# -> Shift(S16)
+    //     Expr = Expr "-" (*) Factor [")"]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [")"]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
     //
-    //   Factor -> S28
-    //   Num -> S13
-    //   Term -> S14
+    //     "(" -> Shift(S15)
+    //     r#"[0-9]+"# -> Shift(S16)
+    //
+    //     Factor -> S28
+    //     Num -> S13
+    //     Term -> S14
     pub fn __state23<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1732,8 +1370,8 @@ mod __parse__Expr {
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1742,14 +1380,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state15(scale, input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(scale, input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1758,56 +1398,63 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state28(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Num(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Num(__sym2) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state14(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 24
-    //   Factor = Factor "*" (*) Term [")"]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [")"]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S15)
-    //   r#"[0-9]+"# -> Shift(S16)
+    //     Factor = Factor "*" (*) Term [")"]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [")"]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
     //
-    //   Num -> S13
-    //   Term -> S29
+    //     "(" -> Shift(S15)
+    //     r#"[0-9]+"# -> Shift(S16)
+    //
+    //     Num -> S13
+    //     Term -> S29
     pub fn __state24<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1815,8 +1462,8 @@ mod __parse__Expr {
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1827,12 +1474,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state15(scale, input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(scale, input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1841,52 +1488,58 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Num(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Num(__sym2) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state29(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 25
-    //   Factor = Factor "/" (*) Term [")"]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Num = (*) r#"[0-9]+"# [")"]
-    //   Num = (*) r#"[0-9]+"# ["*"]
-    //   Num = (*) r#"[0-9]+"# ["+"]
-    //   Num = (*) r#"[0-9]+"# ["-"]
-    //   Num = (*) r#"[0-9]+"# ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S15)
-    //   r#"[0-9]+"# -> Shift(S16)
+    //     Factor = Factor "/" (*) Term [")"]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Num = (*) r#"[0-9]+"# [")"]
+    //     Num = (*) r#"[0-9]+"# ["*"]
+    //     Num = (*) r#"[0-9]+"# ["+"]
+    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
     //
-    //   Num -> S13
-    //   Term -> S30
+    //     "(" -> Shift(S15)
+    //     r#"[0-9]+"# -> Shift(S16)
+    //
+    //     Num -> S13
+    //     Term -> S30
     pub fn __state25<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1894,8 +1547,8 @@ mod __parse__Expr {
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1906,12 +1559,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state15(scale, input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state16(scale, input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1920,41 +1573,47 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Num(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Num(__sym2) => {
+                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state30(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom4(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 26
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [")"]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S31)
-    //   "+" -> Shift(S22)
-    //   "-" -> Shift(S23)
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [")"]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S31)
+    //     "+" -> Shift(S22)
+    //     "-" -> Shift(S23)
     //
     pub fn __state26<
         'input,
@@ -1965,22 +1624,26 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, i32, usize)>,
+        __sym1: (usize, i32, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state31(scale, input, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom5(scale, input, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state22(scale, input, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, (4, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state23(scale, input, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1989,29 +1652,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 27
-    //   Expr = Expr "+" Factor (*) [")"]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "*" -> Shift(S24)
-    //   "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "/" -> Shift(S25)
+    //     Expr = Expr "+" Factor (*) [")"]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S24)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S25)
     //
     pub fn __state27<
         'input,
@@ -2023,25 +1693,26 @@ mod __parse__Expr {
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, i32, usize)>,
         __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, i32, usize)>,
+        __sym2: (usize, i32, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state24(scale, input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state25(scale, input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((_, (1, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(scale, input, __sym0, __sym1, __sym2);
@@ -2050,7 +1721,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2059,29 +1731,36 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 28
-    //   Expr = Expr "-" Factor (*) [")"]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "*" -> Shift(S24)
-    //   "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "/" -> Shift(S25)
+    //     Expr = Expr "-" Factor (*) [")"]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S24)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S25)
     //
     pub fn __state28<
         'input,
@@ -2093,25 +1772,26 @@ mod __parse__Expr {
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, i32, usize)>,
         __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, i32, usize)>,
+        __sym2: (usize, i32, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state24(scale, input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym3 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state25(scale, input, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((_, (1, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action1(scale, input, __sym0, __sym1, __sym2);
@@ -2120,7 +1800,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2129,23 +1810,37 @@ mod __parse__Expr {
                 });
             }
         }
+    }
+
+    // Custom 0
+    //    Reduce Term = Num => ActionFn(7);
+    pub fn __custom0<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, i32, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action7(scale, input, __sym0);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
         return Ok(__result);
     }
 
-    // State 29
-    //   Factor = Factor "*" Term (*) [")"]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "*" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "+" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "-" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "/" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //
-    pub fn __state29<
+    // Custom 1
+    //    Reduce Factor = Term => ActionFn(6);
+    pub fn __custom1<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -2153,118 +1848,32 @@ mod __parse__Expr {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, i32, usize)>,
+        __sym0: (usize, i32, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action4(scale, input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action6(scale, input, __sym0);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 
-    // State 30
-    //   Factor = Factor "/" Term (*) [")"]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //
-    //   ")" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "*" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "+" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "-" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "/" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //
-    pub fn __state30<
+    // Custom 2
+    //    Reduce Num = r#"[0-9]+"# => ActionFn(9);
+    pub fn __custom2<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         scale: i32,
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, i32, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, i32, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(scale, input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 31
-    //   Term = "(" Expr ")" (*) [")"]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //
-    //   ")" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "*" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "+" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "-" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "/" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //
-    pub fn __state31<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, i32, usize)>,
-        __sym2: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -2273,32 +1882,104 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        match __lookahead {
-            Some((_, (1, _), _)) |
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action8(scale, input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action9(scale, input, __sym0);
+        let __nt = __Nonterminal::Num((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 3
+    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
+    pub fn __custom3<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, i32, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action4(scale, input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 4
+    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
+    pub fn __custom4<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, i32, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action5(scale, input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 5
+    //    Reduce Term = "(", Expr, ")" => ActionFn(8);
+    pub fn __custom5<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, i32, usize),
+        __sym2: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action8(scale, input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/expr_lalr.rs
+++ b/lalrpop-test/src/expr_lalr.rs
@@ -46,48 +46,56 @@ mod __parse__Expr {
     }
 
     // State 0
-    //   Expr = (*) Expr "+" Factor [EOF]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [EOF]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [EOF]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   __Expr = (*) Expr [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Expr = (*) Expr "+" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     __Expr = (*) Expr [EOF]
     //
-    //   Expr -> S1
-    //   Factor -> S2
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Expr -> S1
+    //     Factor -> S2
+    //     Term -> S3
     pub fn __state0<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
@@ -99,12 +107,12 @@ mod __parse__Expr {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym0 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym0));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym0));
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -116,17 +124,14 @@ mod __parse__Expr {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym0) => {
                     __result = try!(__state1(scale, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym0) => {
                     __result = try!(__state2(scale, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state3(scale, __tokens, __lookahead, __sym0));
+                __Nonterminal::Term(__sym0) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -136,17 +141,25 @@ mod __parse__Expr {
     }
 
     // State 1
-    //   Expr = Expr (*) "+" Factor [EOF]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [EOF]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   __Expr = Expr (*) [EOF]
+    //     Kind = None
+    //     AllInputs = [Expr]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //   "+" -> Shift(S6)
-    //   "-" -> Shift(S7)
+    //     Expr = Expr (*) "+" Factor [EOF]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [EOF]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     __Expr = Expr (*) [EOF]
+    //
+    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
+    //     "+" -> Shift(S6)
+    //     "-" -> Shift(S7)
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -154,21 +167,22 @@ mod __parse__Expr {
         scale: i32,
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
+        __sym0: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state6(scale, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state7(scale, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action0(scale, __sym0);
@@ -177,7 +191,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -186,43 +201,50 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 2
-    //   Expr = Factor (*) [EOF]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
-    //   Expr = Factor (*) [")"]
-    //   Expr = Factor (*) ["+"]
-    //   Expr = Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //   ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "*" -> Shift(S8)
-    //   "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //   "/" -> Shift(S9)
+    //     Expr = Factor (*) [EOF]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) [")"]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
+    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S9)
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -230,24 +252,25 @@ mod __parse__Expr {
         scale: i32,
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
+        __sym0: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state8(scale, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(scale, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None |
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(scale, __sym0);
@@ -256,64 +279,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 3
-    //   Factor = Term (*) [EOF]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //   Factor = Term (*) [")"]
-    //   Factor = Term (*) ["*"]
-    //   Factor = Term (*) ["+"]
-    //   Factor = Term (*) ["-"]
-    //   Factor = Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Term => ActionFn(6);)
-    //   ")" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "*" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "+" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "-" -> Reduce(Factor = Term => ActionFn(6);)
-    //   "/" -> Reduce(Factor = Term => ActionFn(6);)
-    //
-    pub fn __state3<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action6(scale, __sym0);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -325,97 +292,105 @@ mod __parse__Expr {
     }
 
     // State 4
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [EOF]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Expr = (*) Expr "+" Factor [")"]
-    //   Expr = (*) Expr "+" Factor ["+"]
-    //   Expr = (*) Expr "+" Factor ["-"]
-    //   Expr = (*) Expr "-" Factor [")"]
-    //   Expr = (*) Expr "-" Factor ["+"]
-    //   Expr = (*) Expr "-" Factor ["-"]
-    //   Expr = (*) Factor [")"]
-    //   Expr = (*) Factor ["+"]
-    //   Expr = (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = "(" (*) Expr ")" [")"]
-    //   Term = "(" (*) Expr ")" ["*"]
-    //   Term = "(" (*) Expr ")" ["+"]
-    //   Term = "(" (*) Expr ")" ["-"]
-    //   Term = "(" (*) Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [EOF]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")"]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Expr -> S10
-    //   Factor -> S2
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Expr -> S10
+    //     Factor -> S2
+    //     Term -> S3
     pub fn __state4<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
+        __sym0: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -424,14 +399,15 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym1));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -440,159 +416,106 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expr(__sym1) => {
                     __result = try!(__state10(scale, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Factor(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym1) => {
                     __result = try!(__state2(scale, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state3(scale, __tokens, __lookahead, __sym1));
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 5
-    //   Term = Num (*) [EOF]
-    //   Term = Num (*) ["*"]
-    //   Term = Num (*) ["+"]
-    //   Term = Num (*) ["-"]
-    //   Term = Num (*) ["/"]
-    //   Term = Num (*) [")"]
-    //   Term = Num (*) ["*"]
-    //   Term = Num (*) ["+"]
-    //   Term = Num (*) ["-"]
-    //   Term = Num (*) ["/"]
-    //
-    //   EOF -> Reduce(Term = Num => ActionFn(7);)
-    //   ")" -> Reduce(Term = Num => ActionFn(7);)
-    //   "*" -> Reduce(Term = Num => ActionFn(7);)
-    //   "+" -> Reduce(Term = Num => ActionFn(7);)
-    //   "-" -> Reduce(Term = Num => ActionFn(7);)
-    //   "/" -> Reduce(Term = Num => ActionFn(7);)
-    //
-    pub fn __state5<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            None |
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action7(scale, __sym0);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
             }
         }
     }
 
     // State 6
-    //   Expr = Expr "+" (*) Factor [EOF]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Expr = Expr "+" (*) Factor [")"]
-    //   Expr = Expr "+" (*) Factor ["+"]
-    //   Expr = Expr "+" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Expr = Expr "+" (*) Factor [EOF]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Expr = Expr "+" (*) Factor [")"]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S11
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Factor -> S11
+    //     Term -> S3
     pub fn __state6<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -601,14 +524,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -617,95 +542,103 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state11(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 7
-    //   Expr = Expr "-" (*) Factor [EOF]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [EOF]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [EOF]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [EOF]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Expr = Expr "-" (*) Factor [")"]
-    //   Expr = Expr "-" (*) Factor ["+"]
-    //   Expr = Expr "-" (*) Factor ["-"]
-    //   Factor = (*) Factor "*" Term [")"]
-    //   Factor = (*) Factor "*" Term ["*"]
-    //   Factor = (*) Factor "*" Term ["+"]
-    //   Factor = (*) Factor "*" Term ["-"]
-    //   Factor = (*) Factor "*" Term ["/"]
-    //   Factor = (*) Factor "/" Term [")"]
-    //   Factor = (*) Factor "/" Term ["*"]
-    //   Factor = (*) Factor "/" Term ["+"]
-    //   Factor = (*) Factor "/" Term ["-"]
-    //   Factor = (*) Factor "/" Term ["/"]
-    //   Factor = (*) Term [")"]
-    //   Factor = (*) Term ["*"]
-    //   Factor = (*) Term ["+"]
-    //   Factor = (*) Term ["-"]
-    //   Factor = (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Expr = Expr "-" (*) Factor [EOF]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Expr = Expr "-" (*) Factor [")"]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Factor -> S12
-    //   Term -> S3
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Factor -> S12
+    //     Term -> S3
     pub fn __state7<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -714,14 +647,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -730,68 +665,76 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Factor(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Factor(__sym2) => {
                     __result = try!(__state12(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 8
-    //   Factor = Factor "*" (*) Term [EOF]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Factor = Factor "*" (*) Term [")"]
-    //   Factor = Factor "*" (*) Term ["*"]
-    //   Factor = Factor "*" (*) Term ["+"]
-    //   Factor = Factor "*" (*) Term ["-"]
-    //   Factor = Factor "*" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Factor = Factor "*" (*) Term [EOF]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Factor = Factor "*" (*) Term [")"]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S13
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Term -> S13
     pub fn __state8<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -802,12 +745,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -816,64 +759,71 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state13(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom2(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 9
-    //   Factor = Factor "/" (*) Term [EOF]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [EOF]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [EOF]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
-    //   Factor = Factor "/" (*) Term [")"]
-    //   Factor = Factor "/" (*) Term ["*"]
-    //   Factor = Factor "/" (*) Term ["+"]
-    //   Factor = Factor "/" (*) Term ["-"]
-    //   Factor = Factor "/" (*) Term ["/"]
-    //   Term = (*) "(" Expr ")" [")"]
-    //   Term = (*) "(" Expr ")" ["*"]
-    //   Term = (*) "(" Expr ")" ["+"]
-    //   Term = (*) "(" Expr ")" ["-"]
-    //   Term = (*) "(" Expr ")" ["/"]
-    //   Term = (*) Num [")"]
-    //   Term = (*) Num ["*"]
-    //   Term = (*) Num ["+"]
-    //   Term = (*) Num ["-"]
-    //   Term = (*) Num ["/"]
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     Factor = Factor "/" (*) Term [EOF]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [EOF]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
+    //     Factor = Factor "/" (*) Term [")"]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) Num [")"]
+    //     Term = (*) Num ["*"]
+    //     Term = (*) Num ["+"]
+    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["/"]
     //
-    //   Term -> S14
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     Term -> S14
     pub fn __state9<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -884,12 +834,12 @@ mod __parse__Expr {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(scale, __tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(scale, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -898,48 +848,55 @@ mod __parse__Expr {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Term(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state14(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 10
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [EOF]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
-    //   Expr = Expr (*) "+" Factor [")"]
-    //   Expr = Expr (*) "+" Factor ["+"]
-    //   Expr = Expr (*) "+" Factor ["-"]
-    //   Expr = Expr (*) "-" Factor [")"]
-    //   Expr = Expr (*) "-" Factor ["+"]
-    //   Expr = Expr (*) "-" Factor ["-"]
-    //   Term = "(" Expr (*) ")" [")"]
-    //   Term = "(" Expr (*) ")" ["*"]
-    //   Term = "(" Expr (*) ")" ["+"]
-    //   Term = "(" Expr (*) ")" ["-"]
-    //   Term = "(" Expr (*) ")" ["/"]
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S15)
-    //   "+" -> Shift(S6)
-    //   "-" -> Shift(S7)
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [EOF]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [")"]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S15)
+    //     "+" -> Shift(S6)
+    //     "-" -> Shift(S7)
     //
     pub fn __state10<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -948,22 +905,26 @@ mod __parse__Expr {
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), i32, ())>,
+        __sym1: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state15(scale, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(scale, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state6(scale, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state7(scale, __tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -972,43 +933,50 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 11
-    //   Expr = Expr "+" Factor (*) [EOF]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
-    //   Expr = Expr "+" Factor (*) [")"]
-    //   Expr = Expr "+" Factor (*) ["+"]
-    //   Expr = Expr "+" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "*" -> Shift(S8)
-    //   "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //   "/" -> Shift(S9)
+    //     Expr = Expr "+" Factor (*) [EOF]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) [")"]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S9)
     //
     pub fn __state11<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1018,18 +986,20 @@ mod __parse__Expr {
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), i32, ())>,
         __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
+        __sym2: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state8(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             None |
             Some((_, Tok::RParen, _)) |
@@ -1037,7 +1007,6 @@ mod __parse__Expr {
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(scale, __sym0, __sym1, __sym2);
@@ -1046,7 +1015,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1055,43 +1025,50 @@ mod __parse__Expr {
                 });
             }
         }
-        return Ok(__result);
     }
 
     // State 12
-    //   Expr = Expr "-" Factor (*) [EOF]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [EOF]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [EOF]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
-    //   Expr = Expr "-" Factor (*) [")"]
-    //   Expr = Expr "-" Factor (*) ["+"]
-    //   Expr = Expr "-" Factor (*) ["-"]
-    //   Factor = Factor (*) "*" Term [")"]
-    //   Factor = Factor (*) "*" Term ["*"]
-    //   Factor = Factor (*) "*" Term ["+"]
-    //   Factor = Factor (*) "*" Term ["-"]
-    //   Factor = Factor (*) "*" Term ["/"]
-    //   Factor = Factor (*) "/" Term [")"]
-    //   Factor = Factor (*) "/" Term ["*"]
-    //   Factor = Factor (*) "/" Term ["+"]
-    //   Factor = Factor (*) "/" Term ["-"]
-    //   Factor = Factor (*) "/" Term ["/"]
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "*" -> Shift(S8)
-    //   "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //   "/" -> Shift(S9)
+    //     Expr = Expr "-" Factor (*) [EOF]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) [")"]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S9)
     //
     pub fn __state12<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1101,18 +1078,20 @@ mod __parse__Expr {
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), i32, ())>,
         __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
+        __sym2: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Times, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state8(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Div, __loc2)) => {
-                let mut __sym3 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym3 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(scale, __tokens, __sym2, __sym3));
+                return Ok(__result);
             }
             None |
             Some((_, Tok::RParen, _)) |
@@ -1120,7 +1099,6 @@ mod __parse__Expr {
             Some((_, Tok::Minus, _)) => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action1(scale, __sym0, __sym1, __sym2);
@@ -1129,7 +1107,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1138,156 +1117,40 @@ mod __parse__Expr {
                 });
             }
         }
+    }
+
+    // Custom 0
+    //    Reduce Factor = Term => ActionFn(6);
+    pub fn __custom0<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action6(scale, __sym0);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
         return Ok(__result);
     }
 
-    // State 13
-    //   Factor = Factor "*" Term (*) [EOF]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //   Factor = Factor "*" Term (*) [")"]
-    //   Factor = Factor "*" Term (*) ["*"]
-    //   Factor = Factor "*" Term (*) ["+"]
-    //   Factor = Factor "*" Term (*) ["-"]
-    //   Factor = Factor "*" Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   ")" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "*" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "+" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "-" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //   "/" -> Reduce(Factor = Factor, "*", Term => ActionFn(4);)
-    //
-    pub fn __state13<
+    // Custom 1
+    //    Reduce Term = Num => ActionFn(7);
+    pub fn __custom1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
         __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 14
-    //   Factor = Factor "/" Term (*) [EOF]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //   Factor = Factor "/" Term (*) [")"]
-    //   Factor = Factor "/" Term (*) ["*"]
-    //   Factor = Factor "/" Term (*) ["+"]
-    //   Factor = Factor "/" Term (*) ["-"]
-    //   Factor = Factor "/" Term (*) ["/"]
-    //
-    //   EOF -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   ")" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "*" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "+" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "-" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //   "/" -> Reduce(Factor = Factor, "/", Term => ActionFn(5);)
-    //
-    pub fn __state14<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Factor((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 15
-    //   Term = "(" Expr ")" (*) [EOF]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //   Term = "(" Expr ")" (*) [")"]
-    //   Term = "(" Expr ")" (*) ["*"]
-    //   Term = "(" Expr ")" (*) ["+"]
-    //   Term = "(" Expr ")" (*) ["-"]
-    //   Term = "(" Expr ")" (*) ["/"]
-    //
-    //   EOF -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   ")" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "*" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "+" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "-" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //   "/" -> Reduce(Term = "(", Expr, ")" => ActionFn(8);)
-    //
-    pub fn __state15<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), i32, ())>,
-        __sym2: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1296,33 +1159,98 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        match __lookahead {
-            None |
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Times, _)) |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Term((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action7(scale, __sym0);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 2
+    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
+    pub fn __custom2<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
+        __sym2: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 3
+    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
+    pub fn __custom3<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
+        __sym2: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 4
+    //    Reduce Term = "(", Expr, ")" => ActionFn(8);
+    pub fn __custom4<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __sym0: ((), Tok, ()),
+        __sym1: ((), i32, ()),
+        __sym2: ((), Tok, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/inline.rs
+++ b/lalrpop-test/src/inline.rs
@@ -40,15 +40,23 @@ mod __parse__E {
     }
 
     // State 0
-    //   E = (*) "&" E [EOF]
-    //   E = (*) "&" "L" E [EOF]
-    //   E = (*) "L" [EOF]
-    //   __E = (*) E [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   "&" -> Shift(S2)
-    //   "L" -> Shift(S3)
+    //     E = (*) "&" E [EOF]
+    //     E = (*) "&" "L" E [EOF]
+    //     E = (*) "L" [EOF]
+    //     __E = (*) E [EOF]
     //
-    //   E -> S1
+    //     "&" -> Shift(S2)
+    //     "L" -> Shift(S3)
+    //
+    //     E -> S1
     pub fn __state0<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -61,12 +69,12 @@ mod __parse__E {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym0 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state2(input, __tokens, __sym0));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state3(input, __tokens, __sym0));
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -78,9 +86,8 @@ mod __parse__E {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::E(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state1(input, __tokens, __lookahead, __sym0));
+                __Nonterminal::E(__sym0) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -89,62 +96,32 @@ mod __parse__E {
         }
     }
 
-    // State 1
-    //   __E = E (*) [EOF]
-    //
-    //   EOF -> Reduce(__E = E => ActionFn(0);)
-    //
-    pub fn __state1<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, String, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            None => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action0(input, __sym0);
-                let __nt = __Nonterminal::____E((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
     // State 2
-    //   E = (*) "&" E [EOF]
-    //   E = "&" (*) E [EOF]
-    //   E = (*) "&" "L" E [EOF]
-    //   E = "&" (*) "L" E [EOF]
-    //   E = (*) "L" [EOF]
+    //     Kind = None
+    //     AllInputs = ["&"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["&"]
+    //     WillPushLen = 1
+    //     WillPush = [E]
+    //     WillProduce = Some(E)
     //
-    //   "&" -> Shift(S2)
-    //   "L" -> Shift(S5)
+    //     E = (*) "&" E [EOF]
+    //     E = "&" (*) E [EOF]
+    //     E = (*) "&" "L" E [EOF]
+    //     E = "&" (*) "L" E [EOF]
+    //     E = (*) "L" [EOF]
     //
-    //   E -> S4
+    //     "&" -> Shift(S2)
+    //     "L" -> Shift(S5)
+    //
+    //     E -> S4
     pub fn __state2<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -153,13 +130,14 @@ mod __parse__E {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state2(input, __tokens, __sym1));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state5(input, __tokens, __sym0, __sym1));
             }
             _ => {
@@ -169,115 +147,44 @@ mod __parse__E {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::E(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state4(input, __tokens, __lookahead, __sym0, __sym1));
+                __Nonterminal::E(__sym1) => {
+                    let __sym0 = __sym0.take().unwrap();
+                    __result = try!(__custom2(input, __tokens, __lookahead, __sym0, __sym1));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 3
-    //   E = "L" (*) [EOF]
-    //
-    //   EOF -> Reduce(E = "L" => ActionFn(1);)
-    //
-    pub fn __state3<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            None => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action1(input, __sym0);
-                let __nt = __Nonterminal::E((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 4
-    //   E = "&" E (*) [EOF]
-    //
-    //   EOF -> Reduce(E = "&", E => ActionFn(7);)
-    //
-    pub fn __state4<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, String, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            None => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action7(input, __sym0, __sym1);
-                let __nt = __Nonterminal::E((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 5
-    //   E = (*) "&" E [EOF]
-    //   E = (*) "&" "L" E [EOF]
-    //   E = "&" "L" (*) E [EOF]
-    //   E = (*) "L" [EOF]
-    //   E = "L" (*) [EOF]
+    //     Kind = None
+    //     AllInputs = ["&", "L"]
+    //     OptionalInputs = ["&"]
+    //     FixedInputs = ["L"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(E)
     //
-    //   EOF -> Reduce(E = "L" => ActionFn(1);)
-    //   "&" -> Shift(S2)
-    //   "L" -> Shift(S3)
+    //     E = (*) "&" E [EOF]
+    //     E = (*) "&" "L" E [EOF]
+    //     E = "&" "L" (*) E [EOF]
+    //     E = (*) "L" [EOF]
+    //     E = "L" (*) [EOF]
     //
-    //   E -> S6
+    //     EOF -> Reduce(E = "L" => ActionFn(1);)
+    //     "&" -> Shift(S2)
+    //     "L" -> Shift(S3)
+    //
+    //     E -> S6
     pub fn __state5<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -285,7 +192,7 @@ mod __parse__E {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -296,15 +203,14 @@ mod __parse__E {
         };
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state2(input, __tokens, __sym2));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state3(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
             }
             None => {
-                let __sym1 = __sym1.take().unwrap();
                 let __start = __sym1.0.clone();
                 let __end = __sym1.2.clone();
                 let __nt = super::__action1(input, __sym1);
@@ -313,7 +219,8 @@ mod __parse__E {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -322,61 +229,126 @@ mod __parse__E {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::E(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state6(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::E(__sym2) => {
+                    let __sym0 = __sym0.take().unwrap();
+                    __result = try!(__custom3(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
-    // State 6
-    //   E = "&" "L" E (*) [EOF]
-    //
-    //   EOF -> Reduce(E = "&", "L", E => ActionFn(8);)
-    //
-    pub fn __state6<
+    // Custom 0
+    //    Reduce __E = E => ActionFn(0);
+    pub fn __custom0<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
-        __sym2: &mut Option<(usize, String, usize)>,
+        __sym0: (usize, String, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            None => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action8(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::E((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action0(input, __sym0);
+        let __nt = __Nonterminal::____E((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 1
+    //    Reduce E = "L" => ActionFn(1);
+    pub fn __custom1<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action1(input, __sym0);
+        let __nt = __Nonterminal::E((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 2
+    //    Reduce E = "&", E => ActionFn(7);
+    pub fn __custom2<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, String, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = super::__action7(input, __sym0, __sym1);
+        let __nt = __Nonterminal::E((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 3
+    //    Reduce E = "&", "L", E => ActionFn(8);
+    pub fn __custom3<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, String, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action8(input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::E((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__E::parse_E;

--- a/lalrpop-test/src/intern_tok.rs
+++ b/lalrpop-test/src/intern_tok.rs
@@ -43,22 +43,30 @@ mod __parse__Items {
     }
 
     // State 0
-    //   Items = (*) [EOF]
-    //   Items = (*) ["+"]
-    //   Items = (*) ["-"]
-    //   Items = (*) Items Spanned<"+"> [EOF]
-    //   Items = (*) Items Spanned<"+"> ["+"]
-    //   Items = (*) Items Spanned<"+"> ["-"]
-    //   Items = (*) Items "-" [EOF]
-    //   Items = (*) Items "-" ["+"]
-    //   Items = (*) Items "-" ["-"]
-    //   __Items = (*) Items [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Items =  => ActionFn(9);)
-    //   "+" -> Reduce(Items =  => ActionFn(9);)
-    //   "-" -> Reduce(Items =  => ActionFn(9);)
+    //     Items = (*) [EOF]
+    //     Items = (*) ["+"]
+    //     Items = (*) ["-"]
+    //     Items = (*) Items Spanned<"+"> [EOF]
+    //     Items = (*) Items Spanned<"+"> ["+"]
+    //     Items = (*) Items Spanned<"+"> ["-"]
+    //     Items = (*) Items "-" [EOF]
+    //     Items = (*) Items "-" ["+"]
+    //     Items = (*) Items "-" ["-"]
+    //     __Items = (*) Items [EOF]
     //
-    //   Items -> S1
+    //     EOF -> Reduce(Items =  => ActionFn(9);)
+    //     "+" -> Reduce(Items =  => ActionFn(9);)
+    //     "-" -> Reduce(Items =  => ActionFn(9);)
+    //
+    //     Items -> S1
     pub fn __state0<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -93,8 +101,7 @@ mod __parse__Items {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Items(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Items(__sym0) => {
                     __result = try!(__state1(input, __tokens, __lookahead, __sym0));
                 }
                 _ => {
@@ -105,22 +112,30 @@ mod __parse__Items {
     }
 
     // State 1
-    //   Items = Items (*) Spanned<"+"> [EOF]
-    //   Items = Items (*) Spanned<"+"> ["+"]
-    //   Items = Items (*) Spanned<"+"> ["-"]
-    //   Items = Items (*) "-" [EOF]
-    //   Items = Items (*) "-" ["+"]
-    //   Items = Items (*) "-" ["-"]
-    //   Spanned<"+"> = (*) "+" [EOF]
-    //   Spanned<"+"> = (*) "+" ["+"]
-    //   Spanned<"+"> = (*) "+" ["-"]
-    //   __Items = Items (*) [EOF]
+    //     Kind = None
+    //     AllInputs = [Items]
+    //     OptionalInputs = []
+    //     FixedInputs = [Items]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(__Items = Items => ActionFn(0);)
-    //   "+" -> Shift(S3)
-    //   "-" -> Shift(S4)
+    //     Items = Items (*) Spanned<"+"> [EOF]
+    //     Items = Items (*) Spanned<"+"> ["+"]
+    //     Items = Items (*) Spanned<"+"> ["-"]
+    //     Items = Items (*) "-" [EOF]
+    //     Items = Items (*) "-" ["+"]
+    //     Items = Items (*) "-" ["-"]
+    //     Spanned<"+"> = (*) "+" [EOF]
+    //     Spanned<"+"> = (*) "+" ["+"]
+    //     Spanned<"+"> = (*) "+" ["-"]
+    //     __Items = Items (*) [EOF]
     //
-    //   Spanned<"+"> -> S2
+    //     EOF -> Reduce(__Items = Items => ActionFn(0);)
+    //     "+" -> Shift(S3)
+    //     "-" -> Shift(S4)
+    //
+    //     Spanned<"+"> -> S2
     pub fn __state1<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -128,21 +143,21 @@ mod __parse__Items {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Vec<(usize, usize)>, usize)>,
+        __sym0: (usize, Vec<(usize, usize)>, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state3(input, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym1));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state4(input, __tokens, __sym0, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action0(input, __sym0);
@@ -151,7 +166,8 @@ mod __parse__Items {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -160,83 +176,55 @@ mod __parse__Items {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Spanned_3c_22_2b_22_3e(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state2(input, __tokens, __lookahead, __sym0, __sym1));
+                __Nonterminal::Spanned_3c_22_2b_22_3e(__sym1) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym0, __sym1));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
-    // State 2
-    //   Items = Items Spanned<"+"> (*) [EOF]
-    //   Items = Items Spanned<"+"> (*) ["+"]
-    //   Items = Items Spanned<"+"> (*) ["-"]
-    //
-    //   EOF -> Reduce(Items = Items, Spanned<"+"> => ActionFn(2);)
-    //   "+" -> Reduce(Items = Items, Spanned<"+"> => ActionFn(2);)
-    //   "-" -> Reduce(Items = Items, Spanned<"+"> => ActionFn(2);)
-    //
-    pub fn __state2<
+    // Custom 0
+    //    Reduce Items = Items, Spanned<"+"> => ActionFn(2);
+    pub fn __custom0<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Vec<(usize, usize)>, usize)>,
-        __sym1: &mut Option<(usize, (usize, usize), usize)>,
+        __sym0: (usize, Vec<(usize, usize)>, usize),
+        __sym1: (usize, (usize, usize), usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, (0, _), _)) |
-            Some((_, (1, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action2(input, __sym0, __sym1);
-                let __nt = __Nonterminal::Items((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = super::__action2(input, __sym0, __sym1);
+        let __nt = __Nonterminal::Items((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 
-    // State 3
-    //   Spanned<"+"> = "+" (*) [EOF]
-    //   Spanned<"+"> = "+" (*) ["+"]
-    //   Spanned<"+"> = "+" (*) ["-"]
-    //
-    //   EOF -> Reduce(Spanned<"+"> = "+" => ActionFn(10);)
-    //   "+" -> Reduce(Spanned<"+"> = "+" => ActionFn(10);)
-    //   "-" -> Reduce(Spanned<"+"> = "+" => ActionFn(10);)
-    //
-    pub fn __state3<
+    // Custom 1
+    //    Reduce Spanned<"+"> = "+" => ActionFn(10);
+    pub fn __custom1<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -245,47 +233,28 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        match __lookahead {
-            None |
-            Some((_, (0, _), _)) |
-            Some((_, (1, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action10(input, __sym0);
-                let __nt = __Nonterminal::Spanned_3c_22_2b_22_3e((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action10(input, __sym0);
+        let __nt = __Nonterminal::Spanned_3c_22_2b_22_3e((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 
-    // State 4
-    //   Items = Items "-" (*) [EOF]
-    //   Items = Items "-" (*) ["+"]
-    //   Items = Items "-" (*) ["-"]
-    //
-    //   EOF -> Reduce(Items = Items, "-" => ActionFn(3);)
-    //   "+" -> Reduce(Items = Items, "-" => ActionFn(3);)
-    //   "-" -> Reduce(Items = Items, "-" => ActionFn(3);)
-    //
-    pub fn __state4<
+    // Custom 2
+    //    Reduce Items = Items, "-" => ActionFn(3);
+    pub fn __custom2<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Vec<(usize, usize)>, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, Vec<(usize, usize)>, usize),
+        __sym1: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -294,29 +263,16 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        match __lookahead {
-            None |
-            Some((_, (0, _), _)) |
-            Some((_, (1, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action3(input, __sym0, __sym1);
-                let __nt = __Nonterminal::Items((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = super::__action3(input, __sym0, __sym1);
+        let __nt = __Nonterminal::Items((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__Items::parse_Items;

--- a/lalrpop-test/src/lifetime_tok.rs
+++ b/lalrpop-test/src/lifetime_tok.rs
@@ -45,19 +45,27 @@ mod __parse__Expr {
     }
 
     // State 0
-    //   Expr = (*) [EOF]
-    //   Expr = (*) Other+ [EOF]
-    //   Other+ = (*) Other+ Other [EOF]
-    //   Other+ = (*) Other+ Other [Other]
-    //   Other+ = (*) Other [EOF]
-    //   Other+ = (*) Other [Other]
-    //   __Expr = (*) Expr [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr =  => ActionFn(6);)
-    //   Other -> Shift(S3)
+    //     Expr = (*) [EOF]
+    //     Expr = (*) Other+ [EOF]
+    //     Other+ = (*) Other+ Other [EOF]
+    //     Other+ = (*) Other+ Other [Other]
+    //     Other+ = (*) Other [EOF]
+    //     Other+ = (*) Other [Other]
+    //     __Expr = (*) Expr [EOF]
     //
-    //   Expr -> S1
-    //   Other+ -> S2
+    //     EOF -> Reduce(Expr =  => ActionFn(6);)
+    //     Other -> Shift(S3)
+    //
+    //     Expr -> S1
+    //     Other+ -> S2
     pub fn __state0<
         'input,
         __TOKENS: Iterator<Item=Result<((), LtTok<'input>, ()),()>>,
@@ -69,8 +77,8 @@ mod __parse__Expr {
         let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
         match __lookahead {
             Some((__loc1, LtTok::Other(__tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state3(__tokens, __sym0));
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(__tokens, __sym0));
             }
             None => {
                 let __start: () = ::std::default::Default::default();
@@ -93,12 +101,10 @@ mod __parse__Expr {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expr(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state1(__tokens, __lookahead, __sym0));
+                __Nonterminal::Expr(__sym0) => {
+                    __result = try!(__custom0(__tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Other_2b(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Other_2b(__sym0) => {
                     __result = try!(__state2(__tokens, __lookahead, __sym0));
                 }
                 _ => {
@@ -108,50 +114,21 @@ mod __parse__Expr {
         }
     }
 
-    // State 1
-    //   __Expr = Expr (*) [EOF]
-    //
-    //   EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //
-    pub fn __state1<
-        'input,
-        __TOKENS: Iterator<Item=Result<((), LtTok<'input>, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), LtTok<'input>, ())>,
-        __sym0: &mut Option<((), Vec<&'input str>, ())>,
-    ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __ParseError<(),LtTok<'input>,()>>
-    {
-        let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
-        match __lookahead {
-            None => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action0(__sym0);
-                let __nt = __Nonterminal::____Expr((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
     // State 2
-    //   Expr = Other+ (*) [EOF]
-    //   Other+ = Other+ (*) Other [EOF]
-    //   Other+ = Other+ (*) Other [Other]
+    //     Kind = None
+    //     AllInputs = [Other+]
+    //     OptionalInputs = []
+    //     FixedInputs = [Other+]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Expr = Other+ => ActionFn(7);)
-    //   Other -> Shift(S4)
+    //     Expr = Other+ (*) [EOF]
+    //     Other+ = Other+ (*) Other [EOF]
+    //     Other+ = Other+ (*) Other [Other]
+    //
+    //     EOF -> Reduce(Expr = Other+ => ActionFn(7);)
+    //     Other -> Shift(S4)
     //
     pub fn __state2<
         'input,
@@ -159,17 +136,17 @@ mod __parse__Expr {
     >(
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), LtTok<'input>, ())>,
-        __sym0: &mut Option<((), ::std::vec::Vec<&'input str>, ())>,
+        __sym0: ((), ::std::vec::Vec<&'input str>, ()),
     ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __ParseError<(),LtTok<'input>,()>>
     {
         let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
         match __lookahead {
             Some((__loc1, LtTok::Other(__tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state4(__tokens, __sym0, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(__tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action7(__sym0);
@@ -178,7 +155,8 @@ mod __parse__Expr {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -187,22 +165,40 @@ mod __parse__Expr {
                 });
             }
         }
+    }
+
+    // Custom 0
+    //    Reduce __Expr = Expr => ActionFn(0);
+    pub fn __custom0<
+        'input,
+        __TOKENS: Iterator<Item=Result<((), LtTok<'input>, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), LtTok<'input>, ())>,
+        __sym0: ((), Vec<&'input str>, ()),
+    ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __ParseError<(),LtTok<'input>,()>>
+    {
+        let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action0(__sym0);
+        let __nt = __Nonterminal::____Expr((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
         return Ok(__result);
     }
 
-    // State 3
-    //   Other+ = Other (*) [EOF]
-    //   Other+ = Other (*) [Other]
-    //
-    //   EOF -> Reduce(Other+ = Other => ActionFn(4);)
-    //   Other -> Reduce(Other+ = Other => ActionFn(4);)
-    //
-    pub fn __state3<
+    // Custom 1
+    //    Reduce Other+ = Other => ActionFn(4);
+    pub fn __custom1<
         'input,
         __TOKENS: Iterator<Item=Result<((), LtTok<'input>, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), &'input str, ())>,
+        __sym0: ((), &'input str, ()),
     ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __ParseError<(),LtTok<'input>,()>>
     {
         let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
@@ -211,43 +207,27 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        match __lookahead {
-            None |
-            Some((_, LtTok::Other(_), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action4(__sym0);
-                let __nt = __Nonterminal::Other_2b((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action4(__sym0);
+        let __nt = __Nonterminal::Other_2b((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 
-    // State 4
-    //   Other+ = Other+ Other (*) [EOF]
-    //   Other+ = Other+ Other (*) [Other]
-    //
-    //   EOF -> Reduce(Other+ = Other+, Other => ActionFn(5);)
-    //   Other -> Reduce(Other+ = Other+, Other => ActionFn(5);)
-    //
-    pub fn __state4<
+    // Custom 2
+    //    Reduce Other+ = Other+, Other => ActionFn(5);
+    pub fn __custom2<
         'input,
         __TOKENS: Iterator<Item=Result<((), LtTok<'input>, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), ::std::vec::Vec<&'input str>, ())>,
-        __sym1: &mut Option<((), &'input str, ())>,
+        __sym0: ((), ::std::vec::Vec<&'input str>, ()),
+        __sym1: ((), &'input str, ()),
     ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __ParseError<(),LtTok<'input>,()>>
     {
         let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
@@ -256,28 +236,16 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        match __lookahead {
-            None |
-            Some((_, LtTok::Other(_), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action5(__sym0, __sym1);
-                let __nt = __Nonterminal::Other_2b((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = super::__action5(__sym0, __sym1);
+        let __nt = __Nonterminal::Other_2b((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/loc.rs
+++ b/lalrpop-test/src/loc.rs
@@ -45,22 +45,30 @@ mod __parse__Items {
     }
 
     // State 0
-    //   Items = (*) [EOF]
-    //   Items = (*) ["+"]
-    //   Items = (*) ["-"]
-    //   Items = (*) Items Spanned<"+"> [EOF]
-    //   Items = (*) Items Spanned<"+"> ["+"]
-    //   Items = (*) Items Spanned<"+"> ["-"]
-    //   Items = (*) Items "-" [EOF]
-    //   Items = (*) Items "-" ["+"]
-    //   Items = (*) Items "-" ["-"]
-    //   __Items = (*) Items [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(Items =  => ActionFn(9);)
-    //   "+" -> Reduce(Items =  => ActionFn(9);)
-    //   "-" -> Reduce(Items =  => ActionFn(9);)
+    //     Items = (*) [EOF]
+    //     Items = (*) ["+"]
+    //     Items = (*) ["-"]
+    //     Items = (*) Items Spanned<"+"> [EOF]
+    //     Items = (*) Items Spanned<"+"> ["+"]
+    //     Items = (*) Items Spanned<"+"> ["-"]
+    //     Items = (*) Items "-" [EOF]
+    //     Items = (*) Items "-" ["+"]
+    //     Items = (*) Items "-" ["-"]
+    //     __Items = (*) Items [EOF]
     //
-    //   Items -> S1
+    //     EOF -> Reduce(Items =  => ActionFn(9);)
+    //     "+" -> Reduce(Items =  => ActionFn(9);)
+    //     "-" -> Reduce(Items =  => ActionFn(9);)
+    //
+    //     Items -> S1
     pub fn __state0<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
@@ -93,8 +101,7 @@ mod __parse__Items {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Items(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Items(__sym0) => {
                     __result = try!(__state1(__tokens, __lookahead, __sym0));
                 }
                 _ => {
@@ -105,42 +112,50 @@ mod __parse__Items {
     }
 
     // State 1
-    //   Items = Items (*) Spanned<"+"> [EOF]
-    //   Items = Items (*) Spanned<"+"> ["+"]
-    //   Items = Items (*) Spanned<"+"> ["-"]
-    //   Items = Items (*) "-" [EOF]
-    //   Items = Items (*) "-" ["+"]
-    //   Items = Items (*) "-" ["-"]
-    //   Spanned<"+"> = (*) "+" [EOF]
-    //   Spanned<"+"> = (*) "+" ["+"]
-    //   Spanned<"+"> = (*) "+" ["-"]
-    //   __Items = Items (*) [EOF]
+    //     Kind = None
+    //     AllInputs = [Items]
+    //     OptionalInputs = []
+    //     FixedInputs = [Items]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(__Items = Items => ActionFn(0);)
-    //   "+" -> Shift(S3)
-    //   "-" -> Shift(S4)
+    //     Items = Items (*) Spanned<"+"> [EOF]
+    //     Items = Items (*) Spanned<"+"> ["+"]
+    //     Items = Items (*) Spanned<"+"> ["-"]
+    //     Items = Items (*) "-" [EOF]
+    //     Items = Items (*) "-" ["+"]
+    //     Items = Items (*) "-" ["-"]
+    //     Spanned<"+"> = (*) "+" [EOF]
+    //     Spanned<"+"> = (*) "+" ["+"]
+    //     Spanned<"+"> = (*) "+" ["-"]
+    //     __Items = Items (*) [EOF]
     //
-    //   Spanned<"+"> -> S2
+    //     EOF -> Reduce(__Items = Items => ActionFn(0);)
+    //     "+" -> Shift(S3)
+    //     "-" -> Shift(S4)
+    //
+    //     Spanned<"+"> -> S2
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, Vec<(usize, usize)>, usize)>,
+        __sym0: (usize, Vec<(usize, usize)>, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state3(__tokens, __sym1));
+                let __sym1 = (__loc1, (__tok), __loc2);
+                __result = try!(__custom1(__tokens, __sym1));
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state4(__tokens, __sym0, __sym1));
+                let __sym1 = (__loc1, (__tok), __loc2);
+                __result = try!(__custom2(__tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action0(__sym0);
@@ -149,7 +164,8 @@ mod __parse__Items {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -158,79 +174,51 @@ mod __parse__Items {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Spanned_3c_22_2b_22_3e(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state2(__tokens, __lookahead, __sym0, __sym1));
+                __Nonterminal::Spanned_3c_22_2b_22_3e(__sym1) => {
+                    __result = try!(__custom0(__tokens, __lookahead, __sym0, __sym1));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
-    // State 2
-    //   Items = Items Spanned<"+"> (*) [EOF]
-    //   Items = Items Spanned<"+"> (*) ["+"]
-    //   Items = Items Spanned<"+"> (*) ["-"]
-    //
-    //   EOF -> Reduce(Items = Items, Spanned<"+"> => ActionFn(2);)
-    //   "+" -> Reduce(Items = Items, Spanned<"+"> => ActionFn(2);)
-    //   "-" -> Reduce(Items = Items, Spanned<"+"> => ActionFn(2);)
-    //
-    pub fn __state2<
+    // Custom 0
+    //    Reduce Items = Items, Spanned<"+"> => ActionFn(2);
+    pub fn __custom0<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: &mut Option<(usize, Vec<(usize, usize)>, usize)>,
-        __sym1: &mut Option<(usize, (usize, usize), usize)>,
+        __sym0: (usize, Vec<(usize, usize)>, usize),
+        __sym1: (usize, (usize, usize), usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action2(__sym0, __sym1);
-                let __nt = __Nonterminal::Items((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = super::__action2(__sym0, __sym1);
+        let __nt = __Nonterminal::Items((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 
-    // State 3
-    //   Spanned<"+"> = "+" (*) [EOF]
-    //   Spanned<"+"> = "+" (*) ["+"]
-    //   Spanned<"+"> = "+" (*) ["-"]
-    //
-    //   EOF -> Reduce(Spanned<"+"> = "+" => ActionFn(10);)
-    //   "+" -> Reduce(Spanned<"+"> = "+" => ActionFn(10);)
-    //   "-" -> Reduce(Spanned<"+"> = "+" => ActionFn(10);)
-    //
-    pub fn __state3<
+    // Custom 1
+    //    Reduce Spanned<"+"> = "+" => ActionFn(10);
+    pub fn __custom1<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
@@ -239,45 +227,26 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        match __lookahead {
-            None |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action10(__sym0);
-                let __nt = __Nonterminal::Spanned_3c_22_2b_22_3e((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action10(__sym0);
+        let __nt = __Nonterminal::Spanned_3c_22_2b_22_3e((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 
-    // State 4
-    //   Items = Items "-" (*) [EOF]
-    //   Items = Items "-" (*) ["+"]
-    //   Items = Items "-" (*) ["-"]
-    //
-    //   EOF -> Reduce(Items = Items, "-" => ActionFn(3);)
-    //   "+" -> Reduce(Items = Items, "-" => ActionFn(3);)
-    //   "-" -> Reduce(Items = Items, "-" => ActionFn(3);)
-    //
-    pub fn __state4<
+    // Custom 2
+    //    Reduce Items = Items, "-" => ActionFn(3);
+    pub fn __custom2<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, Vec<(usize, usize)>, usize)>,
-        __sym1: &mut Option<(usize, Tok, usize)>,
+        __sym0: (usize, Vec<(usize, usize)>, usize),
+        __sym1: (usize, Tok, usize),
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
@@ -286,29 +255,16 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        match __lookahead {
-            None |
-            Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action3(__sym0, __sym1);
-                let __nt = __Nonterminal::Items((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = super::__action3(__sym0, __sym1);
+        let __nt = __Nonterminal::Items((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__Items::parse_Items;

--- a/lalrpop-test/src/loc_issue_90.rs
+++ b/lalrpop-test/src/loc_issue_90.rs
@@ -47,33 +47,41 @@ mod __parse__Expression2 {
     }
 
     // State 0
-    //   Expression1 = (*) Wacky [EOF]
-    //   Expression1 = (*) Wacky ["*"]
-    //   Expression1 = (*) "&" Maybe Expression1 [EOF]
-    //   Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //   Expression1 = (*) "(" Expression2 ")" [EOF]
-    //   Expression1 = (*) "(" Expression2 ")" ["*"]
-    //   Expression1 = (*) "wonky" Wonky [EOF]
-    //   Expression1 = (*) "wonky" Wonky ["*"]
-    //   Expression1 = (*) r#"\\w+"# [EOF]
-    //   Expression1 = (*) r#"\\w+"# ["*"]
-    //   Expression2 = (*) Expression1 [EOF]
-    //   Expression2 = (*) Expression1 ["*"]
-    //   Expression2 = (*) Expression2 Expression2Op Expression1 [EOF]
-    //   Expression2 = (*) Expression2 Expression2Op Expression1 ["*"]
-    //   Wacky = (*) "wacky" [EOF]
-    //   Wacky = (*) "wacky" ["*"]
-    //   __Expression2 = (*) Expression2 [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   "&" -> Shift(S4)
-    //   "(" -> Shift(S5)
-    //   "wacky" -> Shift(S6)
-    //   "wonky" -> Shift(S7)
-    //   r#"\\w+"# -> Shift(S8)
+    //     Expression1 = (*) Wacky [EOF]
+    //     Expression1 = (*) Wacky ["*"]
+    //     Expression1 = (*) "&" Maybe Expression1 [EOF]
+    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
+    //     Expression1 = (*) "(" Expression2 ")" [EOF]
+    //     Expression1 = (*) "(" Expression2 ")" ["*"]
+    //     Expression1 = (*) "wonky" Wonky [EOF]
+    //     Expression1 = (*) "wonky" Wonky ["*"]
+    //     Expression1 = (*) r#"\\w+"# [EOF]
+    //     Expression1 = (*) r#"\\w+"# ["*"]
+    //     Expression2 = (*) Expression1 [EOF]
+    //     Expression2 = (*) Expression1 ["*"]
+    //     Expression2 = (*) Expression2 Expression2Op Expression1 [EOF]
+    //     Expression2 = (*) Expression2 Expression2Op Expression1 ["*"]
+    //     Wacky = (*) "wacky" [EOF]
+    //     Wacky = (*) "wacky" ["*"]
+    //     __Expression2 = (*) Expression2 [EOF]
     //
-    //   Expression1 -> S1
-    //   Expression2 -> S2
-    //   Wacky -> S3
+    //     "&" -> Shift(S4)
+    //     "(" -> Shift(S5)
+    //     "wacky" -> Shift(S6)
+    //     "wonky" -> Shift(S7)
+    //     r#"\\w+"# -> Shift(S8)
+    //
+    //     Expression1 -> S1
+    //     Expression2 -> S2
+    //     Wacky -> S3
     pub fn __state0<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -86,24 +94,24 @@ mod __parse__Expression2 {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym0 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state4(input, __tokens, __sym0));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym0 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state5(input, __tokens, __sym0));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(input, __tokens, __sym0));
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(input, __tokens, __sym0));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym0 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state7(input, __tokens, __sym0));
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state8(input, __tokens, __sym0));
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom3(input, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -115,17 +123,14 @@ mod __parse__Expression2 {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expression1(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state1(input, __tokens, __lookahead, __sym0));
+                __Nonterminal::Expression1(__sym0) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Expression2(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::Expression2(__sym0) => {
                     __result = try!(__state2(input, __tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::Wacky(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state3(input, __tokens, __lookahead, __sym0));
+                __Nonterminal::Wacky(__sym0) => {
+                    __result = try!(__custom1(input, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -134,61 +139,28 @@ mod __parse__Expression2 {
         }
     }
 
-    // State 1
-    //   Expression2 = Expression1 (*) [EOF]
-    //   Expression2 = Expression1 (*) ["*"]
-    //
-    //   EOF -> Reduce(Expression2 = Expression1 => ActionFn(29);)
-    //   "*" -> Reduce(Expression2 = Expression1 => ActionFn(29);)
-    //
-    pub fn __state1<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action29(input, __sym0);
-                let __nt = __Nonterminal::Expression2((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
     // State 2
-    //   Expression2 = Expression2 (*) Expression2Op Expression1 [EOF]
-    //   Expression2 = Expression2 (*) Expression2Op Expression1 ["*"]
-    //   Expression2Op = (*) "*" ["&"]
-    //   Expression2Op = (*) "*" ["("]
-    //   Expression2Op = (*) "*" ["wacky"]
-    //   Expression2Op = (*) "*" ["wonky"]
-    //   Expression2Op = (*) "*" [r#"\\w+"#]
-    //   __Expression2 = Expression2 (*) [EOF]
+    //     Kind = None
+    //     AllInputs = [Expression2]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expression2]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(__Expression2 = Expression2 => ActionFn(0);)
-    //   "*" -> Shift(S10)
+    //     Expression2 = Expression2 (*) Expression2Op Expression1 [EOF]
+    //     Expression2 = Expression2 (*) Expression2Op Expression1 ["*"]
+    //     Expression2Op = (*) "*" ["&"]
+    //     Expression2Op = (*) "*" ["("]
+    //     Expression2Op = (*) "*" ["wacky"]
+    //     Expression2Op = (*) "*" ["wonky"]
+    //     Expression2Op = (*) "*" [r#"\\w+"#]
+    //     __Expression2 = Expression2 (*) [EOF]
     //
-    //   Expression2Op -> S9
+    //     EOF -> Reduce(__Expression2 = Expression2 => ActionFn(0);)
+    //     "*" -> Shift(S10)
+    //
+    //     Expression2Op -> S9
     pub fn __state2<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -196,17 +168,16 @@ mod __parse__Expression2 {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Box<Expr<'input>>, usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
             Some((__loc1, (3, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state10(input, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom4(input, __tokens, __sym1));
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action0(input, __sym0);
@@ -215,7 +186,8 @@ mod __parse__Expression2 {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -224,91 +196,57 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expression2Op(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expression2Op(__sym1) => {
                     __result = try!(__state9(input, __tokens, __lookahead, __sym0, __sym1));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 3
-    //   Expression1 = Wacky (*) [EOF]
-    //   Expression1 = Wacky (*) ["*"]
-    //
-    //   EOF -> Reduce(Expression1 = Wacky => ActionFn(8);)
-    //   "*" -> Reduce(Expression1 = Wacky => ActionFn(8);)
-    //
-    pub fn __state3<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action8(input, __sym0);
-                let __nt = __Nonterminal::Expression1((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 4
-    //   Expression1 = "&" (*) Maybe Expression1 [EOF]
-    //   Expression1 = "&" (*) Maybe Expression1 ["*"]
-    //   Maybe = (*) ["&"]
-    //   Maybe = (*) ["("]
-    //   Maybe = (*) ["wacky"]
-    //   Maybe = (*) ["wonky"]
-    //   Maybe = (*) [r#"\\w+"#]
-    //   Maybe = (*) "[" "]" ["&"]
-    //   Maybe = (*) "[" "]" ["("]
-    //   Maybe = (*) "[" "]" ["wacky"]
-    //   Maybe = (*) "[" "]" ["wonky"]
-    //   Maybe = (*) "[" "]" [r#"\\w+"#]
+    //     Kind = None
+    //     AllInputs = ["&"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["&"]
+    //     WillPushLen = 2
+    //     WillPush = [Maybe, Expression1]
+    //     WillProduce = Some(Expression1)
     //
-    //   "&" -> Reduce(Maybe =  => ActionFn(31);)
-    //   "(" -> Reduce(Maybe =  => ActionFn(31);)
-    //   "[" -> Shift(S12)
-    //   "wacky" -> Reduce(Maybe =  => ActionFn(31);)
-    //   "wonky" -> Reduce(Maybe =  => ActionFn(31);)
-    //   r#"\\w+"# -> Reduce(Maybe =  => ActionFn(31);)
+    //     Expression1 = "&" (*) Maybe Expression1 [EOF]
+    //     Expression1 = "&" (*) Maybe Expression1 ["*"]
+    //     Maybe = (*) ["&"]
+    //     Maybe = (*) ["("]
+    //     Maybe = (*) ["wacky"]
+    //     Maybe = (*) ["wonky"]
+    //     Maybe = (*) [r#"\\w+"#]
+    //     Maybe = (*) "[" "]" ["&"]
+    //     Maybe = (*) "[" "]" ["("]
+    //     Maybe = (*) "[" "]" ["wacky"]
+    //     Maybe = (*) "[" "]" ["wonky"]
+    //     Maybe = (*) "[" "]" [r#"\\w+"#]
     //
-    //   Maybe -> S11
+    //     "&" -> Reduce(Maybe =  => ActionFn(31);)
+    //     "(" -> Reduce(Maybe =  => ActionFn(31);)
+    //     "[" -> Shift(S12)
+    //     "wacky" -> Reduce(Maybe =  => ActionFn(31);)
+    //     "wonky" -> Reduce(Maybe =  => ActionFn(31);)
+    //     r#"\\w+"# -> Reduce(Maybe =  => ActionFn(31);)
+    //
+    //     Maybe -> S11
     pub fn __state4<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -319,7 +257,7 @@ mod __parse__Expression2 {
         };
         match __lookahead {
             Some((__loc1, (4, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state12(input, __tokens, __sym1));
             }
             Some((_, (0, _), _)) |
@@ -327,7 +265,7 @@ mod __parse__Expression2 {
             Some((_, (6, _), _)) |
             Some((_, (7, _), _)) |
             Some((_, (8, _), _)) => {
-                let __start = __sym0.as_ref().unwrap().2.clone();
+                let __start = __sym0.2.clone();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action31(input, &__start, &__end);
                 let __nt = __Nonterminal::Maybe((
@@ -344,57 +282,64 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Maybe(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Maybe(__sym1) => {
                     __result = try!(__state11(input, __tokens, __lookahead, __sym0, __sym1));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 5
-    //   Expression1 = (*) Wacky [")"]
-    //   Expression1 = (*) Wacky ["*"]
-    //   Expression1 = (*) "&" Maybe Expression1 [")"]
-    //   Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //   Expression1 = (*) "(" Expression2 ")" [")"]
-    //   Expression1 = (*) "(" Expression2 ")" ["*"]
-    //   Expression1 = "(" (*) Expression2 ")" [EOF]
-    //   Expression1 = "(" (*) Expression2 ")" ["*"]
-    //   Expression1 = (*) "wonky" Wonky [")"]
-    //   Expression1 = (*) "wonky" Wonky ["*"]
-    //   Expression1 = (*) r#"\\w+"# [")"]
-    //   Expression1 = (*) r#"\\w+"# ["*"]
-    //   Expression2 = (*) Expression1 [")"]
-    //   Expression2 = (*) Expression1 ["*"]
-    //   Expression2 = (*) Expression2 Expression2Op Expression1 [")"]
-    //   Expression2 = (*) Expression2 Expression2Op Expression1 ["*"]
-    //   Wacky = (*) "wacky" [")"]
-    //   Wacky = (*) "wacky" ["*"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expression2, ")"]
+    //     WillProduce = Some(Expression1)
     //
-    //   "&" -> Shift(S16)
-    //   "(" -> Shift(S17)
-    //   "wacky" -> Shift(S18)
-    //   "wonky" -> Shift(S19)
-    //   r#"\\w+"# -> Shift(S20)
+    //     Expression1 = (*) Wacky [")"]
+    //     Expression1 = (*) Wacky ["*"]
+    //     Expression1 = (*) "&" Maybe Expression1 [")"]
+    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
+    //     Expression1 = (*) "(" Expression2 ")" [")"]
+    //     Expression1 = (*) "(" Expression2 ")" ["*"]
+    //     Expression1 = "(" (*) Expression2 ")" [EOF]
+    //     Expression1 = "(" (*) Expression2 ")" ["*"]
+    //     Expression1 = (*) "wonky" Wonky [")"]
+    //     Expression1 = (*) "wonky" Wonky ["*"]
+    //     Expression1 = (*) r#"\\w+"# [")"]
+    //     Expression1 = (*) r#"\\w+"# ["*"]
+    //     Expression2 = (*) Expression1 [")"]
+    //     Expression2 = (*) Expression1 ["*"]
+    //     Expression2 = (*) Expression2 Expression2Op Expression1 [")"]
+    //     Expression2 = (*) Expression2 Expression2Op Expression1 ["*"]
+    //     Wacky = (*) "wacky" [")"]
+    //     Wacky = (*) "wacky" ["*"]
     //
-    //   Expression1 -> S13
-    //   Expression2 -> S14
-    //   Wacky -> S15
+    //     "&" -> Shift(S16)
+    //     "(" -> Shift(S17)
+    //     "wacky" -> Shift(S18)
+    //     "wonky" -> Shift(S19)
+    //     r#"\\w+"# -> Shift(S20)
+    //
+    //     Expression1 -> S13
+    //     Expression2 -> S14
+    //     Wacky -> S15
     pub fn __state5<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -403,26 +348,27 @@ mod __parse__Expression2 {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state16(input, __tokens, __sym1));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state17(input, __tokens, __sym1));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state18(input, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(input, __tokens, __sym1));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state19(input, __tokens, __sym1));
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state20(input, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom3(input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -431,91 +377,53 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expression1(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state13(input, __tokens, __lookahead, __sym1));
+                __Nonterminal::Expression1(__sym1) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Expression2(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expression2(__sym1) => {
                     __result = try!(__state14(input, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Wacky(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state15(input, __tokens, __lookahead, __sym1));
+                __Nonterminal::Wacky(__sym1) => {
+                    __result = try!(__custom1(input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 6
-    //   Wacky = "wacky" (*) [EOF]
-    //   Wacky = "wacky" (*) ["*"]
-    //
-    //   EOF -> Reduce(Wacky = "wacky" => ActionFn(33);)
-    //   "*" -> Reduce(Wacky = "wacky" => ActionFn(33);)
-    //
-    pub fn __state6<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action33(input, __sym0);
-                let __nt = __Nonterminal::Wacky((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 7
-    //   Expression1 = "wonky" (*) Wonky [EOF]
-    //   Expression1 = "wonky" (*) Wonky ["*"]
-    //   Wonky = (*) [EOF]
-    //   Wonky = (*) ["*"]
+    //     Kind = None
+    //     AllInputs = ["wonky"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["wonky"]
+    //     WillPushLen = 1
+    //     WillPush = [Wonky]
+    //     WillProduce = Some(Expression1)
     //
-    //   EOF -> Reduce(Wonky =  => ActionFn(34);)
-    //   "*" -> Reduce(Wonky =  => ActionFn(34);)
+    //     Expression1 = "wonky" (*) Wonky [EOF]
+    //     Expression1 = "wonky" (*) Wonky ["*"]
+    //     Wonky = (*) [EOF]
+    //     Wonky = (*) ["*"]
     //
-    //   Wonky -> S21
+    //     EOF -> Reduce(Wonky =  => ActionFn(34);)
+    //     "*" -> Reduce(Wonky =  => ActionFn(34);)
+    //
+    //     Wonky -> S21
     pub fn __state7<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -527,7 +435,7 @@ mod __parse__Expression2 {
         match __lookahead {
             None |
             Some((_, (3, _), _)) => {
-                let __start = __sym0.as_ref().unwrap().2.clone();
+                let __start = __sym0.2.clone();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action34(input, &__start, &__end);
                 let __nt = __Nonterminal::Wonky((
@@ -544,90 +452,52 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Wonky(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state21(input, __tokens, __lookahead, __sym0, __sym1));
+                __Nonterminal::Wonky(__sym1) => {
+                    __result = try!(__custom5(input, __tokens, __lookahead, __sym0, __sym1));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 8
-    //   Expression1 = r#"\\w+"# (*) [EOF]
-    //   Expression1 = r#"\\w+"# (*) ["*"]
-    //
-    //   EOF -> Reduce(Expression1 = r#"\\w+"# => ActionFn(26);)
-    //   "*" -> Reduce(Expression1 = r#"\\w+"# => ActionFn(26);)
-    //
-    pub fn __state8<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action26(input, __sym0);
-                let __nt = __Nonterminal::Expression1((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 9
-    //   Expression1 = (*) Wacky [EOF]
-    //   Expression1 = (*) Wacky ["*"]
-    //   Expression1 = (*) "&" Maybe Expression1 [EOF]
-    //   Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //   Expression1 = (*) "(" Expression2 ")" [EOF]
-    //   Expression1 = (*) "(" Expression2 ")" ["*"]
-    //   Expression1 = (*) "wonky" Wonky [EOF]
-    //   Expression1 = (*) "wonky" Wonky ["*"]
-    //   Expression1 = (*) r#"\\w+"# [EOF]
-    //   Expression1 = (*) r#"\\w+"# ["*"]
-    //   Expression2 = Expression2 Expression2Op (*) Expression1 [EOF]
-    //   Expression2 = Expression2 Expression2Op (*) Expression1 ["*"]
-    //   Wacky = (*) "wacky" [EOF]
-    //   Wacky = (*) "wacky" ["*"]
+    //     Kind = None
+    //     AllInputs = [Expression2, Expression2Op]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expression2, Expression2Op]
+    //     WillPushLen = 1
+    //     WillPush = [Expression1]
+    //     WillProduce = Some(Expression2)
     //
-    //   "&" -> Shift(S4)
-    //   "(" -> Shift(S5)
-    //   "wacky" -> Shift(S6)
-    //   "wonky" -> Shift(S7)
-    //   r#"\\w+"# -> Shift(S8)
+    //     Expression1 = (*) Wacky [EOF]
+    //     Expression1 = (*) Wacky ["*"]
+    //     Expression1 = (*) "&" Maybe Expression1 [EOF]
+    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
+    //     Expression1 = (*) "(" Expression2 ")" [EOF]
+    //     Expression1 = (*) "(" Expression2 ")" ["*"]
+    //     Expression1 = (*) "wonky" Wonky [EOF]
+    //     Expression1 = (*) "wonky" Wonky ["*"]
+    //     Expression1 = (*) r#"\\w+"# [EOF]
+    //     Expression1 = (*) r#"\\w+"# ["*"]
+    //     Expression2 = Expression2 Expression2Op (*) Expression1 [EOF]
+    //     Expression2 = Expression2 Expression2Op (*) Expression1 ["*"]
+    //     Wacky = (*) "wacky" [EOF]
+    //     Wacky = (*) "wacky" ["*"]
     //
-    //   Expression1 -> S22
-    //   Wacky -> S3
+    //     "&" -> Shift(S4)
+    //     "(" -> Shift(S5)
+    //     "wacky" -> Shift(S6)
+    //     "wonky" -> Shift(S7)
+    //     r#"\\w+"# -> Shift(S8)
+    //
+    //     Expression1 -> S22
+    //     Wacky -> S3
     pub fn __state9<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -635,31 +505,31 @@ mod __parse__Expression2 {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state4(input, __tokens, __sym2));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state5(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(input, __tokens, __sym2));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state7(input, __tokens, __sym2));
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state8(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom3(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -668,103 +538,55 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expression1(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state22(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Expression1(__sym2) => {
+                    __result = try!(__custom6(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
-                __Nonterminal::Wacky(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Wacky(__sym2) => {
+                    __result = try!(__custom1(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 10
-    //   Expression2Op = "*" (*) ["&"]
-    //   Expression2Op = "*" (*) ["("]
-    //   Expression2Op = "*" (*) ["wacky"]
-    //   Expression2Op = "*" (*) ["wonky"]
-    //   Expression2Op = "*" (*) [r#"\\w+"#]
-    //
-    //   "&" -> Reduce(Expression2Op = "*" => ActionFn(30);)
-    //   "(" -> Reduce(Expression2Op = "*" => ActionFn(30);)
-    //   "wacky" -> Reduce(Expression2Op = "*" => ActionFn(30);)
-    //   "wonky" -> Reduce(Expression2Op = "*" => ActionFn(30);)
-    //   r#"\\w+"# -> Reduce(Expression2Op = "*" => ActionFn(30);)
-    //
-    pub fn __state10<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            Some((_, (0, _), _)) |
-            Some((_, (1, _), _)) |
-            Some((_, (6, _), _)) |
-            Some((_, (7, _), _)) |
-            Some((_, (8, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action30(input, __sym0);
-                let __nt = __Nonterminal::Expression2Op((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 11
-    //   Expression1 = (*) Wacky [EOF]
-    //   Expression1 = (*) Wacky ["*"]
-    //   Expression1 = (*) "&" Maybe Expression1 [EOF]
-    //   Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //   Expression1 = "&" Maybe (*) Expression1 [EOF]
-    //   Expression1 = "&" Maybe (*) Expression1 ["*"]
-    //   Expression1 = (*) "(" Expression2 ")" [EOF]
-    //   Expression1 = (*) "(" Expression2 ")" ["*"]
-    //   Expression1 = (*) "wonky" Wonky [EOF]
-    //   Expression1 = (*) "wonky" Wonky ["*"]
-    //   Expression1 = (*) r#"\\w+"# [EOF]
-    //   Expression1 = (*) r#"\\w+"# ["*"]
-    //   Wacky = (*) "wacky" [EOF]
-    //   Wacky = (*) "wacky" ["*"]
+    //     Kind = None
+    //     AllInputs = ["&", Maybe]
+    //     OptionalInputs = []
+    //     FixedInputs = ["&", Maybe]
+    //     WillPushLen = 1
+    //     WillPush = [Expression1]
+    //     WillProduce = Some(Expression1)
     //
-    //   "&" -> Shift(S4)
-    //   "(" -> Shift(S5)
-    //   "wacky" -> Shift(S6)
-    //   "wonky" -> Shift(S7)
-    //   r#"\\w+"# -> Shift(S8)
+    //     Expression1 = (*) Wacky [EOF]
+    //     Expression1 = (*) Wacky ["*"]
+    //     Expression1 = (*) "&" Maybe Expression1 [EOF]
+    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
+    //     Expression1 = "&" Maybe (*) Expression1 [EOF]
+    //     Expression1 = "&" Maybe (*) Expression1 ["*"]
+    //     Expression1 = (*) "(" Expression2 ")" [EOF]
+    //     Expression1 = (*) "(" Expression2 ")" ["*"]
+    //     Expression1 = (*) "wonky" Wonky [EOF]
+    //     Expression1 = (*) "wonky" Wonky ["*"]
+    //     Expression1 = (*) r#"\\w+"# [EOF]
+    //     Expression1 = (*) r#"\\w+"# ["*"]
+    //     Wacky = (*) "wacky" [EOF]
+    //     Wacky = (*) "wacky" ["*"]
     //
-    //   Expression1 -> S23
-    //   Wacky -> S3
+    //     "&" -> Shift(S4)
+    //     "(" -> Shift(S5)
+    //     "wacky" -> Shift(S6)
+    //     "wonky" -> Shift(S7)
+    //     r#"\\w+"# -> Shift(S8)
+    //
+    //     Expression1 -> S23
+    //     Wacky -> S3
     pub fn __state11<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -772,31 +594,31 @@ mod __parse__Expression2 {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state4(input, __tokens, __sym2));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state5(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state6(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(input, __tokens, __sym2));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state7(input, __tokens, __sym2));
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state8(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom3(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -805,33 +627,39 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expression1(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state23(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Expression1(__sym2) => {
+                    __result = try!(__custom7(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
-                __Nonterminal::Wacky(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state3(input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Wacky(__sym2) => {
+                    __result = try!(__custom1(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 12
-    //   Maybe = "[" (*) "]" ["&"]
-    //   Maybe = "[" (*) "]" ["("]
-    //   Maybe = "[" (*) "]" ["wacky"]
-    //   Maybe = "[" (*) "]" ["wonky"]
-    //   Maybe = "[" (*) "]" [r#"\\w+"#]
+    //     Kind = None
+    //     AllInputs = ["["]
+    //     OptionalInputs = []
+    //     FixedInputs = ["["]
+    //     WillPushLen = 1
+    //     WillPush = ["]"]
+    //     WillProduce = Some(Maybe)
     //
-    //   "]" -> Shift(S24)
+    //     Maybe = "[" (*) "]" ["&"]
+    //     Maybe = "[" (*) "]" ["("]
+    //     Maybe = "[" (*) "]" ["wacky"]
+    //     Maybe = "[" (*) "]" ["wonky"]
+    //     Maybe = "[" (*) "]" [r#"\\w+"#]
+    //
+    //     "]" -> Shift(S24)
     //
     pub fn __state12<
         'input,
@@ -839,7 +667,7 @@ mod __parse__Expression2 {
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -850,50 +678,9 @@ mod __parse__Expression2 {
         };
         match __lookahead {
             Some((__loc1, (5, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state24(input, __tokens, __sym0, __sym1));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 13
-    //   Expression2 = Expression1 (*) [")"]
-    //   Expression2 = Expression1 (*) ["*"]
-    //
-    //   ")" -> Reduce(Expression2 = Expression1 => ActionFn(29);)
-    //   "*" -> Reduce(Expression2 = Expression1 => ActionFn(29);)
-    //
-    pub fn __state13<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        match __lookahead {
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action29(input, __sym0);
-                let __nt = __Nonterminal::Expression2((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom8(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -905,20 +692,28 @@ mod __parse__Expression2 {
     }
 
     // State 14
-    //   Expression1 = "(" Expression2 (*) ")" [EOF]
-    //   Expression1 = "(" Expression2 (*) ")" ["*"]
-    //   Expression2 = Expression2 (*) Expression2Op Expression1 [")"]
-    //   Expression2 = Expression2 (*) Expression2Op Expression1 ["*"]
-    //   Expression2Op = (*) "*" ["&"]
-    //   Expression2Op = (*) "*" ["("]
-    //   Expression2Op = (*) "*" ["wacky"]
-    //   Expression2Op = (*) "*" ["wonky"]
-    //   Expression2Op = (*) "*" [r#"\\w+"#]
+    //     Kind = None
+    //     AllInputs = ["(", Expression2]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expression2]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S26)
-    //   "*" -> Shift(S10)
+    //     Expression1 = "(" Expression2 (*) ")" [EOF]
+    //     Expression1 = "(" Expression2 (*) ")" ["*"]
+    //     Expression2 = Expression2 (*) Expression2Op Expression1 [")"]
+    //     Expression2 = Expression2 (*) Expression2Op Expression1 ["*"]
+    //     Expression2Op = (*) "*" ["&"]
+    //     Expression2Op = (*) "*" ["("]
+    //     Expression2Op = (*) "*" ["wacky"]
+    //     Expression2Op = (*) "*" ["wonky"]
+    //     Expression2Op = (*) "*" [r#"\\w+"#]
     //
-    //   Expression2Op -> S25
+    //     ")" -> Shift(S26)
+    //     "*" -> Shift(S10)
+    //
+    //     Expression2Op -> S25
     pub fn __state14<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -927,18 +722,20 @@ mod __parse__Expression2 {
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
+        __sym1: (usize, Box<Expr<'input>>, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state26(input, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom9(input, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state10(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom4(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -947,91 +744,57 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expression2Op(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Expression2Op(__sym2) => {
                     __result = try!(__state25(input, __tokens, __lookahead, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 15
-    //   Expression1 = Wacky (*) [")"]
-    //   Expression1 = Wacky (*) ["*"]
-    //
-    //   ")" -> Reduce(Expression1 = Wacky => ActionFn(8);)
-    //   "*" -> Reduce(Expression1 = Wacky => ActionFn(8);)
-    //
-    pub fn __state15<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        match __lookahead {
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action8(input, __sym0);
-                let __nt = __Nonterminal::Expression1((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 16
-    //   Expression1 = "&" (*) Maybe Expression1 [")"]
-    //   Expression1 = "&" (*) Maybe Expression1 ["*"]
-    //   Maybe = (*) ["&"]
-    //   Maybe = (*) ["("]
-    //   Maybe = (*) ["wacky"]
-    //   Maybe = (*) ["wonky"]
-    //   Maybe = (*) [r#"\\w+"#]
-    //   Maybe = (*) "[" "]" ["&"]
-    //   Maybe = (*) "[" "]" ["("]
-    //   Maybe = (*) "[" "]" ["wacky"]
-    //   Maybe = (*) "[" "]" ["wonky"]
-    //   Maybe = (*) "[" "]" [r#"\\w+"#]
+    //     Kind = None
+    //     AllInputs = ["&"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["&"]
+    //     WillPushLen = 2
+    //     WillPush = [Maybe, Expression1]
+    //     WillProduce = Some(Expression1)
     //
-    //   "&" -> Reduce(Maybe =  => ActionFn(31);)
-    //   "(" -> Reduce(Maybe =  => ActionFn(31);)
-    //   "[" -> Shift(S12)
-    //   "wacky" -> Reduce(Maybe =  => ActionFn(31);)
-    //   "wonky" -> Reduce(Maybe =  => ActionFn(31);)
-    //   r#"\\w+"# -> Reduce(Maybe =  => ActionFn(31);)
+    //     Expression1 = "&" (*) Maybe Expression1 [")"]
+    //     Expression1 = "&" (*) Maybe Expression1 ["*"]
+    //     Maybe = (*) ["&"]
+    //     Maybe = (*) ["("]
+    //     Maybe = (*) ["wacky"]
+    //     Maybe = (*) ["wonky"]
+    //     Maybe = (*) [r#"\\w+"#]
+    //     Maybe = (*) "[" "]" ["&"]
+    //     Maybe = (*) "[" "]" ["("]
+    //     Maybe = (*) "[" "]" ["wacky"]
+    //     Maybe = (*) "[" "]" ["wonky"]
+    //     Maybe = (*) "[" "]" [r#"\\w+"#]
     //
-    //   Maybe -> S27
+    //     "&" -> Reduce(Maybe =  => ActionFn(31);)
+    //     "(" -> Reduce(Maybe =  => ActionFn(31);)
+    //     "[" -> Shift(S12)
+    //     "wacky" -> Reduce(Maybe =  => ActionFn(31);)
+    //     "wonky" -> Reduce(Maybe =  => ActionFn(31);)
+    //     r#"\\w+"# -> Reduce(Maybe =  => ActionFn(31);)
+    //
+    //     Maybe -> S27
     pub fn __state16<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1042,7 +805,7 @@ mod __parse__Expression2 {
         };
         match __lookahead {
             Some((__loc1, (4, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state12(input, __tokens, __sym1));
             }
             Some((_, (0, _), _)) |
@@ -1050,7 +813,7 @@ mod __parse__Expression2 {
             Some((_, (6, _), _)) |
             Some((_, (7, _), _)) |
             Some((_, (8, _), _)) => {
-                let __start = __sym0.as_ref().unwrap().2.clone();
+                let __start = __sym0.2.clone();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action31(input, &__start, &__end);
                 let __nt = __Nonterminal::Maybe((
@@ -1067,57 +830,64 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Maybe(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Maybe(__sym1) => {
                     __result = try!(__state27(input, __tokens, __lookahead, __sym0, __sym1));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 17
-    //   Expression1 = (*) Wacky [")"]
-    //   Expression1 = (*) Wacky ["*"]
-    //   Expression1 = (*) "&" Maybe Expression1 [")"]
-    //   Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //   Expression1 = (*) "(" Expression2 ")" [")"]
-    //   Expression1 = (*) "(" Expression2 ")" ["*"]
-    //   Expression1 = "(" (*) Expression2 ")" [")"]
-    //   Expression1 = "(" (*) Expression2 ")" ["*"]
-    //   Expression1 = (*) "wonky" Wonky [")"]
-    //   Expression1 = (*) "wonky" Wonky ["*"]
-    //   Expression1 = (*) r#"\\w+"# [")"]
-    //   Expression1 = (*) r#"\\w+"# ["*"]
-    //   Expression2 = (*) Expression1 [")"]
-    //   Expression2 = (*) Expression1 ["*"]
-    //   Expression2 = (*) Expression2 Expression2Op Expression1 [")"]
-    //   Expression2 = (*) Expression2 Expression2Op Expression1 ["*"]
-    //   Wacky = (*) "wacky" [")"]
-    //   Wacky = (*) "wacky" ["*"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expression2, ")"]
+    //     WillProduce = Some(Expression1)
     //
-    //   "&" -> Shift(S16)
-    //   "(" -> Shift(S17)
-    //   "wacky" -> Shift(S18)
-    //   "wonky" -> Shift(S19)
-    //   r#"\\w+"# -> Shift(S20)
+    //     Expression1 = (*) Wacky [")"]
+    //     Expression1 = (*) Wacky ["*"]
+    //     Expression1 = (*) "&" Maybe Expression1 [")"]
+    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
+    //     Expression1 = (*) "(" Expression2 ")" [")"]
+    //     Expression1 = (*) "(" Expression2 ")" ["*"]
+    //     Expression1 = "(" (*) Expression2 ")" [")"]
+    //     Expression1 = "(" (*) Expression2 ")" ["*"]
+    //     Expression1 = (*) "wonky" Wonky [")"]
+    //     Expression1 = (*) "wonky" Wonky ["*"]
+    //     Expression1 = (*) r#"\\w+"# [")"]
+    //     Expression1 = (*) r#"\\w+"# ["*"]
+    //     Expression2 = (*) Expression1 [")"]
+    //     Expression2 = (*) Expression1 ["*"]
+    //     Expression2 = (*) Expression2 Expression2Op Expression1 [")"]
+    //     Expression2 = (*) Expression2 Expression2Op Expression1 ["*"]
+    //     Wacky = (*) "wacky" [")"]
+    //     Wacky = (*) "wacky" ["*"]
     //
-    //   Expression1 -> S13
-    //   Expression2 -> S28
-    //   Wacky -> S15
+    //     "&" -> Shift(S16)
+    //     "(" -> Shift(S17)
+    //     "wacky" -> Shift(S18)
+    //     "wonky" -> Shift(S19)
+    //     r#"\\w+"# -> Shift(S20)
+    //
+    //     Expression1 -> S13
+    //     Expression2 -> S28
+    //     Wacky -> S15
     pub fn __state17<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1126,26 +896,27 @@ mod __parse__Expression2 {
             None => None,
             Some(Err(e)) => return Err(e),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state16(input, __tokens, __sym1));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state17(input, __tokens, __sym1));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state18(input, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(input, __tokens, __sym1));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym1 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state19(input, __tokens, __sym1));
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state20(input, __tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom3(input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1154,91 +925,53 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expression1(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state13(input, __tokens, __lookahead, __sym1));
+                __Nonterminal::Expression1(__sym1) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
                 }
-                __Nonterminal::Expression2(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::Expression2(__sym1) => {
                     __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::Wacky(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state15(input, __tokens, __lookahead, __sym1));
+                __Nonterminal::Wacky(__sym1) => {
+                    __result = try!(__custom1(input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 18
-    //   Wacky = "wacky" (*) [")"]
-    //   Wacky = "wacky" (*) ["*"]
-    //
-    //   ")" -> Reduce(Wacky = "wacky" => ActionFn(33);)
-    //   "*" -> Reduce(Wacky = "wacky" => ActionFn(33);)
-    //
-    pub fn __state18<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action33(input, __sym0);
-                let __nt = __Nonterminal::Wacky((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 19
-    //   Expression1 = "wonky" (*) Wonky [")"]
-    //   Expression1 = "wonky" (*) Wonky ["*"]
-    //   Wonky = (*) [")"]
-    //   Wonky = (*) ["*"]
+    //     Kind = None
+    //     AllInputs = ["wonky"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["wonky"]
+    //     WillPushLen = 1
+    //     WillPush = [Wonky]
+    //     WillProduce = Some(Expression1)
     //
-    //   ")" -> Reduce(Wonky =  => ActionFn(34);)
-    //   "*" -> Reduce(Wonky =  => ActionFn(34);)
+    //     Expression1 = "wonky" (*) Wonky [")"]
+    //     Expression1 = "wonky" (*) Wonky ["*"]
+    //     Wonky = (*) [")"]
+    //     Wonky = (*) ["*"]
     //
-    //   Wonky -> S29
+    //     ")" -> Reduce(Wonky =  => ActionFn(34);)
+    //     "*" -> Reduce(Wonky =  => ActionFn(34);)
+    //
+    //     Wonky -> S29
     pub fn __state19<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1250,7 +983,7 @@ mod __parse__Expression2 {
         match __lookahead {
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) => {
-                let __start = __sym0.as_ref().unwrap().2.clone();
+                let __start = __sym0.2.clone();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action34(input, &__start, &__end);
                 let __nt = __Nonterminal::Wonky((
@@ -1267,279 +1000,52 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Wonky(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state29(input, __tokens, __lookahead, __sym0, __sym1));
+                __Nonterminal::Wonky(__sym1) => {
+                    __result = try!(__custom5(input, __tokens, __lookahead, __sym0, __sym1));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 20
-    //   Expression1 = r#"\\w+"# (*) [")"]
-    //   Expression1 = r#"\\w+"# (*) ["*"]
-    //
-    //   ")" -> Reduce(Expression1 = r#"\\w+"# => ActionFn(26);)
-    //   "*" -> Reduce(Expression1 = r#"\\w+"# => ActionFn(26);)
-    //
-    pub fn __state20<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action26(input, __sym0);
-                let __nt = __Nonterminal::Expression1((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 21
-    //   Expression1 = "wonky" Wonky (*) [EOF]
-    //   Expression1 = "wonky" Wonky (*) ["*"]
-    //
-    //   EOF -> Reduce(Expression1 = "wonky", Wonky => ActionFn(7);)
-    //   "*" -> Reduce(Expression1 = "wonky", Wonky => ActionFn(7);)
-    //
-    pub fn __state21<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action7(input, __sym0, __sym1);
-                let __nt = __Nonterminal::Expression1((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 22
-    //   Expression2 = Expression2 Expression2Op Expression1 (*) [EOF]
-    //   Expression2 = Expression2 Expression2Op Expression1 (*) ["*"]
-    //
-    //   EOF -> Reduce(Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);)
-    //   "*" -> Reduce(Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);)
-    //
-    pub fn __state22<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-        __sym2: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action28(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Expression2((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 23
-    //   Expression1 = "&" Maybe Expression1 (*) [EOF]
-    //   Expression1 = "&" Maybe Expression1 (*) ["*"]
-    //
-    //   EOF -> Reduce(Expression1 = "&", Maybe, Expression1 => ActionFn(27);)
-    //   "*" -> Reduce(Expression1 = "&", Maybe, Expression1 => ActionFn(27);)
-    //
-    pub fn __state23<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-        __sym2: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action27(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Expression1((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 24
-    //   Maybe = "[" "]" (*) ["&"]
-    //   Maybe = "[" "]" (*) ["("]
-    //   Maybe = "[" "]" (*) ["wacky"]
-    //   Maybe = "[" "]" (*) ["wonky"]
-    //   Maybe = "[" "]" (*) [r#"\\w+"#]
-    //
-    //   "&" -> Reduce(Maybe = "[", "]" => ActionFn(32);)
-    //   "(" -> Reduce(Maybe = "[", "]" => ActionFn(32);)
-    //   "wacky" -> Reduce(Maybe = "[", "]" => ActionFn(32);)
-    //   "wonky" -> Reduce(Maybe = "[", "]" => ActionFn(32);)
-    //   r#"\\w+"# -> Reduce(Maybe = "[", "]" => ActionFn(32);)
-    //
-    pub fn __state24<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            Some((_, (0, _), _)) |
-            Some((_, (1, _), _)) |
-            Some((_, (6, _), _)) |
-            Some((_, (7, _), _)) |
-            Some((_, (8, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action32(input, __sym0, __sym1);
-                let __nt = __Nonterminal::Maybe((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 25
-    //   Expression1 = (*) Wacky [")"]
-    //   Expression1 = (*) Wacky ["*"]
-    //   Expression1 = (*) "&" Maybe Expression1 [")"]
-    //   Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //   Expression1 = (*) "(" Expression2 ")" [")"]
-    //   Expression1 = (*) "(" Expression2 ")" ["*"]
-    //   Expression1 = (*) "wonky" Wonky [")"]
-    //   Expression1 = (*) "wonky" Wonky ["*"]
-    //   Expression1 = (*) r#"\\w+"# [")"]
-    //   Expression1 = (*) r#"\\w+"# ["*"]
-    //   Expression2 = Expression2 Expression2Op (*) Expression1 [")"]
-    //   Expression2 = Expression2 Expression2Op (*) Expression1 ["*"]
-    //   Wacky = (*) "wacky" [")"]
-    //   Wacky = (*) "wacky" ["*"]
+    //     Kind = None
+    //     AllInputs = [Expression2, Expression2Op]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expression2, Expression2Op]
+    //     WillPushLen = 1
+    //     WillPush = [Expression1]
+    //     WillProduce = Some(Expression2)
     //
-    //   "&" -> Shift(S16)
-    //   "(" -> Shift(S17)
-    //   "wacky" -> Shift(S18)
-    //   "wonky" -> Shift(S19)
-    //   r#"\\w+"# -> Shift(S20)
+    //     Expression1 = (*) Wacky [")"]
+    //     Expression1 = (*) Wacky ["*"]
+    //     Expression1 = (*) "&" Maybe Expression1 [")"]
+    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
+    //     Expression1 = (*) "(" Expression2 ")" [")"]
+    //     Expression1 = (*) "(" Expression2 ")" ["*"]
+    //     Expression1 = (*) "wonky" Wonky [")"]
+    //     Expression1 = (*) "wonky" Wonky ["*"]
+    //     Expression1 = (*) r#"\\w+"# [")"]
+    //     Expression1 = (*) r#"\\w+"# ["*"]
+    //     Expression2 = Expression2 Expression2Op (*) Expression1 [")"]
+    //     Expression2 = Expression2 Expression2Op (*) Expression1 ["*"]
+    //     Wacky = (*) "wacky" [")"]
+    //     Wacky = (*) "wacky" ["*"]
     //
-    //   Expression1 -> S30
-    //   Wacky -> S15
+    //     "&" -> Shift(S16)
+    //     "(" -> Shift(S17)
+    //     "wacky" -> Shift(S18)
+    //     "wonky" -> Shift(S19)
+    //     r#"\\w+"# -> Shift(S20)
+    //
+    //     Expression1 -> S30
+    //     Wacky -> S15
     pub fn __state25<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1547,31 +1053,31 @@ mod __parse__Expression2 {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state16(input, __tokens, __sym2));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state17(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state18(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(input, __tokens, __sym2));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state19(input, __tokens, __sym2));
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state20(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom3(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1580,98 +1086,55 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expression1(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state30(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Expression1(__sym2) => {
+                    __result = try!(__custom6(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
-                __Nonterminal::Wacky(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state15(input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Wacky(__sym2) => {
+                    __result = try!(__custom1(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
-    }
-
-    // State 26
-    //   Expression1 = "(" Expression2 ")" (*) [EOF]
-    //   Expression1 = "(" Expression2 ")" (*) ["*"]
-    //
-    //   EOF -> Reduce(Expression1 = "(", Expression2, ")" => ActionFn(25);)
-    //   "*" -> Reduce(Expression1 = "(", Expression2, ")" => ActionFn(25);)
-    //
-    pub fn __state26<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-        __sym2: &mut Option<(usize, &'input str, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action25(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Expression1((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
     }
 
     // State 27
-    //   Expression1 = (*) Wacky [")"]
-    //   Expression1 = (*) Wacky ["*"]
-    //   Expression1 = (*) "&" Maybe Expression1 [")"]
-    //   Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //   Expression1 = "&" Maybe (*) Expression1 [")"]
-    //   Expression1 = "&" Maybe (*) Expression1 ["*"]
-    //   Expression1 = (*) "(" Expression2 ")" [")"]
-    //   Expression1 = (*) "(" Expression2 ")" ["*"]
-    //   Expression1 = (*) "wonky" Wonky [")"]
-    //   Expression1 = (*) "wonky" Wonky ["*"]
-    //   Expression1 = (*) r#"\\w+"# [")"]
-    //   Expression1 = (*) r#"\\w+"# ["*"]
-    //   Wacky = (*) "wacky" [")"]
-    //   Wacky = (*) "wacky" ["*"]
+    //     Kind = None
+    //     AllInputs = ["&", Maybe]
+    //     OptionalInputs = []
+    //     FixedInputs = ["&", Maybe]
+    //     WillPushLen = 1
+    //     WillPush = [Expression1]
+    //     WillProduce = Some(Expression1)
     //
-    //   "&" -> Shift(S16)
-    //   "(" -> Shift(S17)
-    //   "wacky" -> Shift(S18)
-    //   "wonky" -> Shift(S19)
-    //   r#"\\w+"# -> Shift(S20)
+    //     Expression1 = (*) Wacky [")"]
+    //     Expression1 = (*) Wacky ["*"]
+    //     Expression1 = (*) "&" Maybe Expression1 [")"]
+    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
+    //     Expression1 = "&" Maybe (*) Expression1 [")"]
+    //     Expression1 = "&" Maybe (*) Expression1 ["*"]
+    //     Expression1 = (*) "(" Expression2 ")" [")"]
+    //     Expression1 = (*) "(" Expression2 ")" ["*"]
+    //     Expression1 = (*) "wonky" Wonky [")"]
+    //     Expression1 = (*) "wonky" Wonky ["*"]
+    //     Expression1 = (*) r#"\\w+"# [")"]
+    //     Expression1 = (*) r#"\\w+"# ["*"]
+    //     Wacky = (*) "wacky" [")"]
+    //     Wacky = (*) "wacky" ["*"]
     //
-    //   Expression1 -> S31
-    //   Wacky -> S15
+    //     "&" -> Shift(S16)
+    //     "(" -> Shift(S17)
+    //     "wacky" -> Shift(S18)
+    //     "wonky" -> Shift(S19)
+    //     r#"\\w+"# -> Shift(S20)
+    //
+    //     Expression1 -> S31
+    //     Wacky -> S15
     pub fn __state27<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1679,31 +1142,31 @@ mod __parse__Expression2 {
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state16(input, __tokens, __sym2));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state17(input, __tokens, __sym2));
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state18(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(input, __tokens, __sym2));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
                 __result = try!(__state19(input, __tokens, __sym2));
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state20(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom3(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1712,40 +1175,46 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expression1(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state31(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::Expression1(__sym2) => {
+                    __result = try!(__custom7(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
-                __Nonterminal::Wacky(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state15(input, __tokens, __lookahead, __sym2));
+                __Nonterminal::Wacky(__sym2) => {
+                    __result = try!(__custom1(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 28
-    //   Expression1 = "(" Expression2 (*) ")" [")"]
-    //   Expression1 = "(" Expression2 (*) ")" ["*"]
-    //   Expression2 = Expression2 (*) Expression2Op Expression1 [")"]
-    //   Expression2 = Expression2 (*) Expression2Op Expression1 ["*"]
-    //   Expression2Op = (*) "*" ["&"]
-    //   Expression2Op = (*) "*" ["("]
-    //   Expression2Op = (*) "*" ["wacky"]
-    //   Expression2Op = (*) "*" ["wonky"]
-    //   Expression2Op = (*) "*" [r#"\\w+"#]
+    //     Kind = None
+    //     AllInputs = ["(", Expression2]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expression2]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S32)
-    //   "*" -> Shift(S10)
+    //     Expression1 = "(" Expression2 (*) ")" [")"]
+    //     Expression1 = "(" Expression2 (*) ")" ["*"]
+    //     Expression2 = Expression2 (*) Expression2Op Expression1 [")"]
+    //     Expression2 = Expression2 (*) Expression2Op Expression1 ["*"]
+    //     Expression2Op = (*) "*" ["&"]
+    //     Expression2Op = (*) "*" ["("]
+    //     Expression2Op = (*) "*" ["wacky"]
+    //     Expression2Op = (*) "*" ["wonky"]
+    //     Expression2Op = (*) "*" [r#"\\w+"#]
     //
-    //   Expression2Op -> S25
+    //     ")" -> Shift(S32)
+    //     "*" -> Shift(S10)
+    //
+    //     Expression2Op -> S25
     pub fn __state28<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1754,18 +1223,20 @@ mod __parse__Expression2 {
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
         __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
+        __sym1: (usize, Box<Expr<'input>>, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
             Some((__loc1, (2, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state32(input, __tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom9(input, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state10(input, __tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom4(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1774,170 +1245,79 @@ mod __parse__Expression2 {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::Expression2Op(__nt) => {
-                    let __sym2 = &mut Some(__nt);
+                __Nonterminal::Expression2Op(__sym2) => {
                     __result = try!(__state25(input, __tokens, __lookahead, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
+    }
+
+    // Custom 0
+    //    Reduce Expression2 = Expression1 => ActionFn(29);
+    pub fn __custom0<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action29(input, __sym0);
+        let __nt = __Nonterminal::Expression2((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
         return Ok(__result);
     }
 
-    // State 29
-    //   Expression1 = "wonky" Wonky (*) [")"]
-    //   Expression1 = "wonky" Wonky (*) ["*"]
-    //
-    //   ")" -> Reduce(Expression1 = "wonky", Wonky => ActionFn(7);)
-    //   "*" -> Reduce(Expression1 = "wonky", Wonky => ActionFn(7);)
-    //
-    pub fn __state29<
+    // Custom 1
+    //    Reduce Expression1 = Wacky => ActionFn(8);
+    pub fn __custom1<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
         __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        match __lookahead {
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action7(input, __sym0, __sym1);
-                let __nt = __Nonterminal::Expression1((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action8(input, __sym0);
+        let __nt = __Nonterminal::Expression1((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 
-    // State 30
-    //   Expression2 = Expression2 Expression2Op Expression1 (*) [")"]
-    //   Expression2 = Expression2 Expression2Op Expression1 (*) ["*"]
-    //
-    //   ")" -> Reduce(Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);)
-    //   "*" -> Reduce(Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);)
-    //
-    pub fn __state30<
+    // Custom 2
+    //    Reduce Wacky = "wacky" => ActionFn(33);
+    pub fn __custom2<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
         input: &'input str,
         __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-        __sym2: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        match __lookahead {
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action28(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Expression2((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 31
-    //   Expression1 = "&" Maybe Expression1 (*) [")"]
-    //   Expression1 = "&" Maybe Expression1 (*) ["*"]
-    //
-    //   ")" -> Reduce(Expression1 = "&", Maybe, Expression1 => ActionFn(27);)
-    //   "*" -> Reduce(Expression1 = "&", Maybe, Expression1 => ActionFn(27);)
-    //
-    pub fn __state31<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-        __sym2: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        match __lookahead {
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action27(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Expression1((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 32
-    //   Expression1 = "(" Expression2 ")" (*) [")"]
-    //   Expression1 = "(" Expression2 ")" (*) ["*"]
-    //
-    //   ")" -> Reduce(Expression1 = "(", Expression2, ")" => ActionFn(25);)
-    //   "*" -> Reduce(Expression1 = "(", Expression2, ")" => ActionFn(25);)
-    //
-    pub fn __state32<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<(usize, &'input str, usize)>,
-        __sym1: &mut Option<(usize, Box<Expr<'input>>, usize)>,
-        __sym2: &mut Option<(usize, &'input str, usize)>,
+        __sym0: (usize, &'input str, usize),
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1946,29 +1326,215 @@ mod __parse__Expression2 {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        match __lookahead {
-            Some((_, (2, _), _)) |
-            Some((_, (3, _), _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action25(input, __sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::Expression1((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action33(input, __sym0);
+        let __nt = __Nonterminal::Wacky((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 3
+    //    Reduce Expression1 = r#"\\w+"# => ActionFn(26);
+    pub fn __custom3<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action26(input, __sym0);
+        let __nt = __Nonterminal::Expression1((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 4
+    //    Reduce Expression2Op = "*" => ActionFn(30);
+    pub fn __custom4<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action30(input, __sym0);
+        let __nt = __Nonterminal::Expression2Op((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 5
+    //    Reduce Expression1 = "wonky", Wonky => ActionFn(7);
+    pub fn __custom5<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = super::__action7(input, __sym0, __sym1);
+        let __nt = __Nonterminal::Expression1((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 6
+    //    Reduce Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
+    pub fn __custom6<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
+        __sym2: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action28(input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Expression2((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 7
+    //    Reduce Expression1 = "&", Maybe, Expression1 => ActionFn(27);
+    pub fn __custom7<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
+        __sym2: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action27(input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Expression1((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 8
+    //    Reduce Maybe = "[", "]" => ActionFn(32);
+    pub fn __custom8<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = super::__action32(input, __sym0, __sym1);
+        let __nt = __Nonterminal::Maybe((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 9
+    //    Reduce Expression1 = "(", Expression2, ")" => ActionFn(25);
+    pub fn __custom9<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
+        __sym2: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action25(input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Expression1((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__Expression2::parse_Expression2;

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -54,6 +54,9 @@ mod error;
 /// test for inlining expansion issue #55
 mod issue_55;
 
+/// test for unit action code
+mod unit;
+
 mod util;
 
 /// This constant is here so that some of the generator parsers can
@@ -188,6 +191,22 @@ fn expr_arena_test2() {
 }
 
 #[test]
+fn expr_arena_test3() {
+    use expr_arena_ast::*;
+    let arena = Arena::new();
+    let expected =
+        arena.alloc(
+            Node::Binary(Op::Mul,
+                         arena.alloc(Node::Value(22)),
+                         arena.alloc(Node::Paren(
+                             arena.alloc(
+                                 Node::Binary(Op::Sub,
+                                              arena.alloc(Node::Value(3)),
+                                              arena.alloc(Node::Value(6))))))));
+    util::test_loc(|v| expr_arena::parse_Expr(&arena, v), "22 * (3 - 6)", expected);
+}
+
+#[test]
 fn expr_generic_test1() {
     let expected: i32 = 22 * 3 - 6;
     let actual = expr_generic::parse_Expr::<i32>("22 * 3 - 6").unwrap();
@@ -261,3 +280,8 @@ fn issue_55_test1() {
     assert_eq!(c, vec!["X", "Y"]);
 }
 
+#[test]
+fn unit_test1() {
+    assert!(unit::parse_Expr("3 + 4 * 5").is_ok());
+    assert!(unit::parse_Expr("3 + +").is_err());
+}

--- a/lalrpop-test/src/sub.rs
+++ b/lalrpop-test/src/sub.rs
@@ -44,23 +44,31 @@ mod __parse__S {
     }
 
     // State 0
-    //   E = (*) E "-" T [EOF]
-    //   E = (*) E "-" T ["-"]
-    //   E = (*) T [EOF]
-    //   E = (*) T ["-"]
-    //   S = (*) E [EOF]
-    //   T = (*) "(" E ")" [EOF]
-    //   T = (*) "(" E ")" ["-"]
-    //   T = (*) Num [EOF]
-    //   T = (*) Num ["-"]
-    //   __S = (*) S [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     E = (*) E "-" T [EOF]
+    //     E = (*) E "-" T ["-"]
+    //     E = (*) T [EOF]
+    //     E = (*) T ["-"]
+    //     S = (*) E [EOF]
+    //     T = (*) "(" E ")" [EOF]
+    //     T = (*) "(" E ")" ["-"]
+    //     T = (*) Num [EOF]
+    //     T = (*) Num ["-"]
+    //     __S = (*) S [EOF]
     //
-    //   E -> S1
-    //   S -> S2
-    //   T -> S3
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     E -> S1
+    //     S -> S2
+    //     T -> S3
     pub fn __state0<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
@@ -71,12 +79,12 @@ mod __parse__S {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym0 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(__tokens, __sym0));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(__tokens, __sym0));
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(__tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -88,17 +96,14 @@ mod __parse__S {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::E(__nt) => {
-                    let __sym0 = &mut Some(__nt);
+                __Nonterminal::E(__sym0) => {
                     __result = try!(__state1(__tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::S(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state2(__tokens, __lookahead, __sym0));
+                __Nonterminal::S(__sym0) => {
+                    __result = try!(__custom0(__tokens, __lookahead, __sym0));
                 }
-                __Nonterminal::T(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state3(__tokens, __lookahead, __sym0));
+                __Nonterminal::T(__sym0) => {
+                    __result = try!(__custom1(__tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -108,29 +113,37 @@ mod __parse__S {
     }
 
     // State 1
-    //   E = E (*) "-" T [EOF]
-    //   E = E (*) "-" T ["-"]
-    //   S = E (*) [EOF]
+    //     Kind = None
+    //     AllInputs = [E]
+    //     OptionalInputs = []
+    //     FixedInputs = [E]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   EOF -> Reduce(S = E => ActionFn(1);)
-    //   "-" -> Shift(S6)
+    //     E = E (*) "-" T [EOF]
+    //     E = E (*) "-" T ["-"]
+    //     S = E (*) [EOF]
+    //
+    //     EOF -> Reduce(S = E => ActionFn(1);)
+    //     "-" -> Shift(S6)
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
+        __sym0: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state6(__tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             None => {
-                let __sym0 = __sym0.take().unwrap();
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action1(__sym0);
@@ -139,83 +152,8 @@ mod __parse__S {
                     __nt,
                     __end,
                 ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 2
-    //   __S = S (*) [EOF]
-    //
-    //   EOF -> Reduce(__S = S => ActionFn(0);)
-    //
-    pub fn __state2<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            None => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action0(__sym0);
-                let __nt = __Nonterminal::____S((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 3
-    //   E = T (*) [EOF]
-    //   E = T (*) ["-"]
-    //
-    //   EOF -> Reduce(E = T => ActionFn(3);)
-    //   "-" -> Reduce(E = T => ActionFn(3);)
-    //
-    pub fn __state3<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action3(__sym0);
-                let __nt = __Nonterminal::E((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -227,27 +165,35 @@ mod __parse__S {
     }
 
     // State 4
-    //   E = (*) E "-" T [")"]
-    //   E = (*) E "-" T ["-"]
-    //   E = (*) T [")"]
-    //   E = (*) T ["-"]
-    //   T = (*) "(" E ")" [")"]
-    //   T = (*) "(" E ")" ["-"]
-    //   T = "(" (*) E ")" [EOF]
-    //   T = "(" (*) E ")" ["-"]
-    //   T = (*) Num [")"]
-    //   T = (*) Num ["-"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [E, ")"]
+    //     WillProduce = Some(T)
     //
-    //   "(" -> Shift(S9)
-    //   Num -> Shift(S10)
+    //     E = (*) E "-" T [")"]
+    //     E = (*) E "-" T ["-"]
+    //     E = (*) T [")"]
+    //     E = (*) T ["-"]
+    //     T = (*) "(" E ")" [")"]
+    //     T = (*) "(" E ")" ["-"]
+    //     T = "(" (*) E ")" [EOF]
+    //     T = "(" (*) E ")" ["-"]
+    //     T = (*) Num [")"]
+    //     T = (*) Num ["-"]
     //
-    //   E -> S7
-    //   T -> S8
+    //     "(" -> Shift(S9)
+    //     Num -> Shift(S10)
+    //
+    //     E -> S7
+    //     T -> S8
     pub fn __state4<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
+        __sym0: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -256,14 +202,15 @@ mod __parse__S {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(__tokens, __sym1));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state10(__tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(__tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -272,86 +219,51 @@ mod __parse__S {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::E(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::E(__sym1) => {
                     __result = try!(__state7(__tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::T(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state8(__tokens, __lookahead, __sym1));
+                __Nonterminal::T(__sym1) => {
+                    __result = try!(__custom1(__tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 5
-    //   T = Num (*) [EOF]
-    //   T = Num (*) ["-"]
-    //
-    //   EOF -> Reduce(T = Num => ActionFn(4);)
-    //   "-" -> Reduce(T = Num => ActionFn(4);)
-    //
-    pub fn __state5<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            None |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action4(__sym0);
-                let __nt = __Nonterminal::T((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
             }
         }
     }
 
     // State 6
-    //   E = E "-" (*) T [EOF]
-    //   E = E "-" (*) T ["-"]
-    //   T = (*) "(" E ")" [EOF]
-    //   T = (*) "(" E ")" ["-"]
-    //   T = (*) Num [EOF]
-    //   T = (*) Num ["-"]
+    //     Kind = None
+    //     AllInputs = [E, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [E, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [T]
+    //     WillProduce = Some(E)
     //
-    //   "(" -> Shift(S4)
-    //   Num -> Shift(S5)
+    //     E = E "-" (*) T [EOF]
+    //     E = E "-" (*) T ["-"]
+    //     T = (*) "(" E ")" [EOF]
+    //     T = (*) "(" E ")" ["-"]
+    //     T = (*) Num [EOF]
+    //     T = (*) Num ["-"]
     //
-    //   T -> S11
+    //     "(" -> Shift(S4)
+    //     Num -> Shift(S5)
+    //
+    //     T -> S11
     pub fn __state6<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -362,12 +274,12 @@ mod __parse__S {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state4(__tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state5(__tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(__tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -376,29 +288,36 @@ mod __parse__S {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::T(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state11(__tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::T(__sym2) => {
+                    __result = try!(__custom3(__tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 7
-    //   E = E (*) "-" T [")"]
-    //   E = E (*) "-" T ["-"]
-    //   T = "(" E (*) ")" [EOF]
-    //   T = "(" E (*) ")" ["-"]
+    //     Kind = None
+    //     AllInputs = ["(", E]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [E]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S12)
-    //   "-" -> Shift(S13)
+    //     E = E (*) "-" T [")"]
+    //     E = E (*) "-" T ["-"]
+    //     T = "(" E (*) ")" [EOF]
+    //     T = "(" E (*) ")" ["-"]
+    //
+    //     ")" -> Shift(S12)
+    //     "-" -> Shift(S13)
     //
     pub fn __state7<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -406,58 +325,21 @@ mod __parse__S {
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), i32, ())>,
+        __sym1: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state12(__tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(__tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state13(__tokens, __sym1, __sym2));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 8
-    //   E = T (*) [")"]
-    //   E = T (*) ["-"]
-    //
-    //   ")" -> Reduce(E = T => ActionFn(3);)
-    //   "-" -> Reduce(E = T => ActionFn(3);)
-    //
-    pub fn __state8<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action3(__sym0);
-                let __nt = __Nonterminal::E((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -469,27 +351,35 @@ mod __parse__S {
     }
 
     // State 9
-    //   E = (*) E "-" T [")"]
-    //   E = (*) E "-" T ["-"]
-    //   E = (*) T [")"]
-    //   E = (*) T ["-"]
-    //   T = (*) "(" E ")" [")"]
-    //   T = (*) "(" E ")" ["-"]
-    //   T = "(" (*) E ")" [")"]
-    //   T = "(" (*) E ")" ["-"]
-    //   T = (*) Num [")"]
-    //   T = (*) Num ["-"]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [E, ")"]
+    //     WillProduce = Some(T)
     //
-    //   "(" -> Shift(S9)
-    //   Num -> Shift(S10)
+    //     E = (*) E "-" T [")"]
+    //     E = (*) E "-" T ["-"]
+    //     E = (*) T [")"]
+    //     E = (*) T ["-"]
+    //     T = (*) "(" E ")" [")"]
+    //     T = (*) "(" E ")" ["-"]
+    //     T = "(" (*) E ")" [")"]
+    //     T = "(" (*) E ")" ["-"]
+    //     T = (*) Num [")"]
+    //     T = (*) Num ["-"]
     //
-    //   E -> S14
-    //   T -> S8
+    //     "(" -> Shift(S9)
+    //     Num -> Shift(S10)
+    //
+    //     E -> S14
+    //     T -> S8
     pub fn __state9<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
+        __sym0: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -498,14 +388,15 @@ mod __parse__S {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
+        let __sym0 = &mut Some(__sym0);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym1 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(__tokens, __sym1));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state10(__tokens, __sym1));
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(__tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -514,176 +405,51 @@ mod __parse__S {
                 });
             }
         }
-        while __sym0.is_some() {
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::E(__nt) => {
-                    let __sym1 = &mut Some(__nt);
+                __Nonterminal::E(__sym1) => {
                     __result = try!(__state14(__tokens, __lookahead, __sym0, __sym1));
                 }
-                __Nonterminal::T(__nt) => {
-                    let __sym1 = &mut Some(__nt);
-                    __result = try!(__state8(__tokens, __lookahead, __sym1));
+                __Nonterminal::T(__sym1) => {
+                    __result = try!(__custom1(__tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
-            }
-        }
-        return Ok(__result);
-    }
-
-    // State 10
-    //   T = Num (*) [")"]
-    //   T = Num (*) ["-"]
-    //
-    //   ")" -> Reduce(T = Num => ActionFn(4);)
-    //   "-" -> Reduce(T = Num => ActionFn(4);)
-    //
-    pub fn __state10<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action4(__sym0);
-                let __nt = __Nonterminal::T((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 11
-    //   E = E "-" T (*) [EOF]
-    //   E = E "-" T (*) ["-"]
-    //
-    //   EOF -> Reduce(E = E, "-", T => ActionFn(2);)
-    //   "-" -> Reduce(E = E, "-", T => ActionFn(2);)
-    //
-    pub fn __state11<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            None |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action2(__sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::E((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
-    // State 12
-    //   T = "(" E ")" (*) [EOF]
-    //   T = "(" E ")" (*) ["-"]
-    //
-    //   EOF -> Reduce(T = "(", E, ")" => ActionFn(5);)
-    //   "-" -> Reduce(T = "(", E, ")" => ActionFn(5);)
-    //
-    pub fn __state12<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), i32, ())>,
-        __sym2: &mut Option<((), Tok, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        match __lookahead {
-            None |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(__sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::T((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
             }
         }
     }
 
     // State 13
-    //   E = E "-" (*) T [")"]
-    //   E = E "-" (*) T ["-"]
-    //   T = (*) "(" E ")" [")"]
-    //   T = (*) "(" E ")" ["-"]
-    //   T = (*) Num [")"]
-    //   T = (*) Num ["-"]
+    //     Kind = None
+    //     AllInputs = [E, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [E, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [T]
+    //     WillProduce = Some(E)
     //
-    //   "(" -> Shift(S9)
-    //   Num -> Shift(S10)
+    //     E = E "-" (*) T [")"]
+    //     E = E "-" (*) T ["-"]
+    //     T = (*) "(" E ")" [")"]
+    //     T = (*) "(" E ")" ["-"]
+    //     T = (*) Num [")"]
+    //     T = (*) Num ["-"]
     //
-    //   T -> S15
+    //     "(" -> Shift(S9)
+    //     Num -> Shift(S10)
+    //
+    //     T -> S15
     pub fn __state13<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -694,12 +460,12 @@ mod __parse__S {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state9(__tokens, __sym2));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok0), __loc2));
-                __result = try!(__state10(__tokens, __sym2));
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom2(__tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -708,29 +474,36 @@ mod __parse__S {
                 });
             }
         }
-        while __sym1.is_some() {
+        loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::T(__nt) => {
-                    let __sym2 = &mut Some(__nt);
-                    __result = try!(__state15(__tokens, __lookahead, __sym0, __sym1, __sym2));
+                __Nonterminal::T(__sym2) => {
+                    __result = try!(__custom3(__tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
                 }
             }
         }
-        return Ok(__result);
     }
 
     // State 14
-    //   E = E (*) "-" T [")"]
-    //   E = E (*) "-" T ["-"]
-    //   T = "(" E (*) ")" [")"]
-    //   T = "(" E (*) ")" ["-"]
+    //     Kind = None
+    //     AllInputs = ["(", E]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [E]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
     //
-    //   ")" -> Shift(S16)
-    //   "-" -> Shift(S13)
+    //     E = E (*) "-" T [")"]
+    //     E = E (*) "-" T ["-"]
+    //     T = "(" E (*) ")" [")"]
+    //     T = "(" E (*) ")" ["-"]
+    //
+    //     ")" -> Shift(S16)
+    //     "-" -> Shift(S13)
     //
     pub fn __state14<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -738,18 +511,21 @@ mod __parse__S {
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), i32, ())>,
+        __sym1: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state16(__tokens, __sym0, __sym1, __sym2));
+                let __sym2 = (__loc1, (__tok), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(__tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
-                let mut __sym2 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym2 = (__loc1, (__tok), __loc2);
                 __result = try!(__state13(__tokens, __sym1, __sym2));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -758,66 +534,61 @@ mod __parse__S {
                 });
             }
         }
-        return Ok(__result);
     }
 
-    // State 15
-    //   E = E "-" T (*) [")"]
-    //   E = E "-" T (*) ["-"]
-    //
-    //   ")" -> Reduce(E = E, "-", T => ActionFn(2);)
-    //   "-" -> Reduce(E = E, "-", T => ActionFn(2);)
-    //
-    pub fn __state15<
+    // Custom 0
+    //    Reduce __S = S => ActionFn(0);
+    pub fn __custom0<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
-        __sym2: &mut Option<((), i32, ())>,
+        __sym0: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action2(__sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::E((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action0(__sym0);
+        let __nt = __Nonterminal::____S((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 
-    // State 16
-    //   T = "(" E ")" (*) [")"]
-    //   T = "(" E ")" (*) ["-"]
-    //
-    //   ")" -> Reduce(T = "(", E, ")" => ActionFn(5);)
-    //   "-" -> Reduce(T = "(", E, ")" => ActionFn(5);)
-    //
-    pub fn __state16<
+    // Custom 1
+    //    Reduce E = T => ActionFn(3);
+    pub fn __custom1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), i32, ())>,
-        __sym2: &mut Option<((), Tok, ())>,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action3(__sym0);
+        let __nt = __Nonterminal::E((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 2
+    //    Reduce T = Num => ActionFn(4);
+    pub fn __custom2<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __sym0: ((), i32, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -826,29 +597,70 @@ mod __parse__S {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        match __lookahead {
-            Some((_, Tok::RParen, _)) |
-            Some((_, Tok::Minus, _)) => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __sym2 = __sym2.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym2.2.clone();
-                let __nt = super::__action5(__sym0, __sym1, __sym2);
-                let __nt = __Nonterminal::T((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action4(__sym0);
+        let __nt = __Nonterminal::T((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 3
+    //    Reduce E = E, "-", T => ActionFn(2);
+    pub fn __custom3<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
+        __sym2: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action2(__sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::E((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 4
+    //    Reduce T = "(", E, ")" => ActionFn(5);
+    pub fn __custom4<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __sym0: ((), Tok, ()),
+        __sym1: ((), i32, ()),
+        __sym2: ((), Tok, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action5(__sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::T((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__S::parse_S;

--- a/lalrpop-test/src/unit.lalrpop
+++ b/lalrpop-test/src/unit.lalrpop
@@ -1,0 +1,22 @@
+grammar;
+
+// Test that, as long as all nonterminals have type unit, we don't
+// need to write any action code, because the lowering will supply
+// `()` as the action. This is handy when building up a grammar.
+
+pub Expr: () = {
+    Expr "-" Factor,
+    Expr "+" Factor,
+    Factor,
+};
+
+Factor: () = {
+    Factor "*" Term,
+    Factor "/" Term,
+    Term,
+};
+
+Term: () = {
+    r"\d+",
+    "(" Expr ")",
+};

--- a/lalrpop-test/src/unit.rs
+++ b/lalrpop-test/src/unit.rs
@@ -1,0 +1,2876 @@
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+extern crate lalrpop_util as __lalrpop_util;
+use self::__lalrpop_util::ParseError as __ParseError;
+
+mod __parse__Expr {
+    #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
+
+    extern crate lalrpop_util as __lalrpop_util;
+    use self::__lalrpop_util::ParseError as __ParseError;
+    pub fn parse_Expr<
+        'input,
+    >(
+        input: &'input str,
+    ) -> Result<(), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __tokens = super::__intern_token::__Matcher::new(input);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match try!(__state0(input, &mut __tokens, __lookahead)) {
+            (Some(__lookahead), _) => {
+                Err(__ParseError::ExtraToken { token: __lookahead })
+            }
+            (None, __Nonterminal::____Expr((_, __nt, _))) => {
+                Ok(__nt)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub enum __Nonterminal<> {
+        Expr((usize, (), usize)),
+        Factor((usize, (), usize)),
+        Term((usize, (), usize)),
+        ____Expr((usize, (), usize)),
+    }
+
+    // State 0
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
+    //
+    //     Expr = (*) Expr "+" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [EOF]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //     __Expr = (*) Expr [EOF]
+    //
+    //     "(" -> Shift(S4)
+    //     r#"\\d+"# -> Shift(S5)
+    //
+    //     Expr -> S1
+    //     Factor -> S2
+    //     Term -> S3
+    pub fn __state0<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state4(input, __tokens, __sym0));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym0 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym0));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Expr(__sym0) => {
+                    __result = try!(__state1(input, __tokens, __lookahead, __sym0));
+                }
+                __Nonterminal::Factor(__sym0) => {
+                    __result = try!(__state2(input, __tokens, __lookahead, __sym0));
+                }
+                __Nonterminal::Term(__sym0) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym0));
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 1
+    //     Kind = None
+    //     AllInputs = [Expr]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
+    //
+    //     Expr = Expr (*) "+" Factor [EOF]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [EOF]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     __Expr = Expr (*) [EOF]
+    //
+    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
+    //     "+" -> Shift(S6)
+    //     "-" -> Shift(S7)
+    //
+    pub fn __state1<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((__loc1, (3, __tok0), __loc2)) => {
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state6(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
+            }
+            Some((__loc1, (4, __tok0), __loc2)) => {
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state7(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
+            }
+            None => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action0(input, __sym0);
+                let __nt = __Nonterminal::____Expr((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 2
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
+    //
+    //     Expr = Factor (*) [EOF]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S9)
+    //
+    pub fn __state2<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((__loc1, (2, __tok0), __loc2)) => {
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state8(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
+            }
+            Some((__loc1, (5, __tok0), __loc2)) => {
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state9(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
+            }
+            None |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action3(input, __sym0);
+                let __nt = __Nonterminal::Expr((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 4
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
+    //
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [EOF]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [")"]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //
+    //     "(" -> Shift(S13)
+    //     r#"\\d+"# -> Shift(S14)
+    //
+    //     Expr -> S10
+    //     Factor -> S11
+    //     Term -> S12
+    pub fn __state4<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __sym0 = &mut Some(__sym0);
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state13(input, __tokens, __sym1));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym1));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Expr(__sym1) => {
+                    __result = try!(__state10(input, __tokens, __lookahead, __sym0, __sym1));
+                }
+                __Nonterminal::Factor(__sym1) => {
+                    __result = try!(__state11(input, __tokens, __lookahead, __sym1));
+                }
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 6
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
+    //
+    //     Expr = Expr "+" (*) Factor [EOF]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [EOF]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //
+    //     "(" -> Shift(S4)
+    //     r#"\\d+"# -> Shift(S5)
+    //
+    //     Factor -> S15
+    //     Term -> S3
+    pub fn __state6<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state4(input, __tokens, __sym2));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Factor(__sym2) => {
+                    __result = try!(__state15(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                }
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 7
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
+    //
+    //     Expr = Expr "-" (*) Factor [EOF]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [EOF]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [EOF]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //
+    //     "(" -> Shift(S4)
+    //     r#"\\d+"# -> Shift(S5)
+    //
+    //     Factor -> S16
+    //     Term -> S3
+    pub fn __state7<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state4(input, __tokens, __sym2));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Factor(__sym2) => {
+                    __result = try!(__state16(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                }
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 8
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" (*) Term [EOF]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [EOF]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //
+    //     "(" -> Shift(S4)
+    //     r#"\\d+"# -> Shift(S5)
+    //
+    //     Term -> S17
+    pub fn __state8<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state4(input, __tokens, __sym2));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom2(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 9
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" (*) Term [EOF]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [EOF]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //
+    //     "(" -> Shift(S4)
+    //     r#"\\d+"# -> Shift(S5)
+    //
+    //     Term -> S18
+    pub fn __state9<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state4(input, __tokens, __sym2));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 10
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
+    //
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [EOF]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S19)
+    //     "+" -> Shift(S20)
+    //     "-" -> Shift(S21)
+    //
+    pub fn __state10<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym1: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((__loc1, (1, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(input, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
+            }
+            Some((__loc1, (3, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state20(input, __tokens, __sym1, __sym2));
+                return Ok(__result);
+            }
+            Some((__loc1, (4, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state21(input, __tokens, __sym1, __sym2));
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 11
+    //     Kind = None
+    //     AllInputs = [Factor]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
+    //
+    //     Expr = Factor (*) [")"]
+    //     Expr = Factor (*) ["+"]
+    //     Expr = Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "*" -> Shift(S22)
+    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
+    //     "/" -> Shift(S23)
+    //
+    pub fn __state11<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((__loc1, (2, __tok0), __loc2)) => {
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state22(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
+            }
+            Some((__loc1, (5, __tok0), __loc2)) => {
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state23(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
+            }
+            Some((_, (1, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action3(input, __sym0);
+                let __nt = __Nonterminal::Expr((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 13
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 2
+    //     WillPush = [Expr, ")"]
+    //     WillProduce = Some(Term)
+    //
+    //     Expr = (*) Expr "+" Factor [")"]
+    //     Expr = (*) Expr "+" Factor ["+"]
+    //     Expr = (*) Expr "+" Factor ["-"]
+    //     Expr = (*) Expr "-" Factor [")"]
+    //     Expr = (*) Expr "-" Factor ["+"]
+    //     Expr = (*) Expr "-" Factor ["-"]
+    //     Expr = (*) Factor [")"]
+    //     Expr = (*) Factor ["+"]
+    //     Expr = (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")"]
+    //     Term = "(" (*) Expr ")" ["*"]
+    //     Term = "(" (*) Expr ")" ["+"]
+    //     Term = "(" (*) Expr ")" ["-"]
+    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [")"]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //
+    //     "(" -> Shift(S13)
+    //     r#"\\d+"# -> Shift(S14)
+    //
+    //     Expr -> S24
+    //     Factor -> S11
+    //     Term -> S12
+    pub fn __state13<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __sym0 = &mut Some(__sym0);
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state13(input, __tokens, __sym1));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym1 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym1));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            if __sym0.is_none() {
+                return Ok(__result);
+            }
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Expr(__sym1) => {
+                    __result = try!(__state24(input, __tokens, __lookahead, __sym0, __sym1));
+                }
+                __Nonterminal::Factor(__sym1) => {
+                    __result = try!(__state11(input, __tokens, __lookahead, __sym1));
+                }
+                __Nonterminal::Term(__sym1) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 15
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
+    //
+    //     Expr = Expr "+" Factor (*) [EOF]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S9)
+    //
+    pub fn __state15<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: &mut Option<(usize, (), usize)>,
+        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym2: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((__loc1, (2, __tok0), __loc2)) => {
+                let __sym3 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state8(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
+            }
+            Some((__loc1, (5, __tok0), __loc2)) => {
+                let __sym3 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state9(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
+            }
+            None |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) => {
+                let __sym0 = __sym0.take().unwrap();
+                let __sym1 = __sym1.take().unwrap();
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action2(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Expr((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 16
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
+    //
+    //     Expr = Expr "-" Factor (*) [EOF]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [EOF]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [EOF]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S8)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S9)
+    //
+    pub fn __state16<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: &mut Option<(usize, (), usize)>,
+        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym2: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((__loc1, (2, __tok0), __loc2)) => {
+                let __sym3 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state8(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
+            }
+            Some((__loc1, (5, __tok0), __loc2)) => {
+                let __sym3 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state9(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
+            }
+            None |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) => {
+                let __sym0 = __sym0.take().unwrap();
+                let __sym1 = __sym1.take().unwrap();
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action1(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Expr((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 20
+    //     Kind = None
+    //     AllInputs = [Expr, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "+"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
+    //
+    //     Expr = Expr "+" (*) Factor [")"]
+    //     Expr = Expr "+" (*) Factor ["+"]
+    //     Expr = Expr "+" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [")"]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //
+    //     "(" -> Shift(S13)
+    //     r#"\\d+"# -> Shift(S14)
+    //
+    //     Factor -> S25
+    //     Term -> S12
+    pub fn __state20<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state13(input, __tokens, __sym2));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Factor(__sym2) => {
+                    __result = try!(__state25(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                }
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 21
+    //     Kind = None
+    //     AllInputs = [Expr, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, "-"]
+    //     WillPushLen = 1
+    //     WillPush = [Factor]
+    //     WillProduce = Some(Expr)
+    //
+    //     Expr = Expr "-" (*) Factor [")"]
+    //     Expr = Expr "-" (*) Factor ["+"]
+    //     Expr = Expr "-" (*) Factor ["-"]
+    //     Factor = (*) Factor "*" Term [")"]
+    //     Factor = (*) Factor "*" Term ["*"]
+    //     Factor = (*) Factor "*" Term ["+"]
+    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["/"]
+    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term ["*"]
+    //     Factor = (*) Factor "/" Term ["+"]
+    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["/"]
+    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term ["*"]
+    //     Factor = (*) Term ["+"]
+    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [")"]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //
+    //     "(" -> Shift(S13)
+    //     r#"\\d+"# -> Shift(S14)
+    //
+    //     Factor -> S26
+    //     Term -> S12
+    pub fn __state21<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __sym0 = &mut Some(__sym0);
+        let __sym1 = &mut Some(__sym1);
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state13(input, __tokens, __sym2));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            if __sym1.is_none() {
+                return Ok(__result);
+            }
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Factor(__sym2) => {
+                    __result = try!(__state26(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                }
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 22
+    //     Kind = None
+    //     AllInputs = [Factor, "*"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" (*) Term [")"]
+    //     Factor = Factor "*" (*) Term ["*"]
+    //     Factor = Factor "*" (*) Term ["+"]
+    //     Factor = Factor "*" (*) Term ["-"]
+    //     Factor = Factor "*" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [")"]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //
+    //     "(" -> Shift(S13)
+    //     r#"\\d+"# -> Shift(S14)
+    //
+    //     Term -> S27
+    pub fn __state22<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state13(input, __tokens, __sym2));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom2(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 23
+    //     Kind = None
+    //     AllInputs = [Factor, "/"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/"]
+    //     WillPushLen = 1
+    //     WillPush = [Term]
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" (*) Term [")"]
+    //     Factor = Factor "/" (*) Term ["*"]
+    //     Factor = Factor "/" (*) Term ["+"]
+    //     Factor = Factor "/" (*) Term ["-"]
+    //     Factor = Factor "/" (*) Term ["/"]
+    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" ["*"]
+    //     Term = (*) "(" Expr ")" ["+"]
+    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) r#"\\d+"# [")"]
+    //     Term = (*) r#"\\d+"# ["*"]
+    //     Term = (*) r#"\\d+"# ["+"]
+    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["/"]
+    //
+    //     "(" -> Shift(S13)
+    //     r#"\\d+"# -> Shift(S14)
+    //
+    //     Term -> S28
+    pub fn __state23<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((__loc1, (0, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state13(input, __tokens, __sym2));
+            }
+            Some((__loc1, (6, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__custom1(input, __tokens, __sym2));
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+        loop {
+            let (__lookahead, __nt) = __result;
+            match __nt {
+                __Nonterminal::Term(__sym2) => {
+                    __result = try!(__custom3(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    return Ok(__result);
+                }
+                _ => {
+                    return Ok((__lookahead, __nt));
+                }
+            }
+        }
+    }
+
+    // State 24
+    //     Kind = None
+    //     AllInputs = ["(", Expr]
+    //     OptionalInputs = ["("]
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = None
+    //
+    //     Expr = Expr (*) "+" Factor [")"]
+    //     Expr = Expr (*) "+" Factor ["+"]
+    //     Expr = Expr (*) "+" Factor ["-"]
+    //     Expr = Expr (*) "-" Factor [")"]
+    //     Expr = Expr (*) "-" Factor ["+"]
+    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Term = "(" Expr (*) ")" [")"]
+    //     Term = "(" Expr (*) ")" ["*"]
+    //     Term = "(" Expr (*) ")" ["+"]
+    //     Term = "(" Expr (*) ")" ["-"]
+    //     Term = "(" Expr (*) ")" ["/"]
+    //
+    //     ")" -> Shift(S29)
+    //     "+" -> Shift(S20)
+    //     "-" -> Shift(S21)
+    //
+    pub fn __state24<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: &mut Option<(usize, &'input str, usize)>,
+        __sym1: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((__loc1, (1, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                let __sym0 = __sym0.take().unwrap();
+                __result = try!(__custom4(input, __tokens, __sym0, __sym1, __sym2));
+                return Ok(__result);
+            }
+            Some((__loc1, (3, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state20(input, __tokens, __sym1, __sym2));
+                return Ok(__result);
+            }
+            Some((__loc1, (4, __tok0), __loc2)) => {
+                let __sym2 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state21(input, __tokens, __sym1, __sym2));
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 25
+    //     Kind = None
+    //     AllInputs = [Expr, "+", Factor]
+    //     OptionalInputs = [Expr, "+"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
+    //
+    //     Expr = Expr "+" Factor (*) [")"]
+    //     Expr = Expr "+" Factor (*) ["+"]
+    //     Expr = Expr "+" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "*" -> Shift(S22)
+    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
+    //     "/" -> Shift(S23)
+    //
+    pub fn __state25<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: &mut Option<(usize, (), usize)>,
+        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym2: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((__loc1, (2, __tok0), __loc2)) => {
+                let __sym3 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state22(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
+            }
+            Some((__loc1, (5, __tok0), __loc2)) => {
+                let __sym3 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state23(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
+            }
+            Some((_, (1, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) => {
+                let __sym0 = __sym0.take().unwrap();
+                let __sym1 = __sym1.take().unwrap();
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action2(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Expr((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 26
+    //     Kind = None
+    //     AllInputs = [Expr, "-", Factor]
+    //     OptionalInputs = [Expr, "-"]
+    //     FixedInputs = [Factor]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
+    //
+    //     Expr = Expr "-" Factor (*) [")"]
+    //     Expr = Expr "-" Factor (*) ["+"]
+    //     Expr = Expr "-" Factor (*) ["-"]
+    //     Factor = Factor (*) "*" Term [")"]
+    //     Factor = Factor (*) "*" Term ["*"]
+    //     Factor = Factor (*) "*" Term ["+"]
+    //     Factor = Factor (*) "*" Term ["-"]
+    //     Factor = Factor (*) "*" Term ["/"]
+    //     Factor = Factor (*) "/" Term [")"]
+    //     Factor = Factor (*) "/" Term ["*"]
+    //     Factor = Factor (*) "/" Term ["+"]
+    //     Factor = Factor (*) "/" Term ["-"]
+    //     Factor = Factor (*) "/" Term ["/"]
+    //
+    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "*" -> Shift(S22)
+    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
+    //     "/" -> Shift(S23)
+    //
+    pub fn __state26<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: &mut Option<(usize, (), usize)>,
+        __sym1: &mut Option<(usize, &'input str, usize)>,
+        __sym2: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((__loc1, (2, __tok0), __loc2)) => {
+                let __sym3 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state22(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
+            }
+            Some((__loc1, (5, __tok0), __loc2)) => {
+                let __sym3 = (__loc1, (__tok0), __loc2);
+                __result = try!(__state23(input, __tokens, __sym2, __sym3));
+                return Ok(__result);
+            }
+            Some((_, (1, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) => {
+                let __sym0 = __sym0.take().unwrap();
+                let __sym1 = __sym1.take().unwrap();
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action1(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Expr((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // Custom 0
+    //    Reduce Factor = Term => ActionFn(6);
+    pub fn __custom0<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action6(input, __sym0);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 1
+    //    Reduce Term = r#"\\d+"# => ActionFn(7);
+    pub fn __custom1<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action7(input, __sym0);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 2
+    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
+    pub fn __custom2<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action4(input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 3
+    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
+    pub fn __custom3<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action5(input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Factor((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 4
+    //    Reduce Term = "(", Expr, ")" => ActionFn(8);
+    pub fn __custom4<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, (), usize),
+        __sym2: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        let __start = __sym0.0.clone();
+        let __end = __sym2.2.clone();
+        let __nt = super::__action8(input, __sym0, __sym1, __sym2);
+        let __nt = __Nonterminal::Term((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+}
+pub use self::__parse__Expr::parse_Expr;
+mod __intern_token {
+    extern crate lalrpop_util as __lalrpop_util;
+    use self::__lalrpop_util::ParseError as __ParseError;
+    pub struct __Matcher<'input> {
+        text: &'input str,
+        consumed: usize,
+    }
+
+    fn __tokenize(text: &str) -> Option<(usize, usize)> {
+        let mut __chars = text.char_indices();
+        let mut __current_match: Option<(usize, usize)> = None;
+        let mut __current_state: usize = 0;
+        loop {
+            match __current_state {
+                0 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        40 => /* '(' */ {
+                            __current_match = Some((0, __index + 1));
+                            __current_state = 1;
+                            continue;
+                        }
+                        41 => /* ')' */ {
+                            __current_match = Some((1, __index + 1));
+                            __current_state = 2;
+                            continue;
+                        }
+                        42 => /* '*' */ {
+                            __current_match = Some((2, __index + 1));
+                            __current_state = 3;
+                            continue;
+                        }
+                        43 => /* '+' */ {
+                            __current_match = Some((3, __index + 1));
+                            __current_state = 4;
+                            continue;
+                        }
+                        45 => /* '-' */ {
+                            __current_match = Some((4, __index + 1));
+                            __current_state = 5;
+                            continue;
+                        }
+                        47 => /* '/' */ {
+                            __current_match = Some((5, __index + 1));
+                            __current_state = 6;
+                            continue;
+                        }
+                        48 ... 57 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        1632 ... 1641 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        1776 ... 1785 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        1984 ... 1993 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        2406 ... 2415 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        2534 ... 2543 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        2662 ... 2671 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        2790 ... 2799 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        2918 ... 2927 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        3046 ... 3055 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        3174 ... 3183 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        3302 ... 3311 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        3430 ... 3439 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        3558 ... 3567 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        3664 ... 3673 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        3792 ... 3801 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        3872 ... 3881 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        4160 ... 4169 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        4240 ... 4249 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        6112 ... 6121 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        6160 ... 6169 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        6470 ... 6479 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        6608 ... 6617 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        6784 ... 6793 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        6800 ... 6809 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        6992 ... 7001 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        7088 ... 7097 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        7232 ... 7241 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        7248 ... 7257 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        42528 ... 42537 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        43216 ... 43225 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        43264 ... 43273 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        43472 ... 43481 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        43504 ... 43513 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        43600 ... 43609 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        44016 ... 44025 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        65296 ... 65305 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        66720 ... 66729 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        69734 ... 69743 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        69872 ... 69881 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        69942 ... 69951 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        70096 ... 70105 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        70384 ... 70393 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        70864 ... 70873 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        71248 ... 71257 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        71360 ... 71369 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        71472 ... 71481 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        71904 ... 71913 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        92768 ... 92777 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        93008 ... 93017 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        120782 ... 120831 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 7;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                1 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                2 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                3 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                4 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                5 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                6 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                7 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        1632 ... 1641 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        1776 ... 1785 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        1984 ... 1993 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        2406 ... 2415 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        2534 ... 2543 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        2662 ... 2671 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        2790 ... 2799 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        2918 ... 2927 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3046 ... 3055 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3174 ... 3183 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3302 ... 3311 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3430 ... 3439 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3558 ... 3567 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3664 ... 3673 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3792 ... 3801 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3872 ... 3881 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        4160 ... 4169 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        4240 ... 4249 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6112 ... 6121 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6160 ... 6169 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6470 ... 6479 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6608 ... 6617 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6784 ... 6793 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6800 ... 6809 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6992 ... 7001 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        7088 ... 7097 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        7232 ... 7241 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        7248 ... 7257 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        42528 ... 42537 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        43216 ... 43225 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        43264 ... 43273 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        43472 ... 43481 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        43504 ... 43513 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        43600 ... 43609 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        44016 ... 44025 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        65296 ... 65305 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        66720 ... 66729 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        69734 ... 69743 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        69872 ... 69881 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        69942 ... 69951 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        70096 ... 70105 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        70384 ... 70393 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        70864 ... 70873 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        71248 ... 71257 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        71360 ... 71369 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        71472 ... 71481 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        71904 ... 71913 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        92768 ... 92777 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        93008 ... 93017 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        120782 ... 120831 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                8 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                9 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        1632 ... 1641 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        1776 ... 1785 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        1984 ... 1993 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        2406 ... 2415 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        2534 ... 2543 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        2662 ... 2671 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        2790 ... 2799 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        2918 ... 2927 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3046 ... 3055 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3174 ... 3183 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3302 ... 3311 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3430 ... 3439 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3558 ... 3567 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3664 ... 3673 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3792 ... 3801 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        3872 ... 3881 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        4160 ... 4169 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        4240 ... 4249 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6112 ... 6121 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6160 ... 6169 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6470 ... 6479 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6608 ... 6617 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6784 ... 6793 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6800 ... 6809 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        6992 ... 7001 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        7088 ... 7097 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        7232 ... 7241 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        7248 ... 7257 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        42528 ... 42537 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        43216 ... 43225 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        43264 ... 43273 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        43472 ... 43481 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        43504 ... 43513 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        43600 ... 43609 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        44016 ... 44025 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        65296 ... 65305 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        66720 ... 66729 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        69734 ... 69743 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        69872 ... 69881 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        69942 ... 69951 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        70096 ... 70105 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        70384 ... 70393 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        70864 ... 70873 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        71248 ... 71257 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        71360 ... 71369 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        71472 ... 71481 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        71904 ... 71913 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        92768 ... 92777 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        93008 ... 93017 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        120782 ... 120831 => {
+                            __current_match = Some((6, __index + __ch.len_utf8()));
+                            __current_state = 9;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                _ => { panic!("invalid state {}", __current_state); }
+            }
+        }
+    }
+
+    impl<'input> __Matcher<'input> {
+        pub fn new(s: &'input str) -> __Matcher<'input> {
+            __Matcher { text: s, consumed: 0 }
+        }
+    }
+
+    impl<'input> Iterator for __Matcher<'input> {
+        type Item = Result<(usize, (usize, &'input str), usize), __ParseError<usize,(usize, &'input str),()>>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let __text = self.text.trim_left();
+            let __whitespace = self.text.len() - __text.len();
+            let __start_offset = self.consumed + __whitespace;
+            if __text.is_empty() {
+                self.text = __text;
+                self.consumed = __start_offset;
+                None
+            } else {
+                match __tokenize(__text) {
+                    Some((__index, __length)) => {
+                        let __result = &__text[..__length];
+                        let __remaining = &__text[__length..];
+                        let __end_offset = __start_offset + __length;
+                        self.text = __remaining;
+                        self.consumed = __end_offset;
+                        Some(Ok((__start_offset, (__index, __result), __end_offset)))
+                    }
+                    None => {
+                        Some(Err(__ParseError::InvalidToken { location: __start_offset }))
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn __action0<
+    'input,
+>(
+    input: &'input str,
+    (_, __0, _): (usize, (), usize),
+) -> ()
+{
+    ()
+}
+
+pub fn __action1<
+    'input,
+>(
+    input: &'input str,
+    (_, __0, _): (usize, (), usize),
+    (_, __1, _): (usize, &'input str, usize),
+    (_, __2, _): (usize, (), usize),
+) -> ()
+{
+    ()
+}
+
+pub fn __action2<
+    'input,
+>(
+    input: &'input str,
+    (_, __0, _): (usize, (), usize),
+    (_, __1, _): (usize, &'input str, usize),
+    (_, __2, _): (usize, (), usize),
+) -> ()
+{
+    ()
+}
+
+pub fn __action3<
+    'input,
+>(
+    input: &'input str,
+    (_, __0, _): (usize, (), usize),
+) -> ()
+{
+    ()
+}
+
+pub fn __action4<
+    'input,
+>(
+    input: &'input str,
+    (_, __0, _): (usize, (), usize),
+    (_, __1, _): (usize, &'input str, usize),
+    (_, __2, _): (usize, (), usize),
+) -> ()
+{
+    ()
+}
+
+pub fn __action5<
+    'input,
+>(
+    input: &'input str,
+    (_, __0, _): (usize, (), usize),
+    (_, __1, _): (usize, &'input str, usize),
+    (_, __2, _): (usize, (), usize),
+) -> ()
+{
+    ()
+}
+
+pub fn __action6<
+    'input,
+>(
+    input: &'input str,
+    (_, __0, _): (usize, (), usize),
+) -> ()
+{
+    ()
+}
+
+pub fn __action7<
+    'input,
+>(
+    input: &'input str,
+    (_, __0, _): (usize, &'input str, usize),
+) -> ()
+{
+    ()
+}
+
+pub fn __action8<
+    'input,
+>(
+    input: &'input str,
+    (_, __0, _): (usize, &'input str, usize),
+    (_, __1, _): (usize, (), usize),
+    (_, __2, _): (usize, &'input str, usize),
+) -> ()
+{
+    ()
+}
+
+pub trait __ToTriple<'input, > {
+    type Error;
+    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),Self::Error>;
+}
+
+impl<'input, > __ToTriple<'input, > for (usize, (usize, &'input str), usize) {
+    type Error = ();
+    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),()> {
+        Ok(value)
+    }
+}
+impl<'input, > __ToTriple<'input, > for Result<(usize, (usize, &'input str), usize),()> {
+    type Error = ();
+    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),()> {
+        value
+    }
+}

--- a/lalrpop-test/src/use_super.rs
+++ b/lalrpop-test/src/use_super.rs
@@ -42,12 +42,20 @@ mod __parse__S {
     }
 
     // State 0
-    //   S = (*) "(" ")" [EOF]
-    //   __S = (*) S [EOF]
+    //     Kind = None
+    //     AllInputs = []
+    //     OptionalInputs = []
+    //     FixedInputs = []
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = None
     //
-    //   "(" -> Shift(S2)
+    //     S = (*) "(" ")" [EOF]
+    //     __S = (*) S [EOF]
     //
-    //   S -> S1
+    //     "(" -> Shift(S2)
+    //
+    //     S -> S1
     pub fn __state0<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
@@ -58,7 +66,7 @@ mod __parse__S {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
-                let mut __sym0 = &mut Some((__loc1, (__tok), __loc2));
+                let __sym0 = (__loc1, (__tok), __loc2);
                 __result = try!(__state2(__tokens, __sym0));
             }
             _ => {
@@ -71,9 +79,8 @@ mod __parse__S {
         loop {
             let (__lookahead, __nt) = __result;
             match __nt {
-                __Nonterminal::S(__nt) => {
-                    let __sym0 = &mut Some(__nt);
-                    __result = try!(__state1(__tokens, __lookahead, __sym0));
+                __Nonterminal::S(__sym0) => {
+                    __result = try!(__custom0(__tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -82,52 +89,24 @@ mod __parse__S {
         }
     }
 
-    // State 1
-    //   __S = S (*) [EOF]
-    //
-    //   EOF -> Reduce(__S = S => ActionFn(0);)
-    //
-    pub fn __state1<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: &mut Option<((), i32, ())>,
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        match __lookahead {
-            None => {
-                let __sym0 = __sym0.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym0.2.clone();
-                let __nt = super::__action0(__sym0);
-                let __nt = __Nonterminal::____S((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
-    }
-
     // State 2
-    //   S = "(" (*) ")" [EOF]
+    //     Kind = None
+    //     AllInputs = ["("]
+    //     OptionalInputs = []
+    //     FixedInputs = ["("]
+    //     WillPushLen = 1
+    //     WillPush = [")"]
+    //     WillProduce = Some(S)
     //
-    //   ")" -> Shift(S3)
+    //     S = "(" (*) ")" [EOF]
+    //
+    //     ")" -> Shift(S3)
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
+        __sym0: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -138,8 +117,9 @@ mod __parse__S {
         };
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
-                let mut __sym1 = &mut Some((__loc1, (__tok), __loc2));
-                __result = try!(__state3(__tokens, __sym0, __sym1));
+                let __sym1 = (__loc1, (__tok), __loc2);
+                __result = try!(__custom1(__tokens, __sym0, __sym1));
+                return Ok(__result);
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -148,20 +128,39 @@ mod __parse__S {
                 });
             }
         }
-        return Ok(__result);
     }
 
-    // State 3
-    //   S = "(" ")" (*) [EOF]
-    //
-    //   EOF -> Reduce(S = "(", ")" => ActionFn(1);)
-    //
-    pub fn __state3<
+    // Custom 0
+    //    Reduce __S = S => ActionFn(0);
+    pub fn __custom0<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
-        __sym0: &mut Option<((), Tok, ())>,
-        __sym1: &mut Option<((), Tok, ())>,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __start = __sym0.0.clone();
+        let __end = __sym0.2.clone();
+        let __nt = super::__action0(__sym0);
+        let __nt = __Nonterminal::____S((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
+    }
+
+    // Custom 1
+    //    Reduce S = "(", ")" => ActionFn(1);
+    pub fn __custom1<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __sym0: ((), Tok, ()),
+        __sym1: ((), Tok, ()),
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -170,27 +169,16 @@ mod __parse__S {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        match __lookahead {
-            None => {
-                let __sym0 = __sym0.take().unwrap();
-                let __sym1 = __sym1.take().unwrap();
-                let __start = __sym0.0.clone();
-                let __end = __sym1.2.clone();
-                let __nt = super::__action1(__sym0, __sym1);
-                let __nt = __Nonterminal::S((
-                    __start,
-                    __nt,
-                    __end,
-                ));
-                return Ok((__lookahead, __nt));
-            }
-            _ => {
-                return Err(__ParseError::UnrecognizedToken {
-                    token: __lookahead,
-                    expected: vec![],
-                });
-            }
-        }
+        let __start = __sym0.0.clone();
+        let __end = __sym1.2.clone();
+        let __nt = super::__action1(__sym0, __sym1);
+        let __nt = __Nonterminal::S((
+            __start,
+            __nt,
+            __end,
+        ));
+        __result = (__lookahead, __nt);
+        return Ok(__result);
     }
 }
 pub use self::__parse__S::parse_S;

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -164,6 +164,13 @@ pub enum TypeRepr {
 }
 
 impl TypeRepr {
+    pub fn is_unit(&self) -> bool {
+        match *self {
+            TypeRepr::Tuple(ref v) => v.is_empty(),
+            _ => false,
+        }
+    }
+
     pub fn usize() -> TypeRepr {
         TypeRepr::Nominal(NominalTypeRepr {
             path: Path::usize(),

--- a/lalrpop/src/lr1/state_graph.rs
+++ b/lalrpop/src/lr1/state_graph.rs
@@ -75,4 +75,13 @@ impl StateGraph {
         result.dedup();
         result
     }
+
+    pub fn successors(&self,
+                      state_index: StateIndex)
+                      -> Vec<StateIndex> {
+        self.graph.edges_directed(NodeIndex::new(state_index.0),
+                                  EdgeDirection::Outgoing)
+                  .map(|(succ, _)| StateIndex(succ.index()))
+                  .collect()
+    }
 }

--- a/lalrpop/src/main.rs
+++ b/lalrpop/src/main.rs
@@ -61,11 +61,8 @@ fn main1() -> io::Result<()> {
 }
 
 const USAGE: &'static str = "
-Usage: lalrpop [options] inputs...
+Usage: lalrpop [options] <inputs>...
        lalrpop --help
-
-Convert each of the given inputs (which should be a `.lalrpop` file)
-into a `.rs` file, just as a `build.rs` script using LALRPOP would do.
 
 Options:
     -l, --level LEVEL    Set the debug level. (Default: info)

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -257,7 +257,17 @@ impl LowerState {
     {
         let action = match action {
             Some(s) => s,
-            None => format!("(<>)"),
+            None => {
+                // If the user declared a type `()`, or we inferred
+                // it, then there is only one possible action that
+                // will type-check (`()`), so supply that. Otherwise,
+                // default is to include all selected items.
+                if nt_type.is_unit() {
+                    format!("()")
+                } else {
+                    format!("(<>)")
+                }
+            }
         };
 
         // Note that the action fn takes ALL of the symbols in `expr`

--- a/publish.sh
+++ b/publish.sh
@@ -41,12 +41,12 @@ publish lalrpop
 
 printf "Updated version in README and tutorial..."
 perl -p -i -e 's/^version = "[0-9.]+"$/version = "'$VERSION'"/' \
-     README.md doc/tutorial.md doc/calculator/Cargo.toml >& $TMPDIR/publish-log || publish_fail
+     README.md doc/tutorial.md doc/*/Cargo.toml >& $TMPDIR/publish-log || publish_fail
 perl -p -i -e 's/^lalrpop = "[0-9.]+"$/lalrpop = "'$VERSION'"/' \
-     doc/tutorial.md doc/calculator/Cargo.toml >& $TMPDIR/publish-log || publish_fail
+     doc/tutorial.md doc/*/Cargo.toml >& $TMPDIR/publish-log || publish_fail
 perl -p -i -e 's/^lalrpop-util = "[0-9.]+"$/lalrpop-util = "'$VERSION'"/' \
-     doc/tutorial.md doc/calculator/Cargo.toml >& $TMPDIR/publish-log || publish_fail
-git add README.md doc/tutorial.md doc/calculator/Cargo.toml >& $TMPDIR/publish-log || publish_fail
+     doc/tutorial.md doc/*/Cargo.toml >& $TMPDIR/publish-log || publish_fail
+git add README.md doc/tutorial.md doc/*/Cargo.toml >& $TMPDIR/publish-log || publish_fail
 printf "OK\n"
 
 printf "\nAll set. Do not forget to commit new README.md et al.\n"


### PR DESCRIPTION
This branch actually has a few miscellaneous changes:

- If the type of a nonterminal is `()`, the action is now always optional.
- Improve recursive ascent code to generate fewer options (should be faster to execute, maybe a bit faster to compile).
- A (somewhat in progress) pascal grammar example.
- LALRPOP executable now parses options correctly.