### PR TITLE
Input/output directory control

### DIFF
--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -2,9 +2,10 @@ use build;
 use log::Level;
 use session::{ColorConfig, Session};
 use std::default::Default;
+use std::env;
 use std::env::current_dir;
 use std::error::Error;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 /// Configure various aspects of how LALRPOP works.
@@ -37,6 +38,34 @@ impl Configuration {
     /// not otherwise. This is the default.
     pub fn use_colors_if_tty(&mut self) -> &mut Configuration {
         self.session.color_config = ColorConfig::IfTty;
+        self
+    }
+
+    /// Specify a custom directory to search for input files.  This
+    /// directory is recursively searched for `.lalrpop` files to be
+    /// considered as input files.  This configuration setting also
+    /// impacts where output files are placed; paths are made relative
+    /// to the input path before being resolved relative to the output
+    /// path.  By default, the input directory is the current working
+    /// directory.
+    pub fn set_in_dir<P>(&mut self, dir: P) -> &mut Self where P: Into<PathBuf> {
+        self.session.in_dir = Some(dir.into());
+        self
+    }
+
+    /// Specify a custom directory to use when writing output files.
+    /// By default, the output directory is the same as the input
+    /// directory.
+    pub fn set_out_dir<P>(&mut self, dir: P) -> &mut Self where P: Into<PathBuf> {
+        self.session.out_dir = Some(dir.into());
+        self
+    }
+
+    /// Apply `cargo` directory location conventions, by setting the
+    /// input directory to `src` and the output directory to
+    /// `$OUT_DIR`.
+    pub fn use_cargo_dir_conventions(&mut self) -> &mut Self {
+        self.set_in_dir("src").set_out_dir(env::var("OUT_DIR").unwrap());
         self
     }
 

--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -109,6 +109,17 @@ impl Configuration {
         self
     }
 
+    /// Process all files according to the `set_in_dir` and
+    /// `set_out_dir` configuration.
+    pub fn process(&self) -> Result<(), Box<Error>> {
+        let root = if let Some(ref d) = self.session.in_dir {
+            d.as_path()
+        } else {
+            Path::new(".")
+        };
+        self.process_dir(root)
+    }
+
     /// Process all files in the current directory, which -- unless you
     /// have changed it -- is typically the root of the crate being compiled.
     pub fn process_current_dir(&self) -> Result<(), Box<Error>> {

--- a/lalrpop/src/session.rs
+++ b/lalrpop/src/session.rs
@@ -3,6 +3,7 @@
 //! crate. Note that all fields are public and so forth for convenience.
 
 use std::default::Default;
+use std::path;
 use style::{self, Style};
 use log::{Log, Level};
 
@@ -30,6 +31,10 @@ pub struct Session {
     pub log: Log,
 
     pub force_build: bool,
+
+    pub in_dir: Option<path::PathBuf>,
+
+    pub out_dir: Option<path::PathBuf>,
 
     /// Emit comments in generated code explaining the states and so
     /// forth.
@@ -74,6 +79,8 @@ impl Session {
     pub fn new() -> Session {
         Session {
             log: Log::new(Level::Informative),
+            in_dir: None,
+            out_dir: None,
             force_build: false,
             emit_comments: false,
             color_config: ColorConfig::default(),
@@ -94,6 +101,8 @@ impl Session {
     pub fn test() -> Session {
         Session {
             log: Log::new(Level::Debug),
+            in_dir: None,
+            out_dir: None,
             force_build: false,
             emit_comments: false,
             color_config: ColorConfig::IfTty,


### PR DESCRIPTION
A follow-up of #85

> When I started using this library, I was very surprised when it generated source files next to the `.lalrpop` files, so that the generated files were checked into source code management.  I would expect any tools that generate source code to behave like [the example in the Cargo documentation](http://doc.crates.io/build-script.html#case-study-code-generation) and put them in the Cargo `OUT_DIR` directory.

This PR adds API calls that allows for `build.rs` code like:

```rust
fn main() {
    lalrpop::Configuration::new()
        .use_cargo_dir_conventions()
        .process().unwrap();
}
```

...or

```rust
fn main() {
    lalrpop::Configuration::new()
        .set_in_dir("src")
        .set_out_dir("gen")
        .process().unwrap();
}
```