### PR TITLE
Towards lane table support

### DIFF
--- a/lalrpop-test/src/error.rs
+++ b/lalrpop-test/src/error.rs
@@ -44,7 +44,6 @@ mod __parse__Items {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -63,9 +62,9 @@ mod __parse__Items {
     //     Items = (*) Items "-" ["-"]
     //     __Items = (*) Items [EOF]
     //
-    //     EOF -> Reduce(Items =  => ActionFn(1);)
-    //     "+" -> Reduce(Items =  => ActionFn(1);)
-    //     "-" -> Reduce(Items =  => ActionFn(1);)
+    //   EOF -> Items =  => ActionFn(1);
+    //   "+" -> Items =  => ActionFn(1);
+    //   "-" -> Items =  => ActionFn(1);
     //
     //     Items -> S1
     pub fn __state0<
@@ -111,7 +110,6 @@ mod __parse__Items {
     }
 
     // State 1
-    //     Kind = None
     //     AllInputs = [Items]
     //     OptionalInputs = []
     //     FixedInputs = [Items]
@@ -127,9 +125,9 @@ mod __parse__Items {
     //     Items = Items (*) "-" ["-"]
     //     __Items = Items (*) [EOF]
     //
-    //     EOF -> Reduce(__Items = Items => ActionFn(0);)
-    //     "+" -> Shift(S2)
-    //     "-" -> Shift(S3)
+    //   "+" -> S2
+    //   "-" -> S3
+    //   EOF -> __Items = Items => ActionFn(0);
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
@@ -143,12 +141,12 @@ mod __parse__Items {
         match __lookahead {
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                 let __sym1 = (__loc1, (__tok), __loc2);
-                __result = try!(__custom0(__tokens, __sym0, __sym1));
+                __result = try!(__state2(__tokens, __sym0, __sym1));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                 let __sym1 = (__loc1, (__tok), __loc2);
-                __result = try!(__custom1(__tokens, __sym0, __sym1));
+                __result = try!(__state3(__tokens, __sym0, __sym1));
                 return Ok(__result);
             }
             None => {
@@ -172,9 +170,23 @@ mod __parse__Items {
         }
     }
 
-    // Custom 0
-    //    Reduce Items = Items, "+" => ActionFn(2);
-    pub fn __custom0<
+    // State 2
+    //     AllInputs = [Items, "+"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Items, "+"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Items)
+    //
+    //     Items = Items "+" (*) [EOF]
+    //     Items = Items "+" (*) ["+"]
+    //     Items = Items "+" (*) ["-"]
+    //
+    //   EOF -> Items = Items, "+" => ActionFn(2);
+    //   "+" -> Items = Items, "+" => ActionFn(2);
+    //   "-" -> Items = Items, "+" => ActionFn(2);
+    //
+    pub fn __state2<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
     >(
         __tokens: &mut __TOKENS,
@@ -188,21 +200,47 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = try!(super::__action2(__sym0, __sym1));
-        let __nt = __Nonterminal::Items((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = try!(super::__action2(__sym0, __sym1));
+                let __nt = __Nonterminal::Items((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 1
-    //    Reduce Items = Items, "-" => ActionFn(3);
-    pub fn __custom1<
+    // State 3
+    //     AllInputs = [Items, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Items, "-"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Items)
+    //
+    //     Items = Items "-" (*) [EOF]
+    //     Items = Items "-" (*) ["+"]
+    //     Items = Items "-" (*) ["-"]
+    //
+    //   EOF -> Items = Items, "-" => ActionFn(3);
+    //   "+" -> Items = Items, "-" => ActionFn(3);
+    //   "-" -> Items = Items, "-" => ActionFn(3);
+    //
+    pub fn __state3<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
     >(
         __tokens: &mut __TOKENS,
@@ -216,16 +254,28 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = try!(super::__action3(__sym0, __sym1));
-        let __nt = __Nonterminal::Items((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = try!(super::__action3(__sym0, __sym1));
+                let __nt = __Nonterminal::Items((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Items::parse_Items;

--- a/lalrpop-test/src/error.rs
+++ b/lalrpop-test/src/error.rs
@@ -51,20 +51,20 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Items = (*) [EOF]
     //     Items = (*) ["+"]
     //     Items = (*) ["-"]
-    //     Items = (*) Items "+" [EOF]
+    //     Items = (*) [EOF]
     //     Items = (*) Items "+" ["+"]
     //     Items = (*) Items "+" ["-"]
-    //     Items = (*) Items "-" [EOF]
+    //     Items = (*) Items "+" [EOF]
     //     Items = (*) Items "-" ["+"]
     //     Items = (*) Items "-" ["-"]
+    //     Items = (*) Items "-" [EOF]
     //     __Items = (*) Items [EOF]
     //
-    //   EOF -> Items =  => ActionFn(1);
-    //   "+" -> Items =  => ActionFn(1);
-    //   "-" -> Items =  => ActionFn(1);
+    //   ["+"] -> Items =  => ActionFn(1);
+    //   ["-"] -> Items =  => ActionFn(1);
+    //   [EOF] -> Items =  => ActionFn(1);
     //
     //     Items -> S1
     pub fn __state0<
@@ -76,9 +76,9 @@ mod __parse__Items {
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start: usize = ::std::default::Default::default();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action1(&__start, &__end);
@@ -117,17 +117,13 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Items = Items (*) "+" [EOF]
-    //     Items = Items (*) "+" ["+"]
-    //     Items = Items (*) "+" ["-"]
-    //     Items = Items (*) "-" [EOF]
-    //     Items = Items (*) "-" ["+"]
-    //     Items = Items (*) "-" ["-"]
+    //     Items = Items (*) "+" ["+", "-", EOF]
+    //     Items = Items (*) "-" ["+", "-", EOF]
     //     __Items = Items (*) [EOF]
     //
     //   "+" -> S2
     //   "-" -> S3
-    //   EOF -> __Items = Items => ActionFn(0);
+    //   [EOF] -> __Items = Items => ActionFn(0);
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
@@ -178,13 +174,9 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = Some(Items)
     //
-    //     Items = Items "+" (*) [EOF]
-    //     Items = Items "+" (*) ["+"]
-    //     Items = Items "+" (*) ["-"]
+    //     Items = Items "+" (*) ["+", "-", EOF]
     //
-    //   EOF -> Items = Items, "+" => ActionFn(2);
-    //   "+" -> Items = Items, "+" => ActionFn(2);
-    //   "-" -> Items = Items, "+" => ActionFn(2);
+    //   ["+", "-", EOF] -> Items = Items, "+" => ActionFn(2);
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
@@ -201,9 +193,9 @@ mod __parse__Items {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym1.2.clone();
                 let __nt = try!(super::__action2(__sym0, __sym1));
@@ -232,13 +224,9 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = Some(Items)
     //
-    //     Items = Items "-" (*) [EOF]
-    //     Items = Items "-" (*) ["+"]
-    //     Items = Items "-" (*) ["-"]
+    //     Items = Items "-" (*) ["+", "-", EOF]
     //
-    //   EOF -> Items = Items, "-" => ActionFn(3);
-    //   "+" -> Items = Items, "-" => ActionFn(3);
-    //   "-" -> Items = Items, "-" => ActionFn(3);
+    //   ["+", "-", EOF] -> Items = Items, "-" => ActionFn(3);
     //
     pub fn __state3<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),char>>,
@@ -255,9 +243,9 @@ mod __parse__Items {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym1.2.clone();
                 let __nt = try!(super::__action3(__sym0, __sym1));

--- a/lalrpop-test/src/expr.rs
+++ b/lalrpop-test/src/expr.rs
@@ -46,7 +46,6 @@ mod __parse__Expr {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -90,8 +89,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["/"]
     //     __Expr = (*) Expr [EOF]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Expr -> S1
     //     Factor -> S2
@@ -112,7 +111,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym0));
+                __result = try!(__state5(scale, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -131,7 +130,7 @@ mod __parse__Expr {
                     __result = try!(__state2(scale, __tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::Term(__sym0) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym0));
+                    __result = try!(__state3(scale, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -141,7 +140,6 @@ mod __parse__Expr {
     }
 
     // State 1
-    //     Kind = None
     //     AllInputs = [Expr]
     //     OptionalInputs = []
     //     FixedInputs = [Expr]
@@ -157,9 +155,9 @@ mod __parse__Expr {
     //     Expr = Expr (*) "-" Factor ["-"]
     //     __Expr = Expr (*) [EOF]
     //
-    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //     "+" -> Shift(S6)
-    //     "-" -> Shift(S7)
+    //   "+" -> S6
+    //   "-" -> S7
+    //   EOF -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -204,7 +202,6 @@ mod __parse__Expr {
     }
 
     // State 2
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -226,11 +223,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -276,8 +273,63 @@ mod __parse__Expr {
         }
     }
 
+    // State 3
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [EOF]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   EOF -> Factor = Term => ActionFn(6);
+    //   "*" -> Factor = Term => ActionFn(6);
+    //   "+" -> Factor = Term => ActionFn(6);
+    //   "-" -> Factor = Term => ActionFn(6);
+    //   "/" -> Factor = Term => ActionFn(6);
+    //
+    pub fn __state3<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action6(scale, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 4
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -325,8 +377,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     Num -> Shift(S14)
+    //   "(" -> S13
+    //   Num -> S14
     //
     //     Expr -> S10
     //     Factor -> S11
@@ -353,7 +405,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym1));
+                __result = try!(__state14(scale, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -375,7 +427,7 @@ mod __parse__Expr {
                     __result = try!(__state11(scale, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym1));
+                    __result = try!(__state12(scale, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -384,8 +436,67 @@ mod __parse__Expr {
         }
     }
 
+    // State 5
+    //     AllInputs = [Num]
+    //     OptionalInputs = []
+    //     FixedInputs = [Num]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = Num (*) [EOF]
+    //     Term = Num (*) ["*"]
+    //     Term = Num (*) ["+"]
+    //     Term = Num (*) ["-"]
+    //     Term = Num (*) ["/"]
+    //
+    //   EOF -> Term = Num => ActionFn(7);
+    //   "*" -> Term = Num => ActionFn(7);
+    //   "+" -> Term = Num => ActionFn(7);
+    //   "-" -> Term = Num => ActionFn(7);
+    //   "/" -> Term = Num => ActionFn(7);
+    //
+    pub fn __state5<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(scale, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 6
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -422,8 +533,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Factor -> S15
     //     Term -> S3
@@ -451,7 +562,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state5(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -470,7 +581,7 @@ mod __parse__Expr {
                     __result = try!(__state15(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -480,7 +591,6 @@ mod __parse__Expr {
     }
 
     // State 7
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -517,8 +627,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Factor -> S16
     //     Term -> S3
@@ -546,7 +656,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state5(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -565,7 +675,7 @@ mod __parse__Expr {
                     __result = try!(__state16(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -575,7 +685,6 @@ mod __parse__Expr {
     }
 
     // State 8
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -599,8 +708,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Term -> S17
     pub fn __state8<
@@ -625,7 +734,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state5(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -638,7 +747,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom2(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state17(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -649,7 +758,6 @@ mod __parse__Expr {
     }
 
     // State 9
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -673,8 +781,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Term -> S18
     pub fn __state9<
@@ -699,7 +807,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state5(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -712,7 +820,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state18(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -723,7 +831,6 @@ mod __parse__Expr {
     }
 
     // State 10
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -743,9 +850,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S19)
-    //     "+" -> Shift(S20)
-    //     "-" -> Shift(S21)
+    //   ")" -> S19
+    //   "+" -> S20
+    //   "-" -> S21
     //
     pub fn __state10<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -762,7 +869,7 @@ mod __parse__Expr {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(scale, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state19(scale, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
@@ -785,7 +892,6 @@ mod __parse__Expr {
     }
 
     // State 11
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -807,11 +913,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S22)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S23)
+    //   "*" -> S22
+    //   "/" -> S23
+    //   ")" -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state11<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -857,8 +963,63 @@ mod __parse__Expr {
         }
     }
 
+    // State 12
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [")"]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   ")" -> Factor = Term => ActionFn(6);
+    //   "*" -> Factor = Term => ActionFn(6);
+    //   "+" -> Factor = Term => ActionFn(6);
+    //   "-" -> Factor = Term => ActionFn(6);
+    //   "/" -> Factor = Term => ActionFn(6);
+    //
+    pub fn __state12<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action6(scale, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 13
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -906,8 +1067,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     Num -> Shift(S14)
+    //   "(" -> S13
+    //   Num -> S14
     //
     //     Expr -> S24
     //     Factor -> S11
@@ -934,7 +1095,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym1));
+                __result = try!(__state14(scale, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -956,7 +1117,7 @@ mod __parse__Expr {
                     __result = try!(__state11(scale, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym1));
+                    __result = try!(__state12(scale, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -965,8 +1126,67 @@ mod __parse__Expr {
         }
     }
 
+    // State 14
+    //     AllInputs = [Num]
+    //     OptionalInputs = []
+    //     FixedInputs = [Num]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = Num (*) [")"]
+    //     Term = Num (*) ["*"]
+    //     Term = Num (*) ["+"]
+    //     Term = Num (*) ["-"]
+    //     Term = Num (*) ["/"]
+    //
+    //   ")" -> Term = Num => ActionFn(7);
+    //   "*" -> Term = Num => ActionFn(7);
+    //   "+" -> Term = Num => ActionFn(7);
+    //   "-" -> Term = Num => ActionFn(7);
+    //   "/" -> Term = Num => ActionFn(7);
+    //
+    pub fn __state14<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(scale, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 15
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -988,11 +1208,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state15<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1043,7 +1263,6 @@ mod __parse__Expr {
     }
 
     // State 16
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -1065,11 +1284,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state16<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1119,8 +1338,185 @@ mod __parse__Expr {
         }
     }
 
+    // State 17
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [EOF]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state17<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
+        __sym2: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 18
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [EOF]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state18<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
+        __sym2: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 19
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [EOF]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   EOF -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //
+    pub fn __state19<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __sym0: ((), Tok, ()),
+        __sym1: ((), i32, ()),
+        __sym2: ((), Tok, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 20
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -1157,8 +1553,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     Num -> Shift(S14)
+    //   "(" -> S13
+    //   Num -> S14
     //
     //     Factor -> S25
     //     Term -> S12
@@ -1186,7 +1582,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state14(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1205,7 +1601,7 @@ mod __parse__Expr {
                     __result = try!(__state25(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
+                    __result = try!(__state12(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1215,7 +1611,6 @@ mod __parse__Expr {
     }
 
     // State 21
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -1252,8 +1647,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     Num -> Shift(S14)
+    //   "(" -> S13
+    //   Num -> S14
     //
     //     Factor -> S26
     //     Term -> S12
@@ -1281,7 +1676,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state14(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1300,7 +1695,7 @@ mod __parse__Expr {
                     __result = try!(__state26(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
+                    __result = try!(__state12(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1310,7 +1705,6 @@ mod __parse__Expr {
     }
 
     // State 22
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -1334,8 +1728,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     Num -> Shift(S14)
+    //   "(" -> S13
+    //   Num -> S14
     //
     //     Term -> S27
     pub fn __state22<
@@ -1360,7 +1754,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state14(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1373,7 +1767,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom2(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state27(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -1384,7 +1778,6 @@ mod __parse__Expr {
     }
 
     // State 23
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -1408,8 +1801,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     Num -> Shift(S14)
+    //   "(" -> S13
+    //   Num -> S14
     //
     //     Term -> S28
     pub fn __state23<
@@ -1434,7 +1827,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state14(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1447,7 +1840,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state28(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -1458,7 +1851,6 @@ mod __parse__Expr {
     }
 
     // State 24
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -1478,9 +1870,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S29)
-    //     "+" -> Shift(S20)
-    //     "-" -> Shift(S21)
+    //   ")" -> S29
+    //   "+" -> S20
+    //   "-" -> S21
     //
     pub fn __state24<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1497,7 +1889,7 @@ mod __parse__Expr {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(scale, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state29(scale, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
@@ -1520,7 +1912,6 @@ mod __parse__Expr {
     }
 
     // State 25
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -1542,11 +1933,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S22)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S23)
+    //   "*" -> S22
+    //   "/" -> S23
+    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state25<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1597,7 +1988,6 @@ mod __parse__Expr {
     }
 
     // State 26
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -1619,11 +2009,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S22)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S23)
+    //   "*" -> S22
+    //   "/" -> S23
+    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state26<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1673,61 +2063,27 @@ mod __parse__Expr {
         }
     }
 
-    // Custom 0
-    //    Reduce Factor = Term => ActionFn(6);
-    pub fn __custom0<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: ((), i32, ()),
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action6(scale, __sym0);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce Term = Num => ActionFn(7);
-    pub fn __custom1<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __sym0: ((), i32, ()),
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action7(scale, __sym0);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 2
-    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
-    pub fn __custom2<
+    // State 27
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [")"]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state27<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
@@ -1739,21 +2095,53 @@ mod __parse__Expr {
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 3
-    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
-    pub fn __custom3<
+    // State 28
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [")"]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state28<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
@@ -1765,21 +2153,53 @@ mod __parse__Expr {
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 4
-    //    Reduce Term = "(", Expr, ")" => ActionFn(8);
-    pub fn __custom4<
+    // State 29
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [")"]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   ")" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //
+    pub fn __state29<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
@@ -1795,16 +2215,30 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/expr.rs
+++ b/lalrpop-test/src/expr.rs
@@ -53,40 +53,40 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = (*) Expr "+" Factor [EOF]
     //     Expr = (*) Expr "+" Factor ["+"]
     //     Expr = (*) Expr "+" Factor ["-"]
-    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor [EOF]
     //     Expr = (*) Expr "-" Factor ["+"]
     //     Expr = (*) Expr "-" Factor ["-"]
-    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Expr "-" Factor [EOF]
     //     Expr = (*) Factor ["+"]
     //     Expr = (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = (*) Factor [EOF]
     //     Factor = (*) Factor "*" Term ["*"]
     //     Factor = (*) Factor "*" Term ["+"]
     //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "*" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
     //     Factor = (*) Factor "/" Term ["+"]
     //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Term ["*"]
     //     Factor = (*) Term ["+"]
     //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
+    //     Factor = (*) Term [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
+    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) Num ["*"]
     //     Term = (*) Num ["+"]
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
+    //     Term = (*) Num [EOF]
     //     __Expr = (*) Expr [EOF]
     //
     //   "(" -> S4
@@ -147,17 +147,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [EOF]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [EOF]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Expr = Expr (*) "+" Factor ["+", "-", EOF]
+    //     Expr = Expr (*) "-" Factor ["+", "-", EOF]
     //     __Expr = Expr (*) [EOF]
     //
     //   "+" -> S6
     //   "-" -> S7
-    //   EOF -> __Expr = Expr => ActionFn(0);
+    //   [EOF] -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -209,25 +205,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [EOF]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   ["+", "-", EOF] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -250,9 +234,9 @@ mod __parse__Expr {
                 __result = try!(__state9(scale, __tokens, __sym0, __sym1));
                 return Ok(__result);
             }
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(scale, __sym0);
@@ -281,17 +265,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [EOF]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Term => ActionFn(6);
-    //   "*" -> Factor = Term => ActionFn(6);
-    //   "+" -> Factor = Term => ActionFn(6);
-    //   "-" -> Factor = Term => ActionFn(6);
-    //   "/" -> Factor = Term => ActionFn(6);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Term => ActionFn(6);
     //
     pub fn __state3<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -304,11 +280,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action6(scale, __sym0);
@@ -366,11 +342,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [EOF]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" ["*", "+", "-", "/", EOF]
     //     Term = (*) Num [")"]
     //     Term = (*) Num ["*"]
     //     Term = (*) Num ["+"]
@@ -444,17 +416,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = Num (*) [EOF]
-    //     Term = Num (*) ["*"]
-    //     Term = Num (*) ["+"]
-    //     Term = Num (*) ["-"]
-    //     Term = Num (*) ["/"]
+    //     Term = Num (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = Num => ActionFn(7);
-    //   "*" -> Term = Num => ActionFn(7);
-    //   "+" -> Term = Num => ActionFn(7);
-    //   "-" -> Term = Num => ActionFn(7);
-    //   "/" -> Term = Num => ActionFn(7);
+    //   ["*", "+", "-", "/", EOF] -> Term = Num => ActionFn(7);
     //
     pub fn __state5<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -471,11 +435,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action7(scale, __sym0);
@@ -504,33 +468,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [EOF]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = Expr "+" (*) Factor ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["+", "-", EOF]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["+", "-", EOF]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["+", "-", EOF]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["+", "-", EOF]
     //     Term = (*) Num ["/"]
     //
     //   "(" -> S4
@@ -598,33 +550,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [EOF]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = Expr "-" (*) Factor ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["+", "-", EOF]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["+", "-", EOF]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["+", "-", EOF]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["+", "-", EOF]
     //     Term = (*) Num ["/"]
     //
     //   "(" -> S4
@@ -692,21 +632,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [EOF]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "*" (*) Term ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
+    //     Term = (*) Num ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   Num -> S5
@@ -765,21 +693,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [EOF]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "/" (*) Term ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
+    //     Term = (*) Num ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   Num -> S5
@@ -838,17 +754,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [EOF]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" ["*", "+", "-", "/", EOF]
     //
     //   ")" -> S19
     //   "+" -> S20
@@ -899,25 +807,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [")"]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S22
     //   "/" -> S23
-    //   ")" -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   [")", "+", "-"] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state11<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -971,17 +867,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [")"]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Term => ActionFn(6);
-    //   "*" -> Factor = Term => ActionFn(6);
-    //   "+" -> Factor = Term => ActionFn(6);
-    //   "-" -> Factor = Term => ActionFn(6);
-    //   "/" -> Factor = Term => ActionFn(6);
+    //   [")", "*", "+", "-", "/"] -> Factor = Term => ActionFn(6);
     //
     pub fn __state12<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1056,11 +944,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [")"]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")", "*", "+", "-", "/"]
     //     Term = (*) Num [")"]
     //     Term = (*) Num ["*"]
     //     Term = (*) Num ["+"]
@@ -1134,17 +1018,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = Num (*) [")"]
-    //     Term = Num (*) ["*"]
-    //     Term = Num (*) ["+"]
-    //     Term = Num (*) ["-"]
-    //     Term = Num (*) ["/"]
+    //     Term = Num (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Term = Num => ActionFn(7);
-    //   "*" -> Term = Num => ActionFn(7);
-    //   "+" -> Term = Num => ActionFn(7);
-    //   "-" -> Term = Num => ActionFn(7);
-    //   "/" -> Term = Num => ActionFn(7);
+    //   [")", "*", "+", "-", "/"] -> Term = Num => ActionFn(7);
     //
     pub fn __state14<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1194,25 +1070,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [EOF]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   ["+", "-", EOF] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state15<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1237,9 +1101,9 @@ mod __parse__Expr {
                 __result = try!(__state9(scale, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1270,25 +1134,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [EOF]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   ["+", "-", EOF] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state16<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1313,9 +1165,9 @@ mod __parse__Expr {
                 __result = try!(__state9(scale, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1346,17 +1198,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [EOF]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state17<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1371,11 +1215,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
@@ -1404,17 +1248,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [EOF]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state18<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1429,11 +1265,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
@@ -1462,17 +1298,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [EOF]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   ["*", "+", "-", "/", EOF] -> Term = "(", Expr, ")" => ActionFn(8);
     //
     pub fn __state19<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1491,11 +1319,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
@@ -1524,33 +1352,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [")"]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "+" (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
+    //     Term = (*) Num [")", "+", "-"]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
     //   "(" -> S13
@@ -1618,33 +1434,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [")"]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "-" (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
+    //     Term = (*) Num [")", "+", "-"]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
     //   "(" -> S13
@@ -1712,21 +1516,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [")"]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "*" (*) Term [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
+    //     Term = (*) Num [")", "*", "+", "-", "/"]
     //
     //   "(" -> S13
     //   Num -> S14
@@ -1785,21 +1577,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [")"]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "/" (*) Term [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
+    //     Term = (*) Num [")", "*", "+", "-", "/"]
     //
     //   "(" -> S13
     //   Num -> S14
@@ -1858,17 +1638,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [")"]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" [")", "*", "+", "-", "/"]
     //
     //   ")" -> S29
     //   "+" -> S20
@@ -1919,25 +1691,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [")"]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S22
     //   "/" -> S23
-    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   [")", "+", "-"] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state25<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1995,25 +1755,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [")"]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S22
     //   "/" -> S23
-    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   [")", "+", "-"] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state26<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -2071,17 +1819,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [")"]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   [")", "*", "+", "-", "/"] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state27<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -2129,17 +1869,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [")"]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   [")", "*", "+", "-", "/"] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state28<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -2187,17 +1919,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [")"]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   [")", "*", "+", "-", "/"] -> Term = "(", Expr, ")" => ActionFn(8);
     //
     pub fn __state29<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,

--- a/lalrpop-test/src/expr_arena.rs
+++ b/lalrpop-test/src/expr_arena.rs
@@ -54,7 +54,6 @@ mod __parse__Expr {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -103,9 +102,9 @@ mod __parse__Expr {
     //     Term = (*) Num ["/"]
     //     __Expr = (*) Expr [EOF]
     //
-    //     "(" -> Shift(S4)
-    //     "*" -> Shift(S5)
-    //     Num -> Shift(S6)
+    //   "(" -> S4
+    //   "*" -> S5
+    //   Num -> S6
     //
     //     Expr -> S1
     //     Factor -> S2
@@ -131,7 +130,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym0));
+                __result = try!(__state6(arena, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -150,7 +149,7 @@ mod __parse__Expr {
                     __result = try!(__state2(arena, __tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::Term(__sym0) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym0));
+                    __result = try!(__state3(arena, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -160,7 +159,6 @@ mod __parse__Expr {
     }
 
     // State 1
-    //     Kind = None
     //     AllInputs = [Expr]
     //     OptionalInputs = []
     //     FixedInputs = [Expr]
@@ -176,9 +174,9 @@ mod __parse__Expr {
     //     Expr = Expr (*) "-" Factor ["-"]
     //     __Expr = Expr (*) [EOF]
     //
-    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //     "+" -> Shift(S7)
-    //     "-" -> Shift(S8)
+    //   "+" -> S7
+    //   "-" -> S8
+    //   EOF -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         'ast,
@@ -224,7 +222,6 @@ mod __parse__Expr {
     }
 
     // State 2
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -246,11 +243,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S9)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S10)
+    //   "*" -> S9
+    //   "/" -> S10
+    //   EOF -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         'ast,
@@ -297,8 +294,64 @@ mod __parse__Expr {
         }
     }
 
+    // State 3
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [EOF]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   EOF -> Factor = Term => ActionFn(7);
+    //   "*" -> Factor = Term => ActionFn(7);
+    //   "+" -> Factor = Term => ActionFn(7);
+    //   "-" -> Factor = Term => ActionFn(7);
+    //   "/" -> Factor = Term => ActionFn(7);
+    //
+    pub fn __state3<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(arena, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 4
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -351,9 +404,9 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S14)
-    //     "*" -> Shift(S15)
-    //     Num -> Shift(S16)
+    //   "(" -> S14
+    //   "*" -> S15
+    //   Num -> S16
     //
     //     Expr -> S11
     //     Factor -> S12
@@ -385,7 +438,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym1));
+                __result = try!(__state16(arena, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -407,7 +460,7 @@ mod __parse__Expr {
                     __result = try!(__state12(arena, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym1));
+                    __result = try!(__state13(arena, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -417,7 +470,6 @@ mod __parse__Expr {
     }
 
     // State 5
-    //     Kind = None
     //     AllInputs = ["*"]
     //     OptionalInputs = []
     //     FixedInputs = ["*"]
@@ -431,7 +483,7 @@ mod __parse__Expr {
     //     Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
     //     Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
     //
-    //     "(" -> Shift(S17)
+    //   "(" -> S17
     //
     pub fn __state5<
         'ast,
@@ -463,8 +515,68 @@ mod __parse__Expr {
         }
     }
 
+    // State 6
+    //     AllInputs = [Num]
+    //     OptionalInputs = []
+    //     FixedInputs = [Num]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = Num (*) [EOF]
+    //     Term = Num (*) ["*"]
+    //     Term = Num (*) ["+"]
+    //     Term = Num (*) ["-"]
+    //     Term = Num (*) ["/"]
+    //
+    //   EOF -> Term = Num => ActionFn(8);
+    //   "*" -> Term = Num => ActionFn(8);
+    //   "+" -> Term = Num => ActionFn(8);
+    //   "-" -> Term = Num => ActionFn(8);
+    //   "/" -> Term = Num => ActionFn(8);
+    //
+    pub fn __state6<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, i32, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action8(arena, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 7
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -506,9 +618,9 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     "*" -> Shift(S5)
-    //     Num -> Shift(S6)
+    //   "(" -> S4
+    //   "*" -> S5
+    //   Num -> S6
     //
     //     Factor -> S18
     //     Term -> S3
@@ -541,7 +653,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state6(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -560,7 +672,7 @@ mod __parse__Expr {
                     __result = try!(__state18(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -570,7 +682,6 @@ mod __parse__Expr {
     }
 
     // State 8
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -612,9 +723,9 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     "*" -> Shift(S5)
-    //     Num -> Shift(S6)
+    //   "(" -> S4
+    //   "*" -> S5
+    //   Num -> S6
     //
     //     Factor -> S19
     //     Term -> S3
@@ -647,7 +758,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state6(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -666,7 +777,7 @@ mod __parse__Expr {
                     __result = try!(__state19(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -676,7 +787,6 @@ mod __parse__Expr {
     }
 
     // State 9
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -700,8 +810,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S6)
+    //   "(" -> S4
+    //   Num -> S6
     //
     //     Term -> S20
     pub fn __state9<
@@ -727,7 +837,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state6(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -740,7 +850,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom2(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state20(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -751,7 +861,6 @@ mod __parse__Expr {
     }
 
     // State 10
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -775,8 +884,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S6)
+    //   "(" -> S4
+    //   Num -> S6
     //
     //     Term -> S21
     pub fn __state10<
@@ -802,7 +911,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state6(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -815,7 +924,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state21(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -826,7 +935,6 @@ mod __parse__Expr {
     }
 
     // State 11
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -846,9 +954,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S22)
-    //     "+" -> Shift(S23)
-    //     "-" -> Shift(S24)
+    //   ")" -> S22
+    //   "+" -> S23
+    //   "-" -> S24
     //
     pub fn __state11<
         'ast,
@@ -866,7 +974,7 @@ mod __parse__Expr {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(arena, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state22(arena, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
@@ -889,7 +997,6 @@ mod __parse__Expr {
     }
 
     // State 12
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -911,11 +1018,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S25)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S26)
+    //   "*" -> S25
+    //   "/" -> S26
+    //   ")" -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state12<
         'ast,
@@ -962,8 +1069,64 @@ mod __parse__Expr {
         }
     }
 
+    // State 13
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [")"]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   ")" -> Factor = Term => ActionFn(7);
+    //   "*" -> Factor = Term => ActionFn(7);
+    //   "+" -> Factor = Term => ActionFn(7);
+    //   "-" -> Factor = Term => ActionFn(7);
+    //   "/" -> Factor = Term => ActionFn(7);
+    //
+    pub fn __state13<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(arena, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 14
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -1016,9 +1179,9 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S14)
-    //     "*" -> Shift(S15)
-    //     Num -> Shift(S16)
+    //   "(" -> S14
+    //   "*" -> S15
+    //   Num -> S16
     //
     //     Expr -> S27
     //     Factor -> S12
@@ -1050,7 +1213,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym1));
+                __result = try!(__state16(arena, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1072,7 +1235,7 @@ mod __parse__Expr {
                     __result = try!(__state12(arena, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym1));
+                    __result = try!(__state13(arena, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1082,7 +1245,6 @@ mod __parse__Expr {
     }
 
     // State 15
-    //     Kind = None
     //     AllInputs = ["*"]
     //     OptionalInputs = []
     //     FixedInputs = ["*"]
@@ -1096,7 +1258,7 @@ mod __parse__Expr {
     //     Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
     //     Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
     //
-    //     "(" -> Shift(S28)
+    //   "(" -> S28
     //
     pub fn __state15<
         'ast,
@@ -1128,8 +1290,68 @@ mod __parse__Expr {
         }
     }
 
+    // State 16
+    //     AllInputs = [Num]
+    //     OptionalInputs = []
+    //     FixedInputs = [Num]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = Num (*) [")"]
+    //     Term = Num (*) ["*"]
+    //     Term = Num (*) ["+"]
+    //     Term = Num (*) ["-"]
+    //     Term = Num (*) ["/"]
+    //
+    //   ")" -> Term = Num => ActionFn(8);
+    //   "*" -> Term = Num => ActionFn(8);
+    //   "+" -> Term = Num => ActionFn(8);
+    //   "-" -> Term = Num => ActionFn(8);
+    //   "/" -> Term = Num => ActionFn(8);
+    //
+    pub fn __state16<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, i32, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action8(arena, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 17
-    //     Kind = None
     //     AllInputs = ["*", "("]
     //     OptionalInputs = []
     //     FixedInputs = ["*", "("]
@@ -1203,10 +1425,10 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S34)
-    //     ")" -> Reduce(Comma<Expr> =  => ActionFn(23);)
-    //     "*" -> Shift(S35)
-    //     Num -> Shift(S36)
+    //   "(" -> S34
+    //   "*" -> S35
+    //   Num -> S36
+    //   ")" -> Comma<Expr> =  => ActionFn(23);
     //
     //     (<Expr> ",")+ -> S29
     //     Comma<Expr> -> S30
@@ -1240,7 +1462,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state36(arena, __tokens, __sym2));
             }
             Some((_, Tok::RParen, _)) => {
                 let __start = __sym1.2.clone();
@@ -1277,7 +1499,7 @@ mod __parse__Expr {
                     __result = try!(__state32(arena, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
+                    __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1287,7 +1509,6 @@ mod __parse__Expr {
     }
 
     // State 18
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -1309,11 +1530,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S9)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S10)
+    //   "*" -> S9
+    //   "/" -> S10
+    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state18<
         'ast,
@@ -1365,7 +1586,6 @@ mod __parse__Expr {
     }
 
     // State 19
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -1387,11 +1607,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S9)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S10)
+    //   "*" -> S9
+    //   "/" -> S10
+    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state19<
         'ast,
@@ -1442,8 +1662,188 @@ mod __parse__Expr {
         }
     }
 
+    // State 20
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [EOF]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state20<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(arena, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 21
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [EOF]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state21<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(arena, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 22
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [EOF]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   EOF -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(9);
+    //
+    pub fn __state22<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, &'ast Node<'ast>, usize),
+        __sym2: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action9(arena, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 23
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -1485,9 +1885,9 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S14)
-    //     "*" -> Shift(S15)
-    //     Num -> Shift(S16)
+    //   "(" -> S14
+    //   "*" -> S15
+    //   Num -> S16
     //
     //     Factor -> S37
     //     Term -> S13
@@ -1520,7 +1920,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state16(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1539,7 +1939,7 @@ mod __parse__Expr {
                     __result = try!(__state37(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
+                    __result = try!(__state13(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1549,7 +1949,6 @@ mod __parse__Expr {
     }
 
     // State 24
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -1591,9 +1990,9 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S14)
-    //     "*" -> Shift(S15)
-    //     Num -> Shift(S16)
+    //   "(" -> S14
+    //   "*" -> S15
+    //   Num -> S16
     //
     //     Factor -> S38
     //     Term -> S13
@@ -1626,7 +2025,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state16(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1645,7 +2044,7 @@ mod __parse__Expr {
                     __result = try!(__state38(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
+                    __result = try!(__state13(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1655,7 +2054,6 @@ mod __parse__Expr {
     }
 
     // State 25
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -1679,8 +2077,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S14)
-    //     Num -> Shift(S16)
+    //   "(" -> S14
+    //   Num -> S16
     //
     //     Term -> S39
     pub fn __state25<
@@ -1706,7 +2104,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state16(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1719,7 +2117,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom2(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state39(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -1730,7 +2128,6 @@ mod __parse__Expr {
     }
 
     // State 26
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -1754,8 +2151,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S14)
-    //     Num -> Shift(S16)
+    //   "(" -> S14
+    //   Num -> S16
     //
     //     Term -> S40
     pub fn __state26<
@@ -1781,7 +2178,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state16(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1794,7 +2191,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state40(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -1805,7 +2202,6 @@ mod __parse__Expr {
     }
 
     // State 27
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -1825,9 +2221,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S41)
-    //     "+" -> Shift(S23)
-    //     "-" -> Shift(S24)
+    //   ")" -> S41
+    //   "+" -> S23
+    //   "-" -> S24
     //
     pub fn __state27<
         'ast,
@@ -1845,7 +2241,7 @@ mod __parse__Expr {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(arena, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state41(arena, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
@@ -1868,7 +2264,6 @@ mod __parse__Expr {
     }
 
     // State 28
-    //     Kind = None
     //     AllInputs = ["*", "("]
     //     OptionalInputs = []
     //     FixedInputs = ["*", "("]
@@ -1942,10 +2337,10 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S34)
-    //     ")" -> Reduce(Comma<Expr> =  => ActionFn(23);)
-    //     "*" -> Shift(S35)
-    //     Num -> Shift(S36)
+    //   "(" -> S34
+    //   "*" -> S35
+    //   Num -> S36
+    //   ")" -> Comma<Expr> =  => ActionFn(23);
     //
     //     (<Expr> ",")+ -> S29
     //     Comma<Expr> -> S42
@@ -1979,7 +2374,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state36(arena, __tokens, __sym2));
             }
             Some((_, Tok::RParen, _)) => {
                 let __start = __sym1.2.clone();
@@ -2016,7 +2411,7 @@ mod __parse__Expr {
                     __result = try!(__state32(arena, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
+                    __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -2026,7 +2421,6 @@ mod __parse__Expr {
     }
 
     // State 29
-    //     Kind = None
     //     AllInputs = [(<Expr> ",")+]
     //     OptionalInputs = []
     //     FixedInputs = [(<Expr> ",")+]
@@ -2089,10 +2483,10 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S34)
-    //     ")" -> Reduce(Comma<Expr> = (<Expr> ",")+ => ActionFn(25);)
-    //     "*" -> Shift(S35)
-    //     Num -> Shift(S36)
+    //   "(" -> S34
+    //   "*" -> S35
+    //   Num -> S36
+    //   ")" -> Comma<Expr> = (<Expr> ",")+ => ActionFn(25);
     //
     //     Expr -> S43
     //     Factor -> S32
@@ -2120,7 +2514,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym1));
+                __result = try!(__state36(arena, __tokens, __sym1));
             }
             Some((_, Tok::RParen, _)) => {
                 let __sym0 = __sym0.take().unwrap();
@@ -2155,7 +2549,7 @@ mod __parse__Expr {
                     __result = try!(__state32(arena, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym1));
+                    __result = try!(__state33(arena, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -2165,7 +2559,6 @@ mod __parse__Expr {
     }
 
     // State 30
-    //     Kind = None
     //     AllInputs = ["*", "(", Comma<Expr>]
     //     OptionalInputs = []
     //     FixedInputs = ["*", "(", Comma<Expr>]
@@ -2179,7 +2572,7 @@ mod __parse__Expr {
     //     Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
     //     Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
     //
-    //     ")" -> Shift(S44)
+    //   ")" -> S44
     //
     pub fn __state30<
         'ast,
@@ -2197,7 +2590,7 @@ mod __parse__Expr {
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym3 = (__loc1, (__tok), __loc2);
-                __result = try!(__custom5(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                __result = try!(__state44(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
                 return Ok(__result);
             }
             _ => {
@@ -2210,7 +2603,6 @@ mod __parse__Expr {
     }
 
     // State 31
-    //     Kind = None
     //     AllInputs = [Expr]
     //     OptionalInputs = []
     //     FixedInputs = [Expr]
@@ -2232,10 +2624,10 @@ mod __parse__Expr {
     //     Expr = Expr (*) "-" Factor [","]
     //     Expr = Expr (*) "-" Factor ["-"]
     //
-    //     ")" -> Reduce(Comma<Expr> = Expr => ActionFn(22);)
-    //     "+" -> Shift(S45)
-    //     "," -> Shift(S46)
-    //     "-" -> Shift(S47)
+    //   "+" -> S45
+    //   "," -> S46
+    //   "-" -> S47
+    //   ")" -> Comma<Expr> = Expr => ActionFn(22);
     //
     pub fn __state31<
         'ast,
@@ -2256,7 +2648,7 @@ mod __parse__Expr {
             }
             Some((__loc1, __tok @ Tok::Comma, __loc2)) => {
                 let __sym1 = (__loc1, (__tok), __loc2);
-                __result = try!(__custom6(arena, __tokens, __sym0, __sym1));
+                __result = try!(__state46(arena, __tokens, __sym0, __sym1));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
@@ -2286,7 +2678,6 @@ mod __parse__Expr {
     }
 
     // State 32
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -2311,12 +2702,12 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S48)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "," -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S49)
+    //   "*" -> S48
+    //   "/" -> S49
+    //   ")" -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "," -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state32<
         'ast,
@@ -2364,8 +2755,67 @@ mod __parse__Expr {
         }
     }
 
+    // State 33
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [")"]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) [","]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   ")" -> Factor = Term => ActionFn(7);
+    //   "*" -> Factor = Term => ActionFn(7);
+    //   "+" -> Factor = Term => ActionFn(7);
+    //   "," -> Factor = Term => ActionFn(7);
+    //   "-" -> Factor = Term => ActionFn(7);
+    //   "/" -> Factor = Term => ActionFn(7);
+    //
+    pub fn __state33<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Comma, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(arena, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 34
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -2419,9 +2869,9 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S14)
-    //     "*" -> Shift(S15)
-    //     Num -> Shift(S16)
+    //   "(" -> S14
+    //   "*" -> S15
+    //   Num -> S16
     //
     //     Expr -> S50
     //     Factor -> S12
@@ -2453,7 +2903,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym1));
+                __result = try!(__state16(arena, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2475,7 +2925,7 @@ mod __parse__Expr {
                     __result = try!(__state12(arena, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym1));
+                    __result = try!(__state13(arena, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -2485,7 +2935,6 @@ mod __parse__Expr {
     }
 
     // State 35
-    //     Kind = None
     //     AllInputs = ["*"]
     //     OptionalInputs = []
     //     FixedInputs = ["*"]
@@ -2500,7 +2949,7 @@ mod __parse__Expr {
     //     Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
     //     Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
     //
-    //     "(" -> Shift(S51)
+    //   "(" -> S51
     //
     pub fn __state35<
         'ast,
@@ -2532,8 +2981,71 @@ mod __parse__Expr {
         }
     }
 
+    // State 36
+    //     AllInputs = [Num]
+    //     OptionalInputs = []
+    //     FixedInputs = [Num]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = Num (*) [")"]
+    //     Term = Num (*) ["*"]
+    //     Term = Num (*) ["+"]
+    //     Term = Num (*) [","]
+    //     Term = Num (*) ["-"]
+    //     Term = Num (*) ["/"]
+    //
+    //   ")" -> Term = Num => ActionFn(8);
+    //   "*" -> Term = Num => ActionFn(8);
+    //   "+" -> Term = Num => ActionFn(8);
+    //   "," -> Term = Num => ActionFn(8);
+    //   "-" -> Term = Num => ActionFn(8);
+    //   "/" -> Term = Num => ActionFn(8);
+    //
+    pub fn __state36<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, i32, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Comma, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action8(arena, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 37
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -2555,11 +3067,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S25)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S26)
+    //   "*" -> S25
+    //   "/" -> S26
+    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state37<
         'ast,
@@ -2611,7 +3123,6 @@ mod __parse__Expr {
     }
 
     // State 38
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -2633,11 +3144,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S25)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S26)
+    //   "*" -> S25
+    //   "/" -> S26
+    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state38<
         'ast,
@@ -2688,8 +3199,188 @@ mod __parse__Expr {
         }
     }
 
+    // State 39
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [")"]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state39<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(arena, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 40
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [")"]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state40<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(arena, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 41
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [")"]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   ")" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(9);
+    //
+    pub fn __state41<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, &'ast Node<'ast>, usize),
+        __sym2: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action9(arena, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 42
-    //     Kind = None
     //     AllInputs = ["*", "(", Comma<Expr>]
     //     OptionalInputs = []
     //     FixedInputs = ["*", "(", Comma<Expr>]
@@ -2703,7 +3394,7 @@ mod __parse__Expr {
     //     Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
     //     Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
     //
-    //     ")" -> Shift(S52)
+    //   ")" -> S52
     //
     pub fn __state42<
         'ast,
@@ -2721,7 +3412,7 @@ mod __parse__Expr {
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym3 = (__loc1, (__tok), __loc2);
-                __result = try!(__custom5(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                __result = try!(__state52(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
                 return Ok(__result);
             }
             _ => {
@@ -2734,7 +3425,6 @@ mod __parse__Expr {
     }
 
     // State 43
-    //     Kind = None
     //     AllInputs = [(<Expr> ",")+, Expr]
     //     OptionalInputs = [(<Expr> ",")+]
     //     FixedInputs = [Expr]
@@ -2756,10 +3446,10 @@ mod __parse__Expr {
     //     Expr = Expr (*) "-" Factor [","]
     //     Expr = Expr (*) "-" Factor ["-"]
     //
-    //     ")" -> Reduce(Comma<Expr> = (<Expr> ",")+, Expr => ActionFn(24);)
-    //     "+" -> Shift(S45)
-    //     "," -> Shift(S53)
-    //     "-" -> Shift(S47)
+    //   "+" -> S45
+    //   "," -> S53
+    //   "-" -> S47
+    //   ")" -> Comma<Expr> = (<Expr> ",")+, Expr => ActionFn(24);
     //
     pub fn __state43<
         'ast,
@@ -2782,7 +3472,7 @@ mod __parse__Expr {
             Some((__loc1, __tok @ Tok::Comma, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom7(arena, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state53(arena, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
@@ -2812,8 +3502,71 @@ mod __parse__Expr {
         }
     }
 
+    // State 44
+    //     AllInputs = ["*", "(", Comma<Expr>, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*", "(", Comma<Expr>, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = "*" "(" Comma<Expr> ")" (*) [EOF]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["*"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["+"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["-"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["/"]
+    //
+    //   EOF -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "*" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "+" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "-" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "/" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //
+    pub fn __state44<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
+        __sym3: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            None |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym3.2.clone();
+                let __nt = super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 45
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -2862,9 +3615,9 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S34)
-    //     "*" -> Shift(S35)
-    //     Num -> Shift(S36)
+    //   "(" -> S34
+    //   "*" -> S35
+    //   Num -> S36
     //
     //     Factor -> S54
     //     Term -> S33
@@ -2897,7 +3650,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state36(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -2916,7 +3669,7 @@ mod __parse__Expr {
                     __result = try!(__state54(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
+                    __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -2925,8 +3678,66 @@ mod __parse__Expr {
         }
     }
 
+    // State 46
+    //     AllInputs = [Expr, ","]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr, ","]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some((<Expr> ",")+)
+    //
+    //     (<Expr> ",")+ = Expr "," (*) ["("]
+    //     (<Expr> ",")+ = Expr "," (*) [")"]
+    //     (<Expr> ",")+ = Expr "," (*) ["*"]
+    //     (<Expr> ",")+ = Expr "," (*) [Num]
+    //
+    //   "(" -> (<Expr> ",")+ = Expr, "," => ActionFn(18);
+    //   ")" -> (<Expr> ",")+ = Expr, "," => ActionFn(18);
+    //   "*" -> (<Expr> ",")+ = Expr, "," => ActionFn(18);
+    //   Num -> (<Expr> ",")+ = Expr, "," => ActionFn(18);
+    //
+    pub fn __state46<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            Some((_, Tok::LParen, _)) |
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Num(_), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action18(arena, __sym0, __sym1);
+                let __nt = __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 47
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -2975,9 +3786,9 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S34)
-    //     "*" -> Shift(S35)
-    //     Num -> Shift(S36)
+    //   "(" -> S34
+    //   "*" -> S35
+    //   Num -> S36
     //
     //     Factor -> S55
     //     Term -> S33
@@ -3010,7 +3821,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state36(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3029,7 +3840,7 @@ mod __parse__Expr {
                     __result = try!(__state55(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
+                    __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -3039,7 +3850,6 @@ mod __parse__Expr {
     }
 
     // State 48
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -3066,8 +3876,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S34)
-    //     Num -> Shift(S36)
+    //   "(" -> S34
+    //   Num -> S36
     //
     //     Term -> S56
     pub fn __state48<
@@ -3093,7 +3903,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state36(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3106,7 +3916,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom2(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state56(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -3117,7 +3927,6 @@ mod __parse__Expr {
     }
 
     // State 49
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -3144,8 +3953,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S34)
-    //     Num -> Shift(S36)
+    //   "(" -> S34
+    //   Num -> S36
     //
     //     Term -> S57
     pub fn __state49<
@@ -3171,7 +3980,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state36(arena, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -3184,7 +3993,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state57(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -3195,7 +4004,6 @@ mod __parse__Expr {
     }
 
     // State 50
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -3216,9 +4024,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S58)
-    //     "+" -> Shift(S23)
-    //     "-" -> Shift(S24)
+    //   ")" -> S58
+    //   "+" -> S23
+    //   "-" -> S24
     //
     pub fn __state50<
         'ast,
@@ -3236,7 +4044,7 @@ mod __parse__Expr {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(arena, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state58(arena, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
@@ -3259,7 +4067,6 @@ mod __parse__Expr {
     }
 
     // State 51
-    //     Kind = None
     //     AllInputs = ["*", "("]
     //     OptionalInputs = []
     //     FixedInputs = ["*", "("]
@@ -3334,10 +4141,10 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S34)
-    //     ")" -> Reduce(Comma<Expr> =  => ActionFn(23);)
-    //     "*" -> Shift(S35)
-    //     Num -> Shift(S36)
+    //   "(" -> S34
+    //   "*" -> S35
+    //   Num -> S36
+    //   ")" -> Comma<Expr> =  => ActionFn(23);
     //
     //     (<Expr> ",")+ -> S29
     //     Comma<Expr> -> S59
@@ -3371,7 +4178,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(arena, __tokens, __sym2));
+                __result = try!(__state36(arena, __tokens, __sym2));
             }
             Some((_, Tok::RParen, _)) => {
                 let __start = __sym1.2.clone();
@@ -3408,7 +4215,7 @@ mod __parse__Expr {
                     __result = try!(__state32(arena, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(arena, __tokens, __lookahead, __sym2));
+                    __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -3417,8 +4224,131 @@ mod __parse__Expr {
         }
     }
 
+    // State 52
+    //     AllInputs = ["*", "(", Comma<Expr>, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*", "(", Comma<Expr>, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = "*" "(" Comma<Expr> ")" (*) [")"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["*"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["+"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["-"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["/"]
+    //
+    //   ")" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "*" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "+" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "-" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "/" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //
+    pub fn __state52<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
+        __sym3: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym3.2.clone();
+                let __nt = super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 53
+    //     AllInputs = [(<Expr> ",")+, Expr, ","]
+    //     OptionalInputs = []
+    //     FixedInputs = [(<Expr> ",")+, Expr, ","]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some((<Expr> ",")+)
+    //
+    //     (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) ["("]
+    //     (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) [")"]
+    //     (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) ["*"]
+    //     (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) [Num]
+    //
+    //   "(" -> (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
+    //   ")" -> (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
+    //   "*" -> (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
+    //   Num -> (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
+    //
+    pub fn __state53<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, ::std::vec::Vec<&'ast Node<'ast>>, usize),
+        __sym1: (usize, &'ast Node<'ast>, usize),
+        __sym2: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            Some((_, Tok::LParen, _)) |
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Num(_), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action19(arena, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 54
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -3443,12 +4373,12 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S48)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "," -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S49)
+    //   "*" -> S48
+    //   "/" -> S49
+    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "," -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state54<
         'ast,
@@ -3501,7 +4431,6 @@ mod __parse__Expr {
     }
 
     // State 55
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -3526,12 +4455,12 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S48)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "," -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S49)
+    //   "*" -> S48
+    //   "/" -> S49
+    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "," -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state55<
         'ast,
@@ -3583,8 +4512,197 @@ mod __parse__Expr {
         }
     }
 
+    // State 56
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [")"]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) [","]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "," -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state56<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Comma, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(arena, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 57
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [")"]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) [","]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "," -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state57<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, Tok, usize)>,
+        __sym0: (usize, &'ast Node<'ast>, usize),
+        __sym1: (usize, Tok, usize),
+        __sym2: (usize, &'ast Node<'ast>, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Comma, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(arena, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 58
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [")"]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) [","]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   ")" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "," -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(9);
+    //
+    pub fn __state58<
+        'ast,
+        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
+    >(
+        arena: &'ast Arena<'ast>,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, Tok, usize),
+        __sym1: (usize, &'ast Node<'ast>, usize),
+        __sym2: (usize, Tok, usize),
+    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
+    {
+        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Comma, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action9(arena, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 59
-    //     Kind = None
     //     AllInputs = ["*", "(", Comma<Expr>]
     //     OptionalInputs = []
     //     FixedInputs = ["*", "(", Comma<Expr>]
@@ -3599,7 +4717,7 @@ mod __parse__Expr {
     //     Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
     //     Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
     //
-    //     ")" -> Shift(S60)
+    //   ")" -> S60
     //
     pub fn __state59<
         'ast,
@@ -3617,7 +4735,7 @@ mod __parse__Expr {
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym3 = (__loc1, (__tok), __loc2);
-                __result = try!(__custom5(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                __result = try!(__state60(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
                 return Ok(__result);
             }
             _ => {
@@ -3629,148 +4747,29 @@ mod __parse__Expr {
         }
     }
 
-    // Custom 0
-    //    Reduce Factor = Term => ActionFn(7);
-    pub fn __custom0<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: (usize, &'ast Node<'ast>, usize),
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action7(arena, __sym0);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce Term = Num => ActionFn(8);
-    pub fn __custom1<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, i32, usize),
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action8(arena, __sym0);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 2
-    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
-    pub fn __custom2<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: (usize, &'ast Node<'ast>, usize),
-        __sym1: (usize, Tok, usize),
-        __sym2: (usize, &'ast Node<'ast>, usize),
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action4(arena, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 3
-    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
-    pub fn __custom3<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, Tok, usize)>,
-        __sym0: (usize, &'ast Node<'ast>, usize),
-        __sym1: (usize, Tok, usize),
-        __sym2: (usize, &'ast Node<'ast>, usize),
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action5(arena, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 4
-    //    Reduce Term = "(", Expr, ")" => ActionFn(9);
-    pub fn __custom4<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, Tok, usize),
-        __sym1: (usize, &'ast Node<'ast>, usize),
-        __sym2: (usize, Tok, usize),
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action9(arena, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 5
-    //    Reduce Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    pub fn __custom5<
+    // State 60
+    //     AllInputs = ["*", "(", Comma<Expr>, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*", "(", Comma<Expr>, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = "*" "(" Comma<Expr> ")" (*) [")"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["*"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["+"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) [","]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["-"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["/"]
+    //
+    //   ")" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "*" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "+" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "," -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "-" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   "/" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //
+    pub fn __state60<
         'ast,
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
@@ -3788,77 +4787,31 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym3.2.clone();
-        let __nt = super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 6
-    //    Reduce (<Expr> ",")+ = Expr, "," => ActionFn(18);
-    pub fn __custom6<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, &'ast Node<'ast>, usize),
-        __sym1: (usize, Tok, usize),
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = super::__action18(arena, __sym0, __sym1);
-        let __nt = __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 7
-    //    Reduce (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
-    pub fn __custom7<
-        'ast,
-        __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
-    >(
-        arena: &'ast Arena<'ast>,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, ::std::vec::Vec<&'ast Node<'ast>>, usize),
-        __sym1: (usize, &'ast Node<'ast>, usize),
-        __sym2: (usize, Tok, usize),
-    ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __ParseError<usize,Tok,()>>
-    {
-        let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action19(arena, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Comma, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym3.2.clone();
+                let __nt = super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/expr_arena.rs
+++ b/lalrpop-test/src/expr_arena.rs
@@ -61,45 +61,45 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = (*) Expr "+" Factor [EOF]
     //     Expr = (*) Expr "+" Factor ["+"]
     //     Expr = (*) Expr "+" Factor ["-"]
-    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor [EOF]
     //     Expr = (*) Expr "-" Factor ["+"]
     //     Expr = (*) Expr "-" Factor ["-"]
-    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Expr "-" Factor [EOF]
     //     Expr = (*) Factor ["+"]
     //     Expr = (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = (*) Factor [EOF]
     //     Factor = (*) Factor "*" Term ["*"]
     //     Factor = (*) Factor "*" Term ["+"]
     //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "*" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
     //     Factor = (*) Factor "/" Term ["+"]
     //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Term ["*"]
     //     Factor = (*) Term ["+"]
     //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" [EOF]
+    //     Factor = (*) Term [EOF]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
+    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) Num ["*"]
     //     Term = (*) Num ["+"]
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
+    //     Term = (*) Num [EOF]
     //     __Expr = (*) Expr [EOF]
     //
     //   "(" -> S4
@@ -166,17 +166,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [EOF]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [EOF]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Expr = Expr (*) "+" Factor ["+", "-", EOF]
+    //     Expr = Expr (*) "-" Factor ["+", "-", EOF]
     //     __Expr = Expr (*) [EOF]
     //
     //   "+" -> S7
     //   "-" -> S8
-    //   EOF -> __Expr = Expr => ActionFn(0);
+    //   [EOF] -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         'ast,
@@ -229,25 +225,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [EOF]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S9
     //   "/" -> S10
-    //   EOF -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   ["+", "-", EOF] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         'ast,
@@ -271,9 +255,9 @@ mod __parse__Expr {
                 __result = try!(__state10(arena, __tokens, __sym0, __sym1));
                 return Ok(__result);
             }
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(arena, __sym0);
@@ -302,17 +286,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [EOF]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Term => ActionFn(7);
-    //   "*" -> Factor = Term => ActionFn(7);
-    //   "+" -> Factor = Term => ActionFn(7);
-    //   "-" -> Factor = Term => ActionFn(7);
-    //   "/" -> Factor = Term => ActionFn(7);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Term => ActionFn(7);
     //
     pub fn __state3<
         'ast,
@@ -326,11 +302,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action7(arena, __sym0);
@@ -393,11 +369,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [EOF]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" ["*", "+", "-", "/", EOF]
     //     Term = (*) Num [")"]
     //     Term = (*) Num ["*"]
     //     Term = (*) Num ["+"]
@@ -477,11 +449,7 @@ mod __parse__Expr {
     //     WillPush = ["(", Comma<Expr>, ")"]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = "*" (*) "(" Comma<Expr> ")" [EOF]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["*"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["+"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S17
     //
@@ -523,17 +491,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = Num (*) [EOF]
-    //     Term = Num (*) ["*"]
-    //     Term = Num (*) ["+"]
-    //     Term = Num (*) ["-"]
-    //     Term = Num (*) ["/"]
+    //     Term = Num (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = Num => ActionFn(8);
-    //   "*" -> Term = Num => ActionFn(8);
-    //   "+" -> Term = Num => ActionFn(8);
-    //   "-" -> Term = Num => ActionFn(8);
-    //   "/" -> Term = Num => ActionFn(8);
+    //   ["*", "+", "-", "/", EOF] -> Term = Num => ActionFn(8);
     //
     pub fn __state6<
         'ast,
@@ -551,11 +511,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action8(arena, __sym0);
@@ -584,38 +544,24 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [EOF]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = Expr "+" (*) Factor ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["+", "-", EOF]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["+", "-", EOF]
     //     Factor = (*) Term ["/"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" [EOF]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+", "-", EOF]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["+", "-", EOF]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["+", "-", EOF]
     //     Term = (*) Num ["/"]
     //
     //   "(" -> S4
@@ -689,38 +635,24 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [EOF]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = Expr "-" (*) Factor ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["+", "-", EOF]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["+", "-", EOF]
     //     Factor = (*) Term ["/"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" [EOF]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+", "-", EOF]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["+", "-", EOF]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["+", "-", EOF]
     //     Term = (*) Num ["/"]
     //
     //   "(" -> S4
@@ -794,21 +726,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [EOF]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "*" (*) Term ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
+    //     Term = (*) Num ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   Num -> S6
@@ -868,21 +788,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [EOF]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "/" (*) Term ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
+    //     Term = (*) Num ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   Num -> S6
@@ -942,17 +850,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [EOF]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" ["*", "+", "-", "/", EOF]
     //
     //   ")" -> S22
     //   "+" -> S23
@@ -1004,25 +904,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [")"]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S25
     //   "/" -> S26
-    //   ")" -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   [")", "+", "-"] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state12<
         'ast,
@@ -1077,17 +965,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [")"]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Term => ActionFn(7);
-    //   "*" -> Factor = Term => ActionFn(7);
-    //   "+" -> Factor = Term => ActionFn(7);
-    //   "-" -> Factor = Term => ActionFn(7);
-    //   "/" -> Factor = Term => ActionFn(7);
+    //   [")", "*", "+", "-", "/"] -> Factor = Term => ActionFn(7);
     //
     pub fn __state13<
         'ast,
@@ -1168,11 +1048,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [")"]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")", "*", "+", "-", "/"]
     //     Term = (*) Num [")"]
     //     Term = (*) Num ["*"]
     //     Term = (*) Num ["+"]
@@ -1252,11 +1128,7 @@ mod __parse__Expr {
     //     WillPush = ["(", Comma<Expr>, ")"]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = "*" (*) "(" Comma<Expr> ")" [")"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["*"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["+"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" [")", "*", "+", "-", "/"]
     //
     //   "(" -> S28
     //
@@ -1298,17 +1170,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = Num (*) [")"]
-    //     Term = Num (*) ["*"]
-    //     Term = Num (*) ["+"]
-    //     Term = Num (*) ["-"]
-    //     Term = Num (*) ["/"]
+    //     Term = Num (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Term = Num => ActionFn(8);
-    //   "*" -> Term = Num => ActionFn(8);
-    //   "+" -> Term = Num => ActionFn(8);
-    //   "-" -> Term = Num => ActionFn(8);
-    //   "/" -> Term = Num => ActionFn(8);
+    //   [")", "*", "+", "-", "/"] -> Term = Num => ActionFn(8);
     //
     pub fn __state16<
         'ast,
@@ -1359,14 +1223,10 @@ mod __parse__Expr {
     //     WillPush = [Comma<Expr>, ")"]
     //     WillProduce = Some(Factor)
     //
-    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["("]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["(", "*", Num]
     //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [")"]
-    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["*"]
-    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [Num]
-    //     (<Expr> ",")+ = (*) Expr "," ["("]
+    //     (<Expr> ",")+ = (*) Expr "," ["(", "*", Num]
     //     (<Expr> ",")+ = (*) Expr "," [")"]
-    //     (<Expr> ",")+ = (*) Expr "," ["*"]
-    //     (<Expr> ",")+ = (*) Expr "," [Num]
     //     Comma<Expr> = (*) [")"]
     //     Comma<Expr> = (*) (<Expr> ",")+ [")"]
     //     Comma<Expr> = (*) (<Expr> ",")+ Expr [")"]
@@ -1407,11 +1267,7 @@ mod __parse__Expr {
     //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" [EOF]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["*"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["+"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["-"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["/"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" ["*", "+", "-", "/", EOF]
     //     Term = (*) "(" Expr ")" [")"]
     //     Term = (*) "(" Expr ")" ["*"]
     //     Term = (*) "(" Expr ")" ["+"]
@@ -1428,7 +1284,7 @@ mod __parse__Expr {
     //   "(" -> S34
     //   "*" -> S35
     //   Num -> S36
-    //   ")" -> Comma<Expr> =  => ActionFn(23);
+    //   [")"] -> Comma<Expr> =  => ActionFn(23);
     //
     //     (<Expr> ",")+ -> S29
     //     Comma<Expr> -> S30
@@ -1516,25 +1372,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [EOF]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S9
     //   "/" -> S10
-    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   ["+", "-", EOF] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state18<
         'ast,
@@ -1560,9 +1404,9 @@ mod __parse__Expr {
                 __result = try!(__state10(arena, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1593,25 +1437,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [EOF]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S9
     //   "/" -> S10
-    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   ["+", "-", EOF] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state19<
         'ast,
@@ -1637,9 +1469,9 @@ mod __parse__Expr {
                 __result = try!(__state10(arena, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1670,17 +1502,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [EOF]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state20<
         'ast,
@@ -1696,11 +1520,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action4(arena, __sym0, __sym1, __sym2);
@@ -1729,17 +1553,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [EOF]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state21<
         'ast,
@@ -1755,11 +1571,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action5(arena, __sym0, __sym1, __sym2);
@@ -1788,17 +1604,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [EOF]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   ["*", "+", "-", "/", EOF] -> Term = "(", Expr, ")" => ActionFn(9);
     //
     pub fn __state22<
         'ast,
@@ -1818,11 +1626,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action9(arena, __sym0, __sym1, __sym2);
@@ -1851,38 +1659,24 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [")"]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "+" (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")", "+", "-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
+    //     Term = (*) Num [")", "+", "-"]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
     //   "(" -> S14
@@ -1956,38 +1750,24 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [")"]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "-" (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")", "+", "-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
+    //     Term = (*) Num [")", "+", "-"]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
     //   "(" -> S14
@@ -2061,21 +1841,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [")"]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "*" (*) Term [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
+    //     Term = (*) Num [")", "*", "+", "-", "/"]
     //
     //   "(" -> S14
     //   Num -> S16
@@ -2135,21 +1903,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [")"]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "/" (*) Term [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
+    //     Term = (*) Num [")", "*", "+", "-", "/"]
     //
     //   "(" -> S14
     //   Num -> S16
@@ -2209,17 +1965,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [")"]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" [")", "*", "+", "-", "/"]
     //
     //   ")" -> S41
     //   "+" -> S23
@@ -2271,14 +2019,10 @@ mod __parse__Expr {
     //     WillPush = [Comma<Expr>, ")"]
     //     WillProduce = Some(Factor)
     //
-    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["("]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["(", "*", Num]
     //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [")"]
-    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["*"]
-    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [Num]
-    //     (<Expr> ",")+ = (*) Expr "," ["("]
+    //     (<Expr> ",")+ = (*) Expr "," ["(", "*", Num]
     //     (<Expr> ",")+ = (*) Expr "," [")"]
-    //     (<Expr> ",")+ = (*) Expr "," ["*"]
-    //     (<Expr> ",")+ = (*) Expr "," [Num]
     //     Comma<Expr> = (*) [")"]
     //     Comma<Expr> = (*) (<Expr> ",")+ [")"]
     //     Comma<Expr> = (*) (<Expr> ",")+ Expr [")"]
@@ -2319,11 +2063,7 @@ mod __parse__Expr {
     //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" [")"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["*"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["+"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["-"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["/"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" [")", "*", "+", "-", "/"]
     //     Term = (*) "(" Expr ")" [")"]
     //     Term = (*) "(" Expr ")" ["*"]
     //     Term = (*) "(" Expr ")" ["+"]
@@ -2340,7 +2080,7 @@ mod __parse__Expr {
     //   "(" -> S34
     //   "*" -> S35
     //   Num -> S36
-    //   ")" -> Comma<Expr> =  => ActionFn(23);
+    //   [")"] -> Comma<Expr> =  => ActionFn(23);
     //
     //     (<Expr> ",")+ -> S29
     //     Comma<Expr> -> S42
@@ -2428,10 +2168,7 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," ["("]
-    //     (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," [")"]
-    //     (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," ["*"]
-    //     (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," [Num]
+    //     (<Expr> ",")+ = (<Expr> ",")+ (*) Expr "," ["(", ")", "*", Num]
     //     Comma<Expr> = (<Expr> ",")+ (*) [")"]
     //     Comma<Expr> = (<Expr> ",")+ (*) Expr [")"]
     //     Expr = (*) Expr "+" Factor [")"]
@@ -2486,7 +2223,7 @@ mod __parse__Expr {
     //   "(" -> S34
     //   "*" -> S35
     //   Num -> S36
-    //   ")" -> Comma<Expr> = (<Expr> ",")+ => ActionFn(25);
+    //   [")"] -> Comma<Expr> = (<Expr> ",")+ => ActionFn(25);
     //
     //     Expr -> S43
     //     Factor -> S32
@@ -2566,11 +2303,7 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = "*" "(" Comma<Expr> (*) ")" [EOF]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["*"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["+"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" ["*", "+", "-", "/", EOF]
     //
     //   ")" -> S44
     //
@@ -2610,24 +2343,15 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     (<Expr> ",")+ = Expr (*) "," ["("]
-    //     (<Expr> ",")+ = Expr (*) "," [")"]
-    //     (<Expr> ",")+ = Expr (*) "," ["*"]
-    //     (<Expr> ",")+ = Expr (*) "," [Num]
+    //     (<Expr> ",")+ = Expr (*) "," ["(", ")", "*", Num]
     //     Comma<Expr> = Expr (*) [")"]
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor [","]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor [","]
-    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Expr = Expr (*) "+" Factor [")", "+", ",", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", ",", "-"]
     //
     //   "+" -> S45
     //   "," -> S46
     //   "-" -> S47
-    //   ")" -> Comma<Expr> = Expr => ActionFn(22);
+    //   [")"] -> Comma<Expr> = Expr => ActionFn(22);
     //
     pub fn __state31<
         'ast,
@@ -2685,29 +2409,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [")"]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) [","]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term [","]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term [","]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) [")", "+", ",", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", ",", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", ",", "-", "/"]
     //
     //   "*" -> S48
     //   "/" -> S49
-    //   ")" -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "," -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   [")", "+", ",", "-"] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state32<
         'ast,
@@ -2763,19 +2471,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [")"]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) [","]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) [")", "*", "+", ",", "-", "/"]
     //
-    //   ")" -> Factor = Term => ActionFn(7);
-    //   "*" -> Factor = Term => ActionFn(7);
-    //   "+" -> Factor = Term => ActionFn(7);
-    //   "," -> Factor = Term => ActionFn(7);
-    //   "-" -> Factor = Term => ActionFn(7);
-    //   "/" -> Factor = Term => ActionFn(7);
+    //   [")", "*", "+", ",", "-", "/"] -> Factor = Term => ActionFn(7);
     //
     pub fn __state33<
         'ast,
@@ -2857,12 +2555,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [")"]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" [","]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")", "*", "+", ",", "-", "/"]
     //     Term = (*) Num [")"]
     //     Term = (*) Num ["*"]
     //     Term = (*) Num ["+"]
@@ -2942,12 +2635,7 @@ mod __parse__Expr {
     //     WillPush = ["(", Comma<Expr>, ")"]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = "*" (*) "(" Comma<Expr> ")" [")"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["*"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["+"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" [","]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["-"]
-    //     Factor = "*" (*) "(" Comma<Expr> ")" ["/"]
+    //     Factor = "*" (*) "(" Comma<Expr> ")" [")", "*", "+", ",", "-", "/"]
     //
     //   "(" -> S51
     //
@@ -2989,19 +2677,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = Num (*) [")"]
-    //     Term = Num (*) ["*"]
-    //     Term = Num (*) ["+"]
-    //     Term = Num (*) [","]
-    //     Term = Num (*) ["-"]
-    //     Term = Num (*) ["/"]
+    //     Term = Num (*) [")", "*", "+", ",", "-", "/"]
     //
-    //   ")" -> Term = Num => ActionFn(8);
-    //   "*" -> Term = Num => ActionFn(8);
-    //   "+" -> Term = Num => ActionFn(8);
-    //   "," -> Term = Num => ActionFn(8);
-    //   "-" -> Term = Num => ActionFn(8);
-    //   "/" -> Term = Num => ActionFn(8);
+    //   [")", "*", "+", ",", "-", "/"] -> Term = Num => ActionFn(8);
     //
     pub fn __state36<
         'ast,
@@ -3053,25 +2731,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [")"]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S25
     //   "/" -> S26
-    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   [")", "+", "-"] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state37<
         'ast,
@@ -3130,25 +2796,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [")"]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S25
     //   "/" -> S26
-    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   [")", "+", "-"] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state38<
         'ast,
@@ -3207,17 +2861,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [")"]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   [")", "*", "+", "-", "/"] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state39<
         'ast,
@@ -3266,17 +2912,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [")"]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   [")", "*", "+", "-", "/"] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state40<
         'ast,
@@ -3325,17 +2963,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [")"]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   [")", "*", "+", "-", "/"] -> Term = "(", Expr, ")" => ActionFn(9);
     //
     pub fn __state41<
         'ast,
@@ -3388,11 +3018,7 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = "*" "(" Comma<Expr> (*) ")" [")"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["*"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["+"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" [")", "*", "+", "-", "/"]
     //
     //   ")" -> S52
     //
@@ -3432,24 +3058,15 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," ["("]
-    //     (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," [")"]
-    //     (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," ["*"]
-    //     (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," [Num]
+    //     (<Expr> ",")+ = (<Expr> ",")+ Expr (*) "," ["(", ")", "*", Num]
     //     Comma<Expr> = (<Expr> ",")+ Expr (*) [")"]
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor [","]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor [","]
-    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Expr = Expr (*) "+" Factor [")", "+", ",", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", ",", "-"]
     //
     //   "+" -> S45
     //   "," -> S53
     //   "-" -> S47
-    //   ")" -> Comma<Expr> = (<Expr> ",")+, Expr => ActionFn(24);
+    //   [")"] -> Comma<Expr> = (<Expr> ",")+, Expr => ActionFn(24);
     //
     pub fn __state43<
         'ast,
@@ -3510,17 +3127,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = "*" "(" Comma<Expr> ")" (*) [EOF]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["*"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["+"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["-"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["/"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "*" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "+" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "-" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "/" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   ["*", "+", "-", "/", EOF] -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
     //
     pub fn __state44<
         'ast,
@@ -3541,11 +3150,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym3.2.clone();
                 let __nt = super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
@@ -3574,45 +3183,24 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [")"]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor [","]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "+" (*) Factor [")", "+", ",", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", ",", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term [","]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", ",", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term [","]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", ",", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term [","]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")", "+", ",", "-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", ",", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" [","]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
+    //     Term = (*) Num [")", "+", ",", "-"]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num [","]
-    //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
     //   "(" -> S34
@@ -3686,15 +3274,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some((<Expr> ",")+)
     //
-    //     (<Expr> ",")+ = Expr "," (*) ["("]
-    //     (<Expr> ",")+ = Expr "," (*) [")"]
-    //     (<Expr> ",")+ = Expr "," (*) ["*"]
-    //     (<Expr> ",")+ = Expr "," (*) [Num]
+    //     (<Expr> ",")+ = Expr "," (*) ["(", ")", "*", Num]
     //
-    //   "(" -> (<Expr> ",")+ = Expr, "," => ActionFn(18);
-    //   ")" -> (<Expr> ",")+ = Expr, "," => ActionFn(18);
-    //   "*" -> (<Expr> ",")+ = Expr, "," => ActionFn(18);
-    //   Num -> (<Expr> ",")+ = Expr, "," => ActionFn(18);
+    //   ["(", ")", "*", Num] -> (<Expr> ",")+ = Expr, "," => ActionFn(18);
     //
     pub fn __state46<
         'ast,
@@ -3745,45 +3327,24 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [")"]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor [","]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "-" (*) Factor [")", "+", ",", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", ",", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term [","]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", ",", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term [","]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", ",", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term [","]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" [")"]
+    //     Factor = (*) "*" "(" Comma<Expr> ")" [")", "+", ",", "-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["*"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["+"]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
-    //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", ",", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" [","]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
+    //     Term = (*) Num [")", "+", ",", "-"]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num [","]
-    //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
     //   "(" -> S34
@@ -3857,24 +3418,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [")"]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term [","]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" [","]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num [","]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "*" (*) Term [")", "*", "+", ",", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", ",", "-", "/"]
+    //     Term = (*) Num [")", "*", "+", ",", "-", "/"]
     //
     //   "(" -> S34
     //   Num -> S36
@@ -3934,24 +3480,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [")"]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term [","]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" [","]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num [","]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "/" (*) Term [")", "*", "+", ",", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", ",", "-", "/"]
+    //     Term = (*) Num [")", "*", "+", ",", "-", "/"]
     //
     //   "(" -> S34
     //   Num -> S36
@@ -4011,18 +3542,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [")"]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" [","]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" [")", "*", "+", ",", "-", "/"]
     //
     //   ")" -> S58
     //   "+" -> S23
@@ -4074,14 +3596,10 @@ mod __parse__Expr {
     //     WillPush = [Comma<Expr>, ")"]
     //     WillProduce = Some(Factor)
     //
-    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["("]
+    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["(", "*", Num]
     //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [")"]
-    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," ["*"]
-    //     (<Expr> ",")+ = (*) (<Expr> ",")+ Expr "," [Num]
-    //     (<Expr> ",")+ = (*) Expr "," ["("]
+    //     (<Expr> ",")+ = (*) Expr "," ["(", "*", Num]
     //     (<Expr> ",")+ = (*) Expr "," [")"]
-    //     (<Expr> ",")+ = (*) Expr "," ["*"]
-    //     (<Expr> ",")+ = (*) Expr "," [Num]
     //     Comma<Expr> = (*) [")"]
     //     Comma<Expr> = (*) (<Expr> ",")+ [")"]
     //     Comma<Expr> = (*) (<Expr> ",")+ Expr [")"]
@@ -4122,12 +3640,7 @@ mod __parse__Expr {
     //     Factor = (*) "*" "(" Comma<Expr> ")" [","]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["-"]
     //     Factor = (*) "*" "(" Comma<Expr> ")" ["/"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" [")"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["*"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["+"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" [","]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["-"]
-    //     Factor = "*" "(" (*) Comma<Expr> ")" ["/"]
+    //     Factor = "*" "(" (*) Comma<Expr> ")" [")", "*", "+", ",", "-", "/"]
     //     Term = (*) "(" Expr ")" [")"]
     //     Term = (*) "(" Expr ")" ["*"]
     //     Term = (*) "(" Expr ")" ["+"]
@@ -4144,7 +3657,7 @@ mod __parse__Expr {
     //   "(" -> S34
     //   "*" -> S35
     //   Num -> S36
-    //   ")" -> Comma<Expr> =  => ActionFn(23);
+    //   [")"] -> Comma<Expr> =  => ActionFn(23);
     //
     //     (<Expr> ",")+ -> S29
     //     Comma<Expr> -> S59
@@ -4232,17 +3745,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = "*" "(" Comma<Expr> ")" (*) [")"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["*"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["+"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["-"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["/"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "*" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "+" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "-" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "/" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   [")", "*", "+", "-", "/"] -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
     //
     pub fn __state52<
         'ast,
@@ -4296,15 +3801,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some((<Expr> ",")+)
     //
-    //     (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) ["("]
-    //     (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) [")"]
-    //     (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) ["*"]
-    //     (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) [Num]
+    //     (<Expr> ",")+ = (<Expr> ",")+ Expr "," (*) ["(", ")", "*", Num]
     //
-    //   "(" -> (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
-    //   ")" -> (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
-    //   "*" -> (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
-    //   Num -> (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
+    //   ["(", ")", "*", Num] -> (<Expr> ",")+ = (<Expr> ",")+, Expr, "," => ActionFn(19);
     //
     pub fn __state53<
         'ast,
@@ -4356,29 +3855,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [")"]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) [","]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term [","]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term [","]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) [")", "+", ",", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", ",", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", ",", "-", "/"]
     //
     //   "*" -> S48
     //   "/" -> S49
-    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "," -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   [")", "+", ",", "-"] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state54<
         'ast,
@@ -4438,29 +3921,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [")"]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) [","]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term [","]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term [","]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) [")", "+", ",", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", ",", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", ",", "-", "/"]
     //
     //   "*" -> S48
     //   "/" -> S49
-    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "," -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   [")", "+", ",", "-"] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state55<
         'ast,
@@ -4520,19 +3987,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [")"]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) [","]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) [")", "*", "+", ",", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "," -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   [")", "*", "+", ",", "-", "/"] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state56<
         'ast,
@@ -4582,19 +4039,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [")"]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) [","]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) [")", "*", "+", ",", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "," -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   [")", "*", "+", ",", "-", "/"] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state57<
         'ast,
@@ -4644,19 +4091,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [")"]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) [","]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) [")", "*", "+", ",", "-", "/"]
     //
-    //   ")" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "," -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(9);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(9);
+    //   [")", "*", "+", ",", "-", "/"] -> Term = "(", Expr, ")" => ActionFn(9);
     //
     pub fn __state58<
         'ast,
@@ -4710,12 +4147,7 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = "*" "(" Comma<Expr> (*) ")" [")"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["*"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["+"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" [","]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["-"]
-    //     Factor = "*" "(" Comma<Expr> (*) ")" ["/"]
+    //     Factor = "*" "(" Comma<Expr> (*) ")" [")", "*", "+", ",", "-", "/"]
     //
     //   ")" -> S60
     //
@@ -4755,19 +4187,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = "*" "(" Comma<Expr> ")" (*) [")"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["*"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["+"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) [","]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["-"]
-    //     Factor = "*" "(" Comma<Expr> ")" (*) ["/"]
+    //     Factor = "*" "(" Comma<Expr> ")" (*) [")", "*", "+", ",", "-", "/"]
     //
-    //   ")" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "*" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "+" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "," -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "-" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
-    //   "/" -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
+    //   [")", "*", "+", ",", "-", "/"] -> Factor = "*", "(", Comma<Expr>, ")" => ActionFn(6);
     //
     pub fn __state60<
         'ast,

--- a/lalrpop-test/src/expr_generic.rs
+++ b/lalrpop-test/src/expr_generic.rs
@@ -50,7 +50,6 @@ mod __parse__Expr {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -94,8 +93,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["/"]
     //     __Expr = (*) Expr [EOF]
     //
-    //     "(" -> Shift(S4)
-    //     r#"[0-9]+"# -> Shift(S5)
+    //   "(" -> S4
+    //   r#"[0-9]+"# -> S5
     //
     //     Expr -> S1
     //     Factor -> S2
@@ -119,7 +118,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym0));
+                __result = try!(__state5(input, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -138,7 +137,7 @@ mod __parse__Expr {
                     __result = try!(__state2(input, __tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::Term(__sym0) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym0));
+                    __result = try!(__state3(input, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -148,7 +147,6 @@ mod __parse__Expr {
     }
 
     // State 1
-    //     Kind = None
     //     AllInputs = [Expr]
     //     OptionalInputs = []
     //     FixedInputs = [Expr]
@@ -164,9 +162,9 @@ mod __parse__Expr {
     //     Expr = Expr (*) "-" Factor ["-"]
     //     __Expr = Expr (*) [EOF]
     //
-    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //     "+" -> Shift(S6)
-    //     "-" -> Shift(S7)
+    //   "+" -> S6
+    //   "-" -> S7
+    //   EOF -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         'input,
@@ -214,7 +212,6 @@ mod __parse__Expr {
     }
 
     // State 2
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -236,11 +233,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         'input,
@@ -289,8 +286,66 @@ mod __parse__Expr {
         }
     }
 
+    // State 3
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [EOF]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   EOF -> Factor = Term => ActionFn(6);
+    //   "*" -> Factor = Term => ActionFn(6);
+    //   "+" -> Factor = Term => ActionFn(6);
+    //   "-" -> Factor = Term => ActionFn(6);
+    //   "/" -> Factor = Term => ActionFn(6);
+    //
+    pub fn __state3<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, F, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action6(input, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 4
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -338,8 +393,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"[0-9]+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"[0-9]+"# -> S14
     //
     //     Expr -> S10
     //     Factor -> S11
@@ -369,7 +424,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym1));
+                __result = try!(__state14(input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -391,7 +446,7 @@ mod __parse__Expr {
                     __result = try!(__state11(input, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state12(input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -400,8 +455,70 @@ mod __parse__Expr {
         }
     }
 
+    // State 5
+    //     AllInputs = [r#"[0-9]+"#]
+    //     OptionalInputs = []
+    //     FixedInputs = [r#"[0-9]+"#]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = r#"[0-9]+"# (*) [EOF]
+    //     Term = r#"[0-9]+"# (*) ["*"]
+    //     Term = r#"[0-9]+"# (*) ["+"]
+    //     Term = r#"[0-9]+"# (*) ["-"]
+    //     Term = r#"[0-9]+"# (*) ["/"]
+    //
+    //   EOF -> Term = r#"[0-9]+"# => ActionFn(7);
+    //   "*" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //   "+" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //   "-" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //   "/" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //
+    pub fn __state5<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(input, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 6
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -438,8 +555,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     r#"[0-9]+"# -> Shift(S5)
+    //   "(" -> S4
+    //   r#"[0-9]+"# -> S5
     //
     //     Factor -> S15
     //     Term -> S3
@@ -470,7 +587,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state5(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -489,7 +606,7 @@ mod __parse__Expr {
                     __result = try!(__state15(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -499,7 +616,6 @@ mod __parse__Expr {
     }
 
     // State 7
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -536,8 +652,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     r#"[0-9]+"# -> Shift(S5)
+    //   "(" -> S4
+    //   r#"[0-9]+"# -> S5
     //
     //     Factor -> S16
     //     Term -> S3
@@ -568,7 +684,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state5(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -587,7 +703,7 @@ mod __parse__Expr {
                     __result = try!(__state16(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -597,7 +713,6 @@ mod __parse__Expr {
     }
 
     // State 8
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -621,8 +736,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     r#"[0-9]+"# -> Shift(S5)
+    //   "(" -> S4
+    //   r#"[0-9]+"# -> S5
     //
     //     Term -> S17
     pub fn __state8<
@@ -650,7 +765,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state5(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -663,7 +778,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom2(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state17(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -674,7 +789,6 @@ mod __parse__Expr {
     }
 
     // State 9
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -698,8 +812,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     r#"[0-9]+"# -> Shift(S5)
+    //   "(" -> S4
+    //   r#"[0-9]+"# -> S5
     //
     //     Term -> S18
     pub fn __state9<
@@ -727,7 +841,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state5(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -740,7 +854,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state18(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -751,7 +865,6 @@ mod __parse__Expr {
     }
 
     // State 10
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -771,9 +884,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S19)
-    //     "+" -> Shift(S20)
-    //     "-" -> Shift(S21)
+    //   ")" -> S19
+    //   "+" -> S20
+    //   "-" -> S21
     //
     pub fn __state10<
         'input,
@@ -793,7 +906,7 @@ mod __parse__Expr {
             Some((__loc1, (1, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(input, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state19(input, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
@@ -816,7 +929,6 @@ mod __parse__Expr {
     }
 
     // State 11
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -838,11 +950,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S22)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S23)
+    //   "*" -> S22
+    //   "/" -> S23
+    //   ")" -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state11<
         'input,
@@ -891,8 +1003,66 @@ mod __parse__Expr {
         }
     }
 
+    // State 12
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [")"]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   ")" -> Factor = Term => ActionFn(6);
+    //   "*" -> Factor = Term => ActionFn(6);
+    //   "+" -> Factor = Term => ActionFn(6);
+    //   "-" -> Factor = Term => ActionFn(6);
+    //   "/" -> Factor = Term => ActionFn(6);
+    //
+    pub fn __state12<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, F, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action6(input, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 13
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -940,8 +1110,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"[0-9]+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"[0-9]+"# -> S14
     //
     //     Expr -> S24
     //     Factor -> S11
@@ -971,7 +1141,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym1));
+                __result = try!(__state14(input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -993,7 +1163,7 @@ mod __parse__Expr {
                     __result = try!(__state11(input, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state12(input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1002,8 +1172,70 @@ mod __parse__Expr {
         }
     }
 
+    // State 14
+    //     AllInputs = [r#"[0-9]+"#]
+    //     OptionalInputs = []
+    //     FixedInputs = [r#"[0-9]+"#]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = r#"[0-9]+"# (*) [")"]
+    //     Term = r#"[0-9]+"# (*) ["*"]
+    //     Term = r#"[0-9]+"# (*) ["+"]
+    //     Term = r#"[0-9]+"# (*) ["-"]
+    //     Term = r#"[0-9]+"# (*) ["/"]
+    //
+    //   ")" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //   "*" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //   "+" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //   "-" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //   "/" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //
+    pub fn __state14<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(input, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 15
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -1025,11 +1257,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state15<
         'input,
@@ -1083,7 +1315,6 @@ mod __parse__Expr {
     }
 
     // State 16
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -1105,11 +1336,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state16<
         'input,
@@ -1162,8 +1393,194 @@ mod __parse__Expr {
         }
     }
 
+    // State 17
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [EOF]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state17<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, F, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 18
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [EOF]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state18<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, F, usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, F, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 19
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [EOF]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   EOF -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //
+    pub fn __state19<
+        'input,
+        F,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, F, usize),
+        __sym2: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
+      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action8(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 20
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -1200,8 +1617,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"[0-9]+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"[0-9]+"# -> S14
     //
     //     Factor -> S25
     //     Term -> S12
@@ -1232,7 +1649,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state14(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1251,7 +1668,7 @@ mod __parse__Expr {
                     __result = try!(__state25(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state12(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1261,7 +1678,6 @@ mod __parse__Expr {
     }
 
     // State 21
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -1298,8 +1714,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"[0-9]+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"[0-9]+"# -> S14
     //
     //     Factor -> S26
     //     Term -> S12
@@ -1330,7 +1746,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state14(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1349,7 +1765,7 @@ mod __parse__Expr {
                     __result = try!(__state26(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state12(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1359,7 +1775,6 @@ mod __parse__Expr {
     }
 
     // State 22
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -1383,8 +1798,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"[0-9]+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"[0-9]+"# -> S14
     //
     //     Term -> S27
     pub fn __state22<
@@ -1412,7 +1827,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state14(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1425,7 +1840,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom2(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state27(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -1436,7 +1851,6 @@ mod __parse__Expr {
     }
 
     // State 23
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -1460,8 +1874,8 @@ mod __parse__Expr {
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"[0-9]+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"[0-9]+"# -> S14
     //
     //     Term -> S28
     pub fn __state23<
@@ -1489,7 +1903,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state14(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1502,7 +1916,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -1513,7 +1927,6 @@ mod __parse__Expr {
     }
 
     // State 24
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -1533,9 +1946,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S29)
-    //     "+" -> Shift(S20)
-    //     "-" -> Shift(S21)
+    //   ")" -> S29
+    //   "+" -> S20
+    //   "-" -> S21
     //
     pub fn __state24<
         'input,
@@ -1555,7 +1968,7 @@ mod __parse__Expr {
             Some((__loc1, (1, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(input, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state29(input, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
@@ -1578,7 +1991,6 @@ mod __parse__Expr {
     }
 
     // State 25
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -1600,11 +2012,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S22)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S23)
+    //   "*" -> S22
+    //   "/" -> S23
+    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state25<
         'input,
@@ -1658,7 +2070,6 @@ mod __parse__Expr {
     }
 
     // State 26
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -1680,11 +2091,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S22)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S23)
+    //   "*" -> S22
+    //   "/" -> S23
+    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state26<
         'input,
@@ -1737,67 +2148,27 @@ mod __parse__Expr {
         }
     }
 
-    // Custom 0
-    //    Reduce Factor = Term => ActionFn(6);
-    pub fn __custom0<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: (usize, F, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action6(input, __sym0);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce Term = r#"[0-9]+"# => ActionFn(7);
-    pub fn __custom1<
-        'input,
-        F,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, &'input str, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __ParseError<usize,(usize, &'input str),()>> where
-      F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action7(input, __sym0);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 2
-    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
-    pub fn __custom2<
+    // State 27
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [")"]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state27<
         'input,
         F,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1812,21 +2183,53 @@ mod __parse__Expr {
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action4(input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 3
-    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
-    pub fn __custom3<
+    // State 28
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [")"]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state28<
         'input,
         F,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1841,21 +2244,53 @@ mod __parse__Expr {
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F>,
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action5(input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 4
-    //    Reduce Term = "(", Expr, ")" => ActionFn(8);
-    pub fn __custom4<
+    // State 29
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [")"]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   ")" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //
+    pub fn __state29<
         'input,
         F,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
@@ -1874,16 +2309,30 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action8(input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action8(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/expr_generic.rs
+++ b/lalrpop-test/src/expr_generic.rs
@@ -57,40 +57,40 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = (*) Expr "+" Factor [EOF]
     //     Expr = (*) Expr "+" Factor ["+"]
     //     Expr = (*) Expr "+" Factor ["-"]
-    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor [EOF]
     //     Expr = (*) Expr "-" Factor ["+"]
     //     Expr = (*) Expr "-" Factor ["-"]
-    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Expr "-" Factor [EOF]
     //     Expr = (*) Factor ["+"]
     //     Expr = (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = (*) Factor [EOF]
     //     Factor = (*) Factor "*" Term ["*"]
     //     Factor = (*) Factor "*" Term ["+"]
     //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "*" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
     //     Factor = (*) Factor "/" Term ["+"]
     //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Term ["*"]
     //     Factor = (*) Term ["+"]
     //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
+    //     Factor = (*) Term [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"[0-9]+"# [EOF]
+    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) r#"[0-9]+"# ["*"]
     //     Term = (*) r#"[0-9]+"# ["+"]
     //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
+    //     Term = (*) r#"[0-9]+"# [EOF]
     //     __Expr = (*) Expr [EOF]
     //
     //   "(" -> S4
@@ -154,17 +154,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [EOF]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [EOF]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Expr = Expr (*) "+" Factor ["+", "-", EOF]
+    //     Expr = Expr (*) "-" Factor ["+", "-", EOF]
     //     __Expr = Expr (*) [EOF]
     //
     //   "+" -> S6
     //   "-" -> S7
-    //   EOF -> __Expr = Expr => ActionFn(0);
+    //   [EOF] -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         'input,
@@ -219,25 +215,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [EOF]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   ["+", "-", EOF] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         'input,
@@ -263,9 +247,9 @@ mod __parse__Expr {
                 __result = try!(__state9(input, __tokens, __sym0, __sym1));
                 return Ok(__result);
             }
-            None |
             Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) => {
+            Some((_, (4, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(input, __sym0);
@@ -294,17 +278,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [EOF]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Term => ActionFn(6);
-    //   "*" -> Factor = Term => ActionFn(6);
-    //   "+" -> Factor = Term => ActionFn(6);
-    //   "-" -> Factor = Term => ActionFn(6);
-    //   "/" -> Factor = Term => ActionFn(6);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Term => ActionFn(6);
     //
     pub fn __state3<
         'input,
@@ -320,11 +296,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action6(input, __sym0);
@@ -382,11 +358,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [EOF]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" ["*", "+", "-", "/", EOF]
     //     Term = (*) r#"[0-9]+"# [")"]
     //     Term = (*) r#"[0-9]+"# ["*"]
     //     Term = (*) r#"[0-9]+"# ["+"]
@@ -463,17 +435,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = r#"[0-9]+"# (*) [EOF]
-    //     Term = r#"[0-9]+"# (*) ["*"]
-    //     Term = r#"[0-9]+"# (*) ["+"]
-    //     Term = r#"[0-9]+"# (*) ["-"]
-    //     Term = r#"[0-9]+"# (*) ["/"]
+    //     Term = r#"[0-9]+"# (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = r#"[0-9]+"# => ActionFn(7);
-    //   "*" -> Term = r#"[0-9]+"# => ActionFn(7);
-    //   "+" -> Term = r#"[0-9]+"# => ActionFn(7);
-    //   "-" -> Term = r#"[0-9]+"# => ActionFn(7);
-    //   "/" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //   ["*", "+", "-", "/", EOF] -> Term = r#"[0-9]+"# => ActionFn(7);
     //
     pub fn __state5<
         'input,
@@ -493,11 +457,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action7(input, __sym0);
@@ -526,33 +490,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [EOF]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = Expr "+" (*) Factor ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["+", "-", EOF]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["+", "-", EOF]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["+", "-", EOF]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"[0-9]+"# [EOF]
     //     Term = (*) r#"[0-9]+"# ["*"]
-    //     Term = (*) r#"[0-9]+"# ["+"]
-    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["+", "-", EOF]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
     //   "(" -> S4
@@ -623,33 +575,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [EOF]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = Expr "-" (*) Factor ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["+", "-", EOF]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["+", "-", EOF]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["+", "-", EOF]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"[0-9]+"# [EOF]
     //     Term = (*) r#"[0-9]+"# ["*"]
-    //     Term = (*) r#"[0-9]+"# ["+"]
-    //     Term = (*) r#"[0-9]+"# ["-"]
+    //     Term = (*) r#"[0-9]+"# ["+", "-", EOF]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
     //   "(" -> S4
@@ -720,21 +660,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [EOF]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"[0-9]+"# [EOF]
-    //     Term = (*) r#"[0-9]+"# ["*"]
-    //     Term = (*) r#"[0-9]+"# ["+"]
-    //     Term = (*) r#"[0-9]+"# ["-"]
-    //     Term = (*) r#"[0-9]+"# ["/"]
+    //     Factor = Factor "*" (*) Term ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
+    //     Term = (*) r#"[0-9]+"# ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   r#"[0-9]+"# -> S5
@@ -796,21 +724,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [EOF]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"[0-9]+"# [EOF]
-    //     Term = (*) r#"[0-9]+"# ["*"]
-    //     Term = (*) r#"[0-9]+"# ["+"]
-    //     Term = (*) r#"[0-9]+"# ["-"]
-    //     Term = (*) r#"[0-9]+"# ["/"]
+    //     Factor = Factor "/" (*) Term ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
+    //     Term = (*) r#"[0-9]+"# ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   r#"[0-9]+"# -> S5
@@ -872,17 +788,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [EOF]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" ["*", "+", "-", "/", EOF]
     //
     //   ")" -> S19
     //   "+" -> S20
@@ -936,25 +844,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [")"]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S22
     //   "/" -> S23
-    //   ")" -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   [")", "+", "-"] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state11<
         'input,
@@ -1011,17 +907,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [")"]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Term => ActionFn(6);
-    //   "*" -> Factor = Term => ActionFn(6);
-    //   "+" -> Factor = Term => ActionFn(6);
-    //   "-" -> Factor = Term => ActionFn(6);
-    //   "/" -> Factor = Term => ActionFn(6);
+    //   [")", "*", "+", "-", "/"] -> Factor = Term => ActionFn(6);
     //
     pub fn __state12<
         'input,
@@ -1099,11 +987,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [")"]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")", "*", "+", "-", "/"]
     //     Term = (*) r#"[0-9]+"# [")"]
     //     Term = (*) r#"[0-9]+"# ["*"]
     //     Term = (*) r#"[0-9]+"# ["+"]
@@ -1180,17 +1064,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = r#"[0-9]+"# (*) [")"]
-    //     Term = r#"[0-9]+"# (*) ["*"]
-    //     Term = r#"[0-9]+"# (*) ["+"]
-    //     Term = r#"[0-9]+"# (*) ["-"]
-    //     Term = r#"[0-9]+"# (*) ["/"]
+    //     Term = r#"[0-9]+"# (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Term = r#"[0-9]+"# => ActionFn(7);
-    //   "*" -> Term = r#"[0-9]+"# => ActionFn(7);
-    //   "+" -> Term = r#"[0-9]+"# => ActionFn(7);
-    //   "-" -> Term = r#"[0-9]+"# => ActionFn(7);
-    //   "/" -> Term = r#"[0-9]+"# => ActionFn(7);
+    //   [")", "*", "+", "-", "/"] -> Term = r#"[0-9]+"# => ActionFn(7);
     //
     pub fn __state14<
         'input,
@@ -1243,25 +1119,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [EOF]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   ["+", "-", EOF] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state15<
         'input,
@@ -1289,9 +1153,9 @@ mod __parse__Expr {
                 __result = try!(__state9(input, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) => {
+            Some((_, (4, _), _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1322,25 +1186,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [EOF]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   ["+", "-", EOF] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state16<
         'input,
@@ -1368,9 +1220,9 @@ mod __parse__Expr {
                 __result = try!(__state9(input, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) => {
+            Some((_, (4, _), _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1401,17 +1253,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [EOF]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state17<
         'input,
@@ -1429,11 +1273,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action4(input, __sym0, __sym1, __sym2);
@@ -1462,17 +1306,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [EOF]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state18<
         'input,
@@ -1490,11 +1326,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>);
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action5(input, __sym0, __sym1, __sym2);
@@ -1523,17 +1359,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [EOF]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   ["*", "+", "-", "/", EOF] -> Term = "(", Expr, ")" => ActionFn(8);
     //
     pub fn __state19<
         'input,
@@ -1555,11 +1383,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action8(input, __sym0, __sym1, __sym2);
@@ -1588,33 +1416,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [")"]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "+" (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"[0-9]+"# [")"]
+    //     Term = (*) r#"[0-9]+"# [")", "+", "-"]
     //     Term = (*) r#"[0-9]+"# ["*"]
-    //     Term = (*) r#"[0-9]+"# ["+"]
-    //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
     //   "(" -> S13
@@ -1685,33 +1501,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [")"]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "-" (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"[0-9]+"# [")"]
+    //     Term = (*) r#"[0-9]+"# [")", "+", "-"]
     //     Term = (*) r#"[0-9]+"# ["*"]
-    //     Term = (*) r#"[0-9]+"# ["+"]
-    //     Term = (*) r#"[0-9]+"# ["-"]
     //     Term = (*) r#"[0-9]+"# ["/"]
     //
     //   "(" -> S13
@@ -1782,21 +1586,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [")"]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"[0-9]+"# [")"]
-    //     Term = (*) r#"[0-9]+"# ["*"]
-    //     Term = (*) r#"[0-9]+"# ["+"]
-    //     Term = (*) r#"[0-9]+"# ["-"]
-    //     Term = (*) r#"[0-9]+"# ["/"]
+    //     Factor = Factor "*" (*) Term [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
+    //     Term = (*) r#"[0-9]+"# [")", "*", "+", "-", "/"]
     //
     //   "(" -> S13
     //   r#"[0-9]+"# -> S14
@@ -1858,21 +1650,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [")"]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"[0-9]+"# [")"]
-    //     Term = (*) r#"[0-9]+"# ["*"]
-    //     Term = (*) r#"[0-9]+"# ["+"]
-    //     Term = (*) r#"[0-9]+"# ["-"]
-    //     Term = (*) r#"[0-9]+"# ["/"]
+    //     Factor = Factor "/" (*) Term [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
+    //     Term = (*) r#"[0-9]+"# [")", "*", "+", "-", "/"]
     //
     //   "(" -> S13
     //   r#"[0-9]+"# -> S14
@@ -1934,17 +1714,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [")"]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" [")", "*", "+", "-", "/"]
     //
     //   ")" -> S29
     //   "+" -> S20
@@ -1998,25 +1770,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [")"]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S22
     //   "/" -> S23
-    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   [")", "+", "-"] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state25<
         'input,
@@ -2077,25 +1837,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [")"]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S22
     //   "/" -> S23
-    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   [")", "+", "-"] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state26<
         'input,
@@ -2156,17 +1904,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [")"]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   [")", "*", "+", "-", "/"] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state27<
         'input,
@@ -2217,17 +1957,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [")"]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   [")", "*", "+", "-", "/"] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state28<
         'input,
@@ -2278,17 +2010,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [")"]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   [")", "*", "+", "-", "/"] -> Term = "(", Expr, ")" => ActionFn(8);
     //
     pub fn __state29<
         'input,

--- a/lalrpop-test/src/expr_intern_tok.rs
+++ b/lalrpop-test/src/expr_intern_tok.rs
@@ -53,45 +53,45 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = (*) Expr "+" Factor [EOF]
     //     Expr = (*) Expr "+" Factor ["+"]
     //     Expr = (*) Expr "+" Factor ["-"]
-    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor [EOF]
     //     Expr = (*) Expr "-" Factor ["+"]
     //     Expr = (*) Expr "-" Factor ["-"]
-    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Expr "-" Factor [EOF]
     //     Expr = (*) Factor ["+"]
     //     Expr = (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = (*) Factor [EOF]
     //     Factor = (*) Factor "*" Term ["*"]
     //     Factor = (*) Factor "*" Term ["+"]
     //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "*" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
     //     Factor = (*) Factor "/" Term ["+"]
     //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Term ["*"]
     //     Factor = (*) Term ["+"]
     //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Num = (*) r#"[0-9]+"# [EOF]
+    //     Factor = (*) Term [EOF]
     //     Num = (*) r#"[0-9]+"# ["*"]
     //     Num = (*) r#"[0-9]+"# ["+"]
     //     Num = (*) r#"[0-9]+"# ["-"]
     //     Num = (*) r#"[0-9]+"# ["/"]
-    //     Term = (*) Num [EOF]
+    //     Num = (*) r#"[0-9]+"# [EOF]
     //     Term = (*) Num ["*"]
     //     Term = (*) Num ["+"]
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
+    //     Term = (*) Num [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
+    //     Term = (*) "(" Expr ")" [EOF]
     //     __Expr = (*) Expr [EOF]
     //
     //   "(" -> S5
@@ -158,17 +158,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [EOF]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [EOF]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Expr = Expr (*) "+" Factor ["+", "-", EOF]
+    //     Expr = Expr (*) "-" Factor ["+", "-", EOF]
     //     __Expr = Expr (*) [EOF]
     //
     //   "+" -> S7
     //   "-" -> S8
-    //   EOF -> __Expr = Expr => ActionFn(0);
+    //   [EOF] -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         'input,
@@ -222,25 +218,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [EOF]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S9
     //   "/" -> S10
-    //   EOF -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   ["+", "-", EOF] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         'input,
@@ -265,9 +249,9 @@ mod __parse__Expr {
                 __result = try!(__state10(scale, input, __tokens, __sym0, __sym1));
                 return Ok(__result);
             }
-            None |
             Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) => {
+            Some((_, (4, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(scale, input, __sym0);
@@ -296,17 +280,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = Num (*) [EOF]
-    //     Term = Num (*) ["*"]
-    //     Term = Num (*) ["+"]
-    //     Term = Num (*) ["-"]
-    //     Term = Num (*) ["/"]
+    //     Term = Num (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = Num => ActionFn(7);
-    //   "*" -> Term = Num => ActionFn(7);
-    //   "+" -> Term = Num => ActionFn(7);
-    //   "-" -> Term = Num => ActionFn(7);
-    //   "/" -> Term = Num => ActionFn(7);
+    //   ["*", "+", "-", "/", EOF] -> Term = Num => ActionFn(7);
     //
     pub fn __state3<
         'input,
@@ -321,11 +297,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action7(scale, input, __sym0);
@@ -354,17 +330,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [EOF]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Term => ActionFn(6);
-    //   "*" -> Factor = Term => ActionFn(6);
-    //   "+" -> Factor = Term => ActionFn(6);
-    //   "-" -> Factor = Term => ActionFn(6);
-    //   "/" -> Factor = Term => ActionFn(6);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Term => ActionFn(6);
     //
     pub fn __state4<
         'input,
@@ -379,11 +347,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action6(scale, input, __sym0);
@@ -451,11 +419,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [EOF]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S15
     //   r#"[0-9]+"# -> S16
@@ -530,17 +494,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Num)
     //
-    //     Num = r#"[0-9]+"# (*) [EOF]
-    //     Num = r#"[0-9]+"# (*) ["*"]
-    //     Num = r#"[0-9]+"# (*) ["+"]
-    //     Num = r#"[0-9]+"# (*) ["-"]
-    //     Num = r#"[0-9]+"# (*) ["/"]
+    //     Num = r#"[0-9]+"# (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Num = r#"[0-9]+"# => ActionFn(9);
-    //   "*" -> Num = r#"[0-9]+"# => ActionFn(9);
-    //   "+" -> Num = r#"[0-9]+"# => ActionFn(9);
-    //   "-" -> Num = r#"[0-9]+"# => ActionFn(9);
-    //   "/" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //   ["*", "+", "-", "/", EOF] -> Num = r#"[0-9]+"# => ActionFn(9);
     //
     pub fn __state6<
         'input,
@@ -559,11 +515,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action9(scale, input, __sym0);
@@ -592,38 +548,24 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [EOF]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = Expr "+" (*) Factor ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["+", "-", EOF]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["+", "-", EOF]
     //     Factor = (*) Term ["/"]
-    //     Num = (*) r#"[0-9]+"# [EOF]
     //     Num = (*) r#"[0-9]+"# ["*"]
-    //     Num = (*) r#"[0-9]+"# ["+"]
-    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["+", "-", EOF]
     //     Num = (*) r#"[0-9]+"# ["/"]
-    //     Term = (*) Num [EOF]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["+", "-", EOF]
     //     Term = (*) Num ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["+", "-", EOF]
     //     Term = (*) "(" Expr ")" ["/"]
     //
     //   "(" -> S5
@@ -697,38 +639,24 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [EOF]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = Expr "-" (*) Factor ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["+", "-", EOF]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["+", "-", EOF]
     //     Factor = (*) Term ["/"]
-    //     Num = (*) r#"[0-9]+"# [EOF]
     //     Num = (*) r#"[0-9]+"# ["*"]
-    //     Num = (*) r#"[0-9]+"# ["+"]
-    //     Num = (*) r#"[0-9]+"# ["-"]
+    //     Num = (*) r#"[0-9]+"# ["+", "-", EOF]
     //     Num = (*) r#"[0-9]+"# ["/"]
-    //     Term = (*) Num [EOF]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
+    //     Term = (*) Num ["+", "-", EOF]
     //     Term = (*) Num ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["+", "-", EOF]
     //     Term = (*) "(" Expr ")" ["/"]
     //
     //   "(" -> S5
@@ -802,26 +730,10 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [EOF]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Num = (*) r#"[0-9]+"# [EOF]
-    //     Num = (*) r#"[0-9]+"# ["*"]
-    //     Num = (*) r#"[0-9]+"# ["+"]
-    //     Num = (*) r#"[0-9]+"# ["-"]
-    //     Num = (*) r#"[0-9]+"# ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
+    //     Factor = Factor "*" (*) Term ["*", "+", "-", "/", EOF]
+    //     Num = (*) r#"[0-9]+"# ["*", "+", "-", "/", EOF]
+    //     Term = (*) Num ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S5
     //   r#"[0-9]+"# -> S6
@@ -886,26 +798,10 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [EOF]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Num = (*) r#"[0-9]+"# [EOF]
-    //     Num = (*) r#"[0-9]+"# ["*"]
-    //     Num = (*) r#"[0-9]+"# ["+"]
-    //     Num = (*) r#"[0-9]+"# ["-"]
-    //     Num = (*) r#"[0-9]+"# ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
+    //     Factor = Factor "/" (*) Term ["*", "+", "-", "/", EOF]
+    //     Num = (*) r#"[0-9]+"# ["*", "+", "-", "/", EOF]
+    //     Term = (*) Num ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S5
     //   r#"[0-9]+"# -> S6
@@ -970,17 +866,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [EOF]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" ["*", "+", "-", "/", EOF]
     //
     //   ")" -> S21
     //   "+" -> S22
@@ -1033,25 +921,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [")"]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S24
     //   "/" -> S25
-    //   ")" -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   [")", "+", "-"] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state12<
         'input,
@@ -1107,17 +983,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = Num (*) [")"]
-    //     Term = Num (*) ["*"]
-    //     Term = Num (*) ["+"]
-    //     Term = Num (*) ["-"]
-    //     Term = Num (*) ["/"]
+    //     Term = Num (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Term = Num => ActionFn(7);
-    //   "*" -> Term = Num => ActionFn(7);
-    //   "+" -> Term = Num => ActionFn(7);
-    //   "-" -> Term = Num => ActionFn(7);
-    //   "/" -> Term = Num => ActionFn(7);
+    //   [")", "*", "+", "-", "/"] -> Term = Num => ActionFn(7);
     //
     pub fn __state13<
         'input,
@@ -1165,17 +1033,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [")"]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Term => ActionFn(6);
-    //   "*" -> Factor = Term => ActionFn(6);
-    //   "+" -> Factor = Term => ActionFn(6);
-    //   "-" -> Factor = Term => ActionFn(6);
-    //   "/" -> Factor = Term => ActionFn(6);
+    //   [")", "*", "+", "-", "/"] -> Factor = Term => ActionFn(6);
     //
     pub fn __state14<
         'input,
@@ -1262,11 +1122,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [")"]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")", "*", "+", "-", "/"]
     //
     //   "(" -> S15
     //   r#"[0-9]+"# -> S16
@@ -1341,17 +1197,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Num)
     //
-    //     Num = r#"[0-9]+"# (*) [")"]
-    //     Num = r#"[0-9]+"# (*) ["*"]
-    //     Num = r#"[0-9]+"# (*) ["+"]
-    //     Num = r#"[0-9]+"# (*) ["-"]
-    //     Num = r#"[0-9]+"# (*) ["/"]
+    //     Num = r#"[0-9]+"# (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Num = r#"[0-9]+"# => ActionFn(9);
-    //   "*" -> Num = r#"[0-9]+"# => ActionFn(9);
-    //   "+" -> Num = r#"[0-9]+"# => ActionFn(9);
-    //   "-" -> Num = r#"[0-9]+"# => ActionFn(9);
-    //   "/" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //   [")", "*", "+", "-", "/"] -> Num = r#"[0-9]+"# => ActionFn(9);
     //
     pub fn __state16<
         'input,
@@ -1403,25 +1251,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [EOF]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S9
     //   "/" -> S10
-    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   ["+", "-", EOF] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state17<
         'input,
@@ -1448,9 +1284,9 @@ mod __parse__Expr {
                 __result = try!(__state10(scale, input, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) => {
+            Some((_, (4, _), _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1481,25 +1317,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [EOF]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S9
     //   "/" -> S10
-    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   ["+", "-", EOF] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state18<
         'input,
@@ -1526,9 +1350,9 @@ mod __parse__Expr {
                 __result = try!(__state10(scale, input, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) => {
+            Some((_, (4, _), _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1559,17 +1383,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [EOF]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state19<
         'input,
@@ -1586,11 +1402,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action4(scale, input, __sym0, __sym1, __sym2);
@@ -1619,17 +1435,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [EOF]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state20<
         'input,
@@ -1646,11 +1454,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action5(scale, input, __sym0, __sym1, __sym2);
@@ -1679,17 +1487,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [EOF]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   ["*", "+", "-", "/", EOF] -> Term = "(", Expr, ")" => ActionFn(8);
     //
     pub fn __state21<
         'input,
@@ -1710,11 +1510,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action8(scale, input, __sym0, __sym1, __sym2);
@@ -1743,38 +1543,24 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [")"]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "+" (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Num = (*) r#"[0-9]+"# [")"]
+    //     Num = (*) r#"[0-9]+"# [")", "+", "-"]
     //     Num = (*) r#"[0-9]+"# ["*"]
-    //     Num = (*) r#"[0-9]+"# ["+"]
-    //     Num = (*) r#"[0-9]+"# ["-"]
     //     Num = (*) r#"[0-9]+"# ["/"]
-    //     Term = (*) Num [")"]
+    //     Term = (*) Num [")", "+", "-"]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
     //
     //   "(" -> S15
@@ -1848,38 +1634,24 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [")"]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "-" (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Num = (*) r#"[0-9]+"# [")"]
+    //     Num = (*) r#"[0-9]+"# [")", "+", "-"]
     //     Num = (*) r#"[0-9]+"# ["*"]
-    //     Num = (*) r#"[0-9]+"# ["+"]
-    //     Num = (*) r#"[0-9]+"# ["-"]
     //     Num = (*) r#"[0-9]+"# ["/"]
-    //     Term = (*) Num [")"]
+    //     Term = (*) Num [")", "+", "-"]
     //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
     //
     //   "(" -> S15
@@ -1953,26 +1725,10 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [")"]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Num = (*) r#"[0-9]+"# [")"]
-    //     Num = (*) r#"[0-9]+"# ["*"]
-    //     Num = (*) r#"[0-9]+"# ["+"]
-    //     Num = (*) r#"[0-9]+"# ["-"]
-    //     Num = (*) r#"[0-9]+"# ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
+    //     Factor = Factor "*" (*) Term [")", "*", "+", "-", "/"]
+    //     Num = (*) r#"[0-9]+"# [")", "*", "+", "-", "/"]
+    //     Term = (*) Num [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
     //
     //   "(" -> S15
     //   r#"[0-9]+"# -> S16
@@ -2037,26 +1793,10 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [")"]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Num = (*) r#"[0-9]+"# [")"]
-    //     Num = (*) r#"[0-9]+"# ["*"]
-    //     Num = (*) r#"[0-9]+"# ["+"]
-    //     Num = (*) r#"[0-9]+"# ["-"]
-    //     Num = (*) r#"[0-9]+"# ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
+    //     Factor = Factor "/" (*) Term [")", "*", "+", "-", "/"]
+    //     Num = (*) r#"[0-9]+"# [")", "*", "+", "-", "/"]
+    //     Term = (*) Num [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
     //
     //   "(" -> S15
     //   r#"[0-9]+"# -> S16
@@ -2121,17 +1861,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [")"]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" [")", "*", "+", "-", "/"]
     //
     //   ")" -> S31
     //   "+" -> S22
@@ -2184,25 +1916,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [")"]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S24
     //   "/" -> S25
-    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   [")", "+", "-"] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state27<
         'input,
@@ -2262,25 +1982,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [")"]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S24
     //   "/" -> S25
-    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   [")", "+", "-"] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state28<
         'input,
@@ -2340,17 +2048,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [")"]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   [")", "*", "+", "-", "/"] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state29<
         'input,
@@ -2400,17 +2100,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [")"]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   [")", "*", "+", "-", "/"] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state30<
         'input,
@@ -2460,17 +2152,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [")"]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   [")", "*", "+", "-", "/"] -> Term = "(", Expr, ")" => ActionFn(8);
     //
     pub fn __state31<
         'input,

--- a/lalrpop-test/src/expr_intern_tok.rs
+++ b/lalrpop-test/src/expr_intern_tok.rs
@@ -46,7 +46,6 @@ mod __parse__Expr {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -95,8 +94,8 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["/"]
     //     __Expr = (*) Expr [EOF]
     //
-    //     "(" -> Shift(S5)
-    //     r#"[0-9]+"# -> Shift(S6)
+    //   "(" -> S5
+    //   r#"[0-9]+"# -> S6
     //
     //     Expr -> S1
     //     Factor -> S2
@@ -120,7 +119,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym0));
+                __result = try!(__state6(scale, input, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -139,10 +138,10 @@ mod __parse__Expr {
                     __result = try!(__state2(scale, input, __tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::Num(__sym0) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym0));
+                    __result = try!(__state3(scale, input, __tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::Term(__sym0) => {
-                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym0));
+                    __result = try!(__state4(scale, input, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -152,7 +151,6 @@ mod __parse__Expr {
     }
 
     // State 1
-    //     Kind = None
     //     AllInputs = [Expr]
     //     OptionalInputs = []
     //     FixedInputs = [Expr]
@@ -168,9 +166,9 @@ mod __parse__Expr {
     //     Expr = Expr (*) "-" Factor ["-"]
     //     __Expr = Expr (*) [EOF]
     //
-    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //     "+" -> Shift(S7)
-    //     "-" -> Shift(S8)
+    //   "+" -> S7
+    //   "-" -> S8
+    //   EOF -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         'input,
@@ -217,7 +215,6 @@ mod __parse__Expr {
     }
 
     // State 2
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -239,11 +236,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S9)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S10)
+    //   "*" -> S9
+    //   "/" -> S10
+    //   EOF -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         'input,
@@ -291,8 +288,123 @@ mod __parse__Expr {
         }
     }
 
+    // State 3
+    //     AllInputs = [Num]
+    //     OptionalInputs = []
+    //     FixedInputs = [Num]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = Num (*) [EOF]
+    //     Term = Num (*) ["*"]
+    //     Term = Num (*) ["+"]
+    //     Term = Num (*) ["-"]
+    //     Term = Num (*) ["/"]
+    //
+    //   EOF -> Term = Num => ActionFn(7);
+    //   "*" -> Term = Num => ActionFn(7);
+    //   "+" -> Term = Num => ActionFn(7);
+    //   "-" -> Term = Num => ActionFn(7);
+    //   "/" -> Term = Num => ActionFn(7);
+    //
+    pub fn __state3<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, i32, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(scale, input, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 4
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [EOF]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   EOF -> Factor = Term => ActionFn(6);
+    //   "*" -> Factor = Term => ActionFn(6);
+    //   "+" -> Factor = Term => ActionFn(6);
+    //   "-" -> Factor = Term => ActionFn(6);
+    //   "/" -> Factor = Term => ActionFn(6);
+    //
+    pub fn __state4<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, i32, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action6(scale, input, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 5
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -345,8 +457,8 @@ mod __parse__Expr {
     //     Term = "(" (*) Expr ")" ["-"]
     //     Term = "(" (*) Expr ")" ["/"]
     //
-    //     "(" -> Shift(S15)
-    //     r#"[0-9]+"# -> Shift(S16)
+    //   "(" -> S15
+    //   r#"[0-9]+"# -> S16
     //
     //     Expr -> S11
     //     Factor -> S12
@@ -376,7 +488,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym1));
+                __result = try!(__state16(scale, input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -398,10 +510,10 @@ mod __parse__Expr {
                     __result = try!(__state12(scale, input, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Num(__sym1) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state14(scale, input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -410,8 +522,69 @@ mod __parse__Expr {
         }
     }
 
+    // State 6
+    //     AllInputs = [r#"[0-9]+"#]
+    //     OptionalInputs = []
+    //     FixedInputs = [r#"[0-9]+"#]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Num)
+    //
+    //     Num = r#"[0-9]+"# (*) [EOF]
+    //     Num = r#"[0-9]+"# (*) ["*"]
+    //     Num = r#"[0-9]+"# (*) ["+"]
+    //     Num = r#"[0-9]+"# (*) ["-"]
+    //     Num = r#"[0-9]+"# (*) ["/"]
+    //
+    //   EOF -> Num = r#"[0-9]+"# => ActionFn(9);
+    //   "*" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //   "+" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //   "-" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //   "/" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //
+    pub fn __state6<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action9(scale, input, __sym0);
+                let __nt = __Nonterminal::Num((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 7
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -453,8 +626,8 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
     //
-    //     "(" -> Shift(S5)
-    //     r#"[0-9]+"# -> Shift(S6)
+    //   "(" -> S5
+    //   r#"[0-9]+"# -> S6
     //
     //     Factor -> S17
     //     Num -> S3
@@ -485,7 +658,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym2));
+                __result = try!(__state6(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -504,10 +677,10 @@ mod __parse__Expr {
                     __result = try!(__state17(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Num(__sym2) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state4(scale, input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -517,7 +690,6 @@ mod __parse__Expr {
     }
 
     // State 8
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -559,8 +731,8 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
     //
-    //     "(" -> Shift(S5)
-    //     r#"[0-9]+"# -> Shift(S6)
+    //   "(" -> S5
+    //   r#"[0-9]+"# -> S6
     //
     //     Factor -> S18
     //     Num -> S3
@@ -591,7 +763,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym2));
+                __result = try!(__state6(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -610,10 +782,10 @@ mod __parse__Expr {
                     __result = try!(__state18(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Num(__sym2) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state4(scale, input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -623,7 +795,6 @@ mod __parse__Expr {
     }
 
     // State 9
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -652,8 +823,8 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
     //
-    //     "(" -> Shift(S5)
-    //     r#"[0-9]+"# -> Shift(S6)
+    //   "(" -> S5
+    //   r#"[0-9]+"# -> S6
     //
     //     Num -> S3
     //     Term -> S19
@@ -681,7 +852,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym2));
+                __result = try!(__state6(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -694,10 +865,10 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Num(__sym2) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state19(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -708,7 +879,6 @@ mod __parse__Expr {
     }
 
     // State 10
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -737,8 +907,8 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
     //
-    //     "(" -> Shift(S5)
-    //     r#"[0-9]+"# -> Shift(S6)
+    //   "(" -> S5
+    //   r#"[0-9]+"# -> S6
     //
     //     Num -> S3
     //     Term -> S20
@@ -766,7 +936,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym2));
+                __result = try!(__state6(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -779,10 +949,10 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Num(__sym2) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom4(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state20(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -793,7 +963,6 @@ mod __parse__Expr {
     }
 
     // State 11
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -813,9 +982,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S21)
-    //     "+" -> Shift(S22)
-    //     "-" -> Shift(S23)
+    //   ")" -> S21
+    //   "+" -> S22
+    //   "-" -> S23
     //
     pub fn __state11<
         'input,
@@ -834,7 +1003,7 @@ mod __parse__Expr {
             Some((__loc1, (1, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom5(scale, input, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state21(scale, input, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
@@ -857,7 +1026,6 @@ mod __parse__Expr {
     }
 
     // State 12
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -879,11 +1047,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S24)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S25)
+    //   "*" -> S24
+    //   "/" -> S25
+    //   ")" -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state12<
         'input,
@@ -931,8 +1099,123 @@ mod __parse__Expr {
         }
     }
 
+    // State 13
+    //     AllInputs = [Num]
+    //     OptionalInputs = []
+    //     FixedInputs = [Num]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = Num (*) [")"]
+    //     Term = Num (*) ["*"]
+    //     Term = Num (*) ["+"]
+    //     Term = Num (*) ["-"]
+    //     Term = Num (*) ["/"]
+    //
+    //   ")" -> Term = Num => ActionFn(7);
+    //   "*" -> Term = Num => ActionFn(7);
+    //   "+" -> Term = Num => ActionFn(7);
+    //   "-" -> Term = Num => ActionFn(7);
+    //   "/" -> Term = Num => ActionFn(7);
+    //
+    pub fn __state13<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, i32, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(scale, input, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 14
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [")"]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   ")" -> Factor = Term => ActionFn(6);
+    //   "*" -> Factor = Term => ActionFn(6);
+    //   "+" -> Factor = Term => ActionFn(6);
+    //   "-" -> Factor = Term => ActionFn(6);
+    //   "/" -> Factor = Term => ActionFn(6);
+    //
+    pub fn __state14<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, i32, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action6(scale, input, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 15
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -985,8 +1268,8 @@ mod __parse__Expr {
     //     Term = "(" (*) Expr ")" ["-"]
     //     Term = "(" (*) Expr ")" ["/"]
     //
-    //     "(" -> Shift(S15)
-    //     r#"[0-9]+"# -> Shift(S16)
+    //   "(" -> S15
+    //   r#"[0-9]+"# -> S16
     //
     //     Expr -> S26
     //     Factor -> S12
@@ -1016,7 +1299,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym1));
+                __result = try!(__state16(scale, input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1038,10 +1321,10 @@ mod __parse__Expr {
                     __result = try!(__state12(scale, input, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Num(__sym1) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state14(scale, input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1050,8 +1333,69 @@ mod __parse__Expr {
         }
     }
 
+    // State 16
+    //     AllInputs = [r#"[0-9]+"#]
+    //     OptionalInputs = []
+    //     FixedInputs = [r#"[0-9]+"#]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Num)
+    //
+    //     Num = r#"[0-9]+"# (*) [")"]
+    //     Num = r#"[0-9]+"# (*) ["*"]
+    //     Num = r#"[0-9]+"# (*) ["+"]
+    //     Num = r#"[0-9]+"# (*) ["-"]
+    //     Num = r#"[0-9]+"# (*) ["/"]
+    //
+    //   ")" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //   "*" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //   "+" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //   "-" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //   "/" -> Num = r#"[0-9]+"# => ActionFn(9);
+    //
+    pub fn __state16<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action9(scale, input, __sym0);
+                let __nt = __Nonterminal::Num((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 17
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -1073,11 +1417,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S9)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S10)
+    //   "*" -> S9
+    //   "/" -> S10
+    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state17<
         'input,
@@ -1130,7 +1474,6 @@ mod __parse__Expr {
     }
 
     // State 18
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -1152,11 +1495,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S9)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S10)
+    //   "*" -> S9
+    //   "/" -> S10
+    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state18<
         'input,
@@ -1208,8 +1551,191 @@ mod __parse__Expr {
         }
     }
 
+    // State 19
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [EOF]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state19<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, i32, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(scale, input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 20
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [EOF]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state20<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, i32, usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, i32, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(scale, input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 21
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [EOF]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   EOF -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //
+    pub fn __state21<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        scale: i32,
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, i32, usize),
+        __sym2: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action8(scale, input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 22
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -1251,8 +1777,8 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
     //
-    //     "(" -> Shift(S15)
-    //     r#"[0-9]+"# -> Shift(S16)
+    //   "(" -> S15
+    //   r#"[0-9]+"# -> S16
     //
     //     Factor -> S27
     //     Num -> S13
@@ -1283,7 +1809,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym2));
+                __result = try!(__state16(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1302,10 +1828,10 @@ mod __parse__Expr {
                     __result = try!(__state27(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Num(__sym2) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state14(scale, input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1315,7 +1841,6 @@ mod __parse__Expr {
     }
 
     // State 23
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -1357,8 +1882,8 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
     //
-    //     "(" -> Shift(S15)
-    //     r#"[0-9]+"# -> Shift(S16)
+    //   "(" -> S15
+    //   r#"[0-9]+"# -> S16
     //
     //     Factor -> S28
     //     Num -> S13
@@ -1389,7 +1914,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym2));
+                __result = try!(__state16(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1408,10 +1933,10 @@ mod __parse__Expr {
                     __result = try!(__state28(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Num(__sym2) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom1(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state14(scale, input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1421,7 +1946,6 @@ mod __parse__Expr {
     }
 
     // State 24
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -1450,8 +1974,8 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
     //
-    //     "(" -> Shift(S15)
-    //     r#"[0-9]+"# -> Shift(S16)
+    //   "(" -> S15
+    //   r#"[0-9]+"# -> S16
     //
     //     Num -> S13
     //     Term -> S29
@@ -1479,7 +2003,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym2));
+                __result = try!(__state16(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1492,10 +2016,10 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Num(__sym2) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state29(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -1506,7 +2030,6 @@ mod __parse__Expr {
     }
 
     // State 25
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -1535,8 +2058,8 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
     //
-    //     "(" -> Shift(S15)
-    //     r#"[0-9]+"# -> Shift(S16)
+    //   "(" -> S15
+    //   r#"[0-9]+"# -> S16
     //
     //     Num -> S13
     //     Term -> S30
@@ -1564,7 +2087,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(scale, input, __tokens, __sym2));
+                __result = try!(__state16(scale, input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1577,10 +2100,10 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Num(__sym2) => {
-                    __result = try!(__custom0(scale, input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom4(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state30(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -1591,7 +2114,6 @@ mod __parse__Expr {
     }
 
     // State 26
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -1611,9 +2133,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S31)
-    //     "+" -> Shift(S22)
-    //     "-" -> Shift(S23)
+    //   ")" -> S31
+    //   "+" -> S22
+    //   "-" -> S23
     //
     pub fn __state26<
         'input,
@@ -1632,7 +2154,7 @@ mod __parse__Expr {
             Some((__loc1, (1, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom5(scale, input, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state31(scale, input, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
@@ -1655,7 +2177,6 @@ mod __parse__Expr {
     }
 
     // State 27
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -1677,11 +2198,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S24)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S25)
+    //   "*" -> S24
+    //   "/" -> S25
+    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state27<
         'input,
@@ -1734,7 +2255,6 @@ mod __parse__Expr {
     }
 
     // State 28
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -1756,11 +2276,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S24)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S25)
+    //   "*" -> S24
+    //   "/" -> S25
+    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state28<
         'input,
@@ -1812,91 +2332,27 @@ mod __parse__Expr {
         }
     }
 
-    // Custom 0
-    //    Reduce Term = Num => ActionFn(7);
-    pub fn __custom0<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: (usize, i32, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action7(scale, input, __sym0);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce Factor = Term => ActionFn(6);
-    pub fn __custom1<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: (usize, i32, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action6(scale, input, __sym0);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 2
-    //    Reduce Num = r#"[0-9]+"# => ActionFn(9);
-    pub fn __custom2<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        scale: i32,
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, &'input str, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action9(scale, input, __sym0);
-        let __nt = __Nonterminal::Num((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 3
-    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
-    pub fn __custom3<
+    // State 29
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [")"]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state29<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -1910,21 +2366,53 @@ mod __parse__Expr {
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action4(scale, input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(scale, input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 4
-    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
-    pub fn __custom4<
+    // State 30
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [")"]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state30<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -1938,21 +2426,53 @@ mod __parse__Expr {
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action5(scale, input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(scale, input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 5
-    //    Reduce Term = "(", Expr, ")" => ActionFn(8);
-    pub fn __custom5<
+    // State 31
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [")"]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   ")" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //
+    pub fn __state31<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -1970,16 +2490,30 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action8(scale, input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action8(scale, input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/expr_lalr.rs
+++ b/lalrpop-test/src/expr_lalr.rs
@@ -46,7 +46,6 @@ mod __parse__Expr {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -90,8 +89,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["/"]
     //     __Expr = (*) Expr [EOF]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Expr -> S1
     //     Factor -> S2
@@ -112,7 +111,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym0));
+                __result = try!(__state5(scale, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -131,7 +130,7 @@ mod __parse__Expr {
                     __result = try!(__state2(scale, __tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::Term(__sym0) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym0));
+                    __result = try!(__state3(scale, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -141,7 +140,6 @@ mod __parse__Expr {
     }
 
     // State 1
-    //     Kind = None
     //     AllInputs = [Expr]
     //     OptionalInputs = []
     //     FixedInputs = [Expr]
@@ -157,9 +155,9 @@ mod __parse__Expr {
     //     Expr = Expr (*) "-" Factor ["-"]
     //     __Expr = Expr (*) [EOF]
     //
-    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //     "+" -> Shift(S6)
-    //     "-" -> Shift(S7)
+    //   "+" -> S6
+    //   "-" -> S7
+    //   EOF -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -204,7 +202,6 @@ mod __parse__Expr {
     }
 
     // State 2
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -239,12 +236,12 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Factor => ActionFn(3);
+    //   ")" -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -291,8 +288,70 @@ mod __parse__Expr {
         }
     }
 
+    // State 3
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [EOF]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) [")"]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   EOF -> Factor = Term => ActionFn(6);
+    //   ")" -> Factor = Term => ActionFn(6);
+    //   "*" -> Factor = Term => ActionFn(6);
+    //   "+" -> Factor = Term => ActionFn(6);
+    //   "-" -> Factor = Term => ActionFn(6);
+    //   "/" -> Factor = Term => ActionFn(6);
+    //
+    pub fn __state3<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action6(scale, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 4
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -379,8 +438,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Expr -> S10
     //     Factor -> S2
@@ -407,7 +466,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym1));
+                __result = try!(__state5(scale, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -429,7 +488,7 @@ mod __parse__Expr {
                     __result = try!(__state2(scale, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym1));
+                    __result = try!(__state3(scale, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -438,8 +497,74 @@ mod __parse__Expr {
         }
     }
 
+    // State 5
+    //     AllInputs = [Num]
+    //     OptionalInputs = []
+    //     FixedInputs = [Num]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = Num (*) [EOF]
+    //     Term = Num (*) ["*"]
+    //     Term = Num (*) ["+"]
+    //     Term = Num (*) ["-"]
+    //     Term = Num (*) ["/"]
+    //     Term = Num (*) [")"]
+    //     Term = Num (*) ["*"]
+    //     Term = Num (*) ["+"]
+    //     Term = Num (*) ["-"]
+    //     Term = Num (*) ["/"]
+    //
+    //   EOF -> Term = Num => ActionFn(7);
+    //   ")" -> Term = Num => ActionFn(7);
+    //   "*" -> Term = Num => ActionFn(7);
+    //   "+" -> Term = Num => ActionFn(7);
+    //   "-" -> Term = Num => ActionFn(7);
+    //   "/" -> Term = Num => ActionFn(7);
+    //
+    pub fn __state5<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        scale: i32,
+        __tokens: &mut __TOKENS,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            None |
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(scale, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 6
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -504,8 +629,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Factor -> S11
     //     Term -> S3
@@ -533,7 +658,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state5(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -552,7 +677,7 @@ mod __parse__Expr {
                     __result = try!(__state11(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -562,7 +687,6 @@ mod __parse__Expr {
     }
 
     // State 7
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -627,8 +751,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Factor -> S12
     //     Term -> S3
@@ -656,7 +780,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state5(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -675,7 +799,7 @@ mod __parse__Expr {
                     __result = try!(__state12(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(scale, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -685,7 +809,6 @@ mod __parse__Expr {
     }
 
     // State 8
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -724,8 +847,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Term -> S13
     pub fn __state8<
@@ -750,7 +873,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state5(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -763,7 +886,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom2(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state13(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -774,7 +897,6 @@ mod __parse__Expr {
     }
 
     // State 9
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -813,8 +935,8 @@ mod __parse__Expr {
     //     Term = (*) Num ["-"]
     //     Term = (*) Num ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     Term -> S14
     pub fn __state9<
@@ -839,7 +961,7 @@ mod __parse__Expr {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(scale, __tokens, __sym2));
+                __result = try!(__state5(scale, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -852,7 +974,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state14(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -863,7 +985,6 @@ mod __parse__Expr {
     }
 
     // State 10
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -894,9 +1015,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S15)
-    //     "+" -> Shift(S6)
-    //     "-" -> Shift(S7)
+    //   ")" -> S15
+    //   "+" -> S6
+    //   "-" -> S7
     //
     pub fn __state10<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -913,7 +1034,7 @@ mod __parse__Expr {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(scale, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state15(scale, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
@@ -936,7 +1057,6 @@ mod __parse__Expr {
     }
 
     // State 11
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -971,12 +1091,12 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state11<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1028,7 +1148,6 @@ mod __parse__Expr {
     }
 
     // State 12
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -1063,12 +1182,12 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state12<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1119,61 +1238,33 @@ mod __parse__Expr {
         }
     }
 
-    // Custom 0
-    //    Reduce Factor = Term => ActionFn(6);
-    pub fn __custom0<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: ((), i32, ()),
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action6(scale, __sym0);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce Term = Num => ActionFn(7);
-    pub fn __custom1<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        scale: i32,
-        __tokens: &mut __TOKENS,
-        __sym0: ((), i32, ()),
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action7(scale, __sym0);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 2
-    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
-    pub fn __custom2<
+    // State 13
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [EOF]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) [")"]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
+    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state13<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
@@ -1185,21 +1276,60 @@ mod __parse__Expr {
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 3
-    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
-    pub fn __custom3<
+    // State 14
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [EOF]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) [")"]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
+    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state14<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
@@ -1211,21 +1341,60 @@ mod __parse__Expr {
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 4
-    //    Reduce Term = "(", Expr, ")" => ActionFn(8);
-    pub fn __custom4<
+    // State 15
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [EOF]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) [")"]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   EOF -> Term = "(", Expr, ")" => ActionFn(8);
+    //   ")" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //
+    pub fn __state15<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         scale: i32,
@@ -1241,16 +1410,31 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Times, _)) |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) |
+            Some((_, Tok::Div, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action8(scale, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/expr_lalr.rs
+++ b/lalrpop-test/src/expr_lalr.rs
@@ -53,40 +53,14 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = (*) Expr "+" Factor [EOF]
-    //     Expr = (*) Expr "+" Factor ["+"]
-    //     Expr = (*) Expr "+" Factor ["-"]
-    //     Expr = (*) Expr "-" Factor [EOF]
-    //     Expr = (*) Expr "-" Factor ["+"]
-    //     Expr = (*) Expr "-" Factor ["-"]
-    //     Expr = (*) Factor [EOF]
-    //     Expr = (*) Factor ["+"]
-    //     Expr = (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
-    //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
-    //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
-    //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
-    //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
-    //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
-    //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Expr = (*) Expr "+" Factor ["+", "-", EOF]
+    //     Expr = (*) Expr "-" Factor ["+", "-", EOF]
+    //     Expr = (*) Factor ["+", "-", EOF]
+    //     Factor = (*) Factor "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = (*) Factor "/" Term ["*", "+", "-", "/", EOF]
+    //     Factor = (*) Term ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
+    //     Term = (*) Num ["*", "+", "-", "/", EOF]
     //     __Expr = (*) Expr [EOF]
     //
     //   "(" -> S4
@@ -147,17 +121,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [EOF]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [EOF]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Expr = Expr (*) "+" Factor ["+", "-", EOF]
+    //     Expr = Expr (*) "-" Factor ["+", "-", EOF]
     //     __Expr = Expr (*) [EOF]
     //
     //   "+" -> S6
     //   "-" -> S7
-    //   EOF -> __Expr = Expr => ActionFn(0);
+    //   [EOF] -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -209,39 +179,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [EOF]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
-    //     Expr = Factor (*) [")"]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) [")", "+", "-", EOF]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Factor => ActionFn(3);
-    //   ")" -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   [")", "+", "-", EOF] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -264,10 +208,10 @@ mod __parse__Expr {
                 __result = try!(__state9(scale, __tokens, __sym0, __sym1));
                 return Ok(__result);
             }
-            None |
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(scale, __sym0);
@@ -296,23 +240,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [EOF]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
-    //     Factor = Term (*) [")"]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) [")", "*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Term => ActionFn(6);
-    //   ")" -> Factor = Term => ActionFn(6);
-    //   "*" -> Factor = Term => ActionFn(6);
-    //   "+" -> Factor = Term => ActionFn(6);
-    //   "-" -> Factor = Term => ActionFn(6);
-    //   "/" -> Factor = Term => ActionFn(6);
+    //   [")", "*", "+", "-", "/", EOF] -> Factor = Term => ActionFn(6);
     //
     pub fn __state3<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -325,12 +255,12 @@ mod __parse__Expr {
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action6(scale, __sym0);
@@ -359,84 +289,15 @@ mod __parse__Expr {
     //     WillPush = [Expr, ")"]
     //     WillProduce = Some(Term)
     //
-    //     Expr = (*) Expr "+" Factor [")"]
-    //     Expr = (*) Expr "+" Factor ["+"]
-    //     Expr = (*) Expr "+" Factor ["-"]
-    //     Expr = (*) Expr "-" Factor [")"]
-    //     Expr = (*) Expr "-" Factor ["+"]
-    //     Expr = (*) Expr "-" Factor ["-"]
-    //     Expr = (*) Factor [")"]
-    //     Expr = (*) Factor ["+"]
-    //     Expr = (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
-    //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
-    //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
-    //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
-    //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
-    //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
-    //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [EOF]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
-    //     Expr = (*) Expr "+" Factor [")"]
-    //     Expr = (*) Expr "+" Factor ["+"]
-    //     Expr = (*) Expr "+" Factor ["-"]
-    //     Expr = (*) Expr "-" Factor [")"]
-    //     Expr = (*) Expr "-" Factor ["+"]
-    //     Expr = (*) Expr "-" Factor ["-"]
-    //     Expr = (*) Factor [")"]
-    //     Expr = (*) Factor ["+"]
-    //     Expr = (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
-    //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
-    //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
-    //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
-    //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
-    //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
-    //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [")"]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Expr = (*) Expr "+" Factor [")", "+", "-"]
+    //     Expr = (*) Expr "-" Factor [")", "+", "-"]
+    //     Expr = (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = (*) Factor "/" Term [")", "*", "+", "-", "/"]
+    //     Factor = (*) Term [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
+    //     Term = "(" (*) Expr ")" [")", "*", "+", "-", "/", EOF]
+    //     Term = (*) Num [")", "*", "+", "-", "/"]
     //
     //   "(" -> S4
     //   Num -> S5
@@ -505,23 +366,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = Num (*) [EOF]
-    //     Term = Num (*) ["*"]
-    //     Term = Num (*) ["+"]
-    //     Term = Num (*) ["-"]
-    //     Term = Num (*) ["/"]
-    //     Term = Num (*) [")"]
-    //     Term = Num (*) ["*"]
-    //     Term = Num (*) ["+"]
-    //     Term = Num (*) ["-"]
-    //     Term = Num (*) ["/"]
+    //     Term = Num (*) [")", "*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = Num => ActionFn(7);
-    //   ")" -> Term = Num => ActionFn(7);
-    //   "*" -> Term = Num => ActionFn(7);
-    //   "+" -> Term = Num => ActionFn(7);
-    //   "-" -> Term = Num => ActionFn(7);
-    //   "/" -> Term = Num => ActionFn(7);
+    //   [")", "*", "+", "-", "/", EOF] -> Term = Num => ActionFn(7);
     //
     pub fn __state5<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -538,12 +385,12 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action7(scale, __sym0);
@@ -572,62 +419,12 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [EOF]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
-    //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
-    //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
-    //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
-    //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
-    //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
-    //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
-    //     Expr = Expr "+" (*) Factor [")"]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
-    //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
-    //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
-    //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
-    //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
-    //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
-    //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Expr = Expr "+" (*) Factor [")", "+", "-", EOF]
+    //     Factor = (*) Factor "*" Term [")", "*", "+", "-", "/", EOF]
+    //     Factor = (*) Factor "/" Term [")", "*", "+", "-", "/", EOF]
+    //     Factor = (*) Term [")", "*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/", EOF]
+    //     Term = (*) Num [")", "*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   Num -> S5
@@ -694,62 +491,12 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [EOF]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
-    //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
-    //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
-    //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
-    //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
-    //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
-    //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
-    //     Expr = Expr "-" (*) Factor [")"]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
-    //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
-    //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
-    //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
-    //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
-    //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
-    //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Expr = Expr "-" (*) Factor [")", "+", "-", EOF]
+    //     Factor = (*) Factor "*" Term [")", "*", "+", "-", "/", EOF]
+    //     Factor = (*) Factor "/" Term [")", "*", "+", "-", "/", EOF]
+    //     Factor = (*) Term [")", "*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/", EOF]
+    //     Term = (*) Num [")", "*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   Num -> S5
@@ -816,36 +563,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [EOF]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
-    //     Factor = Factor "*" (*) Term [")"]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "*" (*) Term [")", "*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/", EOF]
+    //     Term = (*) Num [")", "*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   Num -> S5
@@ -904,36 +624,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [EOF]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [EOF]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
-    //     Factor = Factor "/" (*) Term [")"]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) Num [")"]
-    //     Term = (*) Num ["*"]
-    //     Term = (*) Num ["+"]
-    //     Term = (*) Num ["-"]
-    //     Term = (*) Num ["/"]
+    //     Factor = Factor "/" (*) Term [")", "*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/", EOF]
+    //     Term = (*) Num [")", "*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   Num -> S5
@@ -992,28 +685,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [EOF]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [")"]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" [")", "*", "+", "-", "/", EOF]
     //
     //   ")" -> S15
     //   "+" -> S6
@@ -1064,39 +738,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [EOF]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
-    //     Expr = Expr "+" Factor (*) [")"]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) [")", "+", "-", EOF]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   [")", "+", "-", EOF] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state11<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1121,10 +769,10 @@ mod __parse__Expr {
                 __result = try!(__state9(scale, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1155,39 +803,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [EOF]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
-    //     Expr = Expr "-" Factor (*) [")"]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) [")", "+", "-", EOF]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   [")", "+", "-", EOF] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state12<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1212,10 +834,10 @@ mod __parse__Expr {
                 __result = try!(__state9(scale, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1246,23 +868,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [EOF]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
-    //     Factor = Factor "*" Term (*) [")"]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) [")", "*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
-    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   [")", "*", "+", "-", "/", EOF] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state13<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1277,12 +885,12 @@ mod __parse__Expr {
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action4(scale, __sym0, __sym1, __sym2);
@@ -1311,23 +919,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [EOF]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
-    //     Factor = Factor "/" Term (*) [")"]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) [")", "*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
-    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   [")", "*", "+", "-", "/", EOF] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state14<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1342,12 +936,12 @@ mod __parse__Expr {
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action5(scale, __sym0, __sym1, __sym2);
@@ -1376,23 +970,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [EOF]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
-    //     Term = "(" Expr ")" (*) [")"]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) [")", "*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = "(", Expr, ")" => ActionFn(8);
-    //   ")" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   [")", "*", "+", "-", "/", EOF] -> Term = "(", Expr, ")" => ActionFn(8);
     //
     pub fn __state15<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -1411,12 +991,12 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::RParen, _)) |
             Some((_, Tok::Times, _)) |
             Some((_, Tok::Plus, _)) |
             Some((_, Tok::Minus, _)) |
-            Some((_, Tok::Div, _)) => {
+            Some((_, Tok::Div, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action8(scale, __sym0, __sym1, __sym2);

--- a/lalrpop-test/src/inline.rs
+++ b/lalrpop-test/src/inline.rs
@@ -40,7 +40,6 @@ mod __parse__E {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -53,8 +52,8 @@ mod __parse__E {
     //     E = (*) "L" [EOF]
     //     __E = (*) E [EOF]
     //
-    //     "&" -> Shift(S2)
-    //     "L" -> Shift(S3)
+    //   "&" -> S2
+    //   "L" -> S3
     //
     //     E -> S1
     pub fn __state0<
@@ -74,7 +73,7 @@ mod __parse__E {
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym0));
+                __result = try!(__state3(input, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -87,7 +86,7 @@ mod __parse__E {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::E(__sym0) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym0));
+                    __result = try!(__state1(input, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -96,8 +95,52 @@ mod __parse__E {
         }
     }
 
+    // State 1
+    //     AllInputs = [E]
+    //     OptionalInputs = []
+    //     FixedInputs = [E]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(__E)
+    //
+    //     __E = E (*) [EOF]
+    //
+    //   EOF -> __E = E => ActionFn(0);
+    //
+    pub fn __state1<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, String, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            None => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action0(input, __sym0);
+                let __nt = __Nonterminal::____E((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 2
-    //     Kind = None
     //     AllInputs = ["&"]
     //     OptionalInputs = []
     //     FixedInputs = ["&"]
@@ -111,8 +154,8 @@ mod __parse__E {
     //     E = "&" (*) "L" E [EOF]
     //     E = (*) "L" [EOF]
     //
-    //     "&" -> Shift(S2)
-    //     "L" -> Shift(S5)
+    //   "&" -> S2
+    //   "L" -> S5
     //
     //     E -> S4
     pub fn __state2<
@@ -155,7 +198,7 @@ mod __parse__E {
             match __nt {
                 __Nonterminal::E(__sym1) => {
                     let __sym0 = __sym0.take().unwrap();
-                    __result = try!(__custom2(input, __tokens, __lookahead, __sym0, __sym1));
+                    __result = try!(__state4(input, __tokens, __lookahead, __sym0, __sym1));
                     return Ok(__result);
                 }
                 _ => {
@@ -165,8 +208,102 @@ mod __parse__E {
         }
     }
 
+    // State 3
+    //     AllInputs = ["L"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["L"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(E)
+    //
+    //     E = "L" (*) [EOF]
+    //
+    //   EOF -> E = "L" => ActionFn(1);
+    //
+    pub fn __state3<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            None => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action1(input, __sym0);
+                let __nt = __Nonterminal::E((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 4
+    //     AllInputs = ["&", E]
+    //     OptionalInputs = []
+    //     FixedInputs = ["&", E]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(E)
+    //
+    //     E = "&" E (*) [EOF]
+    //
+    //   EOF -> E = "&", E => ActionFn(7);
+    //
+    pub fn __state4<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, String, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            None => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action7(input, __sym0, __sym1);
+                let __nt = __Nonterminal::E((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 5
-    //     Kind = None
     //     AllInputs = ["&", "L"]
     //     OptionalInputs = ["&"]
     //     FixedInputs = ["L"]
@@ -180,9 +317,9 @@ mod __parse__E {
     //     E = (*) "L" [EOF]
     //     E = "L" (*) [EOF]
     //
-    //     EOF -> Reduce(E = "L" => ActionFn(1);)
-    //     "&" -> Shift(S2)
-    //     "L" -> Shift(S3)
+    //   "&" -> S2
+    //   "L" -> S3
+    //   EOF -> E = "L" => ActionFn(1);
     //
     //     E -> S6
     pub fn __state5<
@@ -208,7 +345,7 @@ mod __parse__E {
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state3(input, __tokens, __sym2));
             }
             None => {
                 let __start = __sym1.0.clone();
@@ -234,7 +371,7 @@ mod __parse__E {
             match __nt {
                 __Nonterminal::E(__sym2) => {
                     let __sym0 = __sym0.take().unwrap();
-                    __result = try!(__custom3(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state6(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -244,89 +381,19 @@ mod __parse__E {
         }
     }
 
-    // Custom 0
-    //    Reduce __E = E => ActionFn(0);
-    pub fn __custom0<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: (usize, String, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action0(input, __sym0);
-        let __nt = __Nonterminal::____E((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce E = "L" => ActionFn(1);
-    pub fn __custom1<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, &'input str, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action1(input, __sym0);
-        let __nt = __Nonterminal::E((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 2
-    //    Reduce E = "&", E => ActionFn(7);
-    pub fn __custom2<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: (usize, &'input str, usize),
-        __sym1: (usize, String, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = super::__action7(input, __sym0, __sym1);
-        let __nt = __Nonterminal::E((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 3
-    //    Reduce E = "&", "L", E => ActionFn(8);
-    pub fn __custom3<
+    // State 6
+    //     AllInputs = ["&", "L", E]
+    //     OptionalInputs = []
+    //     FixedInputs = ["&", "L", E]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(E)
+    //
+    //     E = "&" "L" E (*) [EOF]
+    //
+    //   EOF -> E = "&", "L", E => ActionFn(8);
+    //
+    pub fn __state6<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -339,16 +406,26 @@ mod __parse__E {
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action8(input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::E((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action8(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::E((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__E::parse_E;

--- a/lalrpop-test/src/inline.rs
+++ b/lalrpop-test/src/inline.rs
@@ -105,7 +105,7 @@ mod __parse__E {
     //
     //     __E = E (*) [EOF]
     //
-    //   EOF -> __E = E => ActionFn(0);
+    //   [EOF] -> __E = E => ActionFn(0);
     //
     pub fn __state1<
         'input,
@@ -218,7 +218,7 @@ mod __parse__E {
     //
     //     E = "L" (*) [EOF]
     //
-    //   EOF -> E = "L" => ActionFn(1);
+    //   [EOF] -> E = "L" => ActionFn(1);
     //
     pub fn __state3<
         'input,
@@ -267,7 +267,7 @@ mod __parse__E {
     //
     //     E = "&" E (*) [EOF]
     //
-    //   EOF -> E = "&", E => ActionFn(7);
+    //   [EOF] -> E = "&", E => ActionFn(7);
     //
     pub fn __state4<
         'input,
@@ -319,7 +319,7 @@ mod __parse__E {
     //
     //   "&" -> S2
     //   "L" -> S3
-    //   EOF -> E = "L" => ActionFn(1);
+    //   [EOF] -> E = "L" => ActionFn(1);
     //
     //     E -> S6
     pub fn __state5<
@@ -391,7 +391,7 @@ mod __parse__E {
     //
     //     E = "&" "L" E (*) [EOF]
     //
-    //   EOF -> E = "&", "L", E => ActionFn(8);
+    //   [EOF] -> E = "&", "L", E => ActionFn(8);
     //
     pub fn __state6<
         'input,

--- a/lalrpop-test/src/intern_tok.rs
+++ b/lalrpop-test/src/intern_tok.rs
@@ -50,20 +50,20 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Items = (*) [EOF]
     //     Items = (*) ["+"]
     //     Items = (*) ["-"]
-    //     Items = (*) Items Spanned<"+"> [EOF]
+    //     Items = (*) [EOF]
     //     Items = (*) Items Spanned<"+"> ["+"]
     //     Items = (*) Items Spanned<"+"> ["-"]
-    //     Items = (*) Items "-" [EOF]
+    //     Items = (*) Items Spanned<"+"> [EOF]
     //     Items = (*) Items "-" ["+"]
     //     Items = (*) Items "-" ["-"]
+    //     Items = (*) Items "-" [EOF]
     //     __Items = (*) Items [EOF]
     //
-    //   EOF -> Items =  => ActionFn(9);
-    //   "+" -> Items =  => ActionFn(9);
-    //   "-" -> Items =  => ActionFn(9);
+    //   ["+"] -> Items =  => ActionFn(9);
+    //   ["-"] -> Items =  => ActionFn(9);
+    //   [EOF] -> Items =  => ActionFn(9);
     //
     //     Items -> S1
     pub fn __state0<
@@ -77,9 +77,9 @@ mod __parse__Items {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, (0, _), _)) |
-            Some((_, (1, _), _)) => {
+            Some((_, (1, _), _)) |
+            None => {
                 let __start: usize = ::std::default::Default::default();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action9(input, &__start, &__end);
@@ -118,20 +118,14 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Items = Items (*) Spanned<"+"> [EOF]
-    //     Items = Items (*) Spanned<"+"> ["+"]
-    //     Items = Items (*) Spanned<"+"> ["-"]
-    //     Items = Items (*) "-" [EOF]
-    //     Items = Items (*) "-" ["+"]
-    //     Items = Items (*) "-" ["-"]
-    //     Spanned<"+"> = (*) "+" [EOF]
-    //     Spanned<"+"> = (*) "+" ["+"]
-    //     Spanned<"+"> = (*) "+" ["-"]
+    //     Items = Items (*) Spanned<"+"> ["+", "-", EOF]
+    //     Items = Items (*) "-" ["+", "-", EOF]
+    //     Spanned<"+"> = (*) "+" ["+", "-", EOF]
     //     __Items = Items (*) [EOF]
     //
     //   "+" -> S3
     //   "-" -> S4
-    //   EOF -> __Items = Items => ActionFn(0);
+    //   [EOF] -> __Items = Items => ActionFn(0);
     //
     //     Spanned<"+"> -> S2
     pub fn __state1<
@@ -196,13 +190,9 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = Some(Items)
     //
-    //     Items = Items Spanned<"+"> (*) [EOF]
-    //     Items = Items Spanned<"+"> (*) ["+"]
-    //     Items = Items Spanned<"+"> (*) ["-"]
+    //     Items = Items Spanned<"+"> (*) ["+", "-", EOF]
     //
-    //   EOF -> Items = Items, Spanned<"+"> => ActionFn(2);
-    //   "+" -> Items = Items, Spanned<"+"> => ActionFn(2);
-    //   "-" -> Items = Items, Spanned<"+"> => ActionFn(2);
+    //   ["+", "-", EOF] -> Items = Items, Spanned<"+"> => ActionFn(2);
     //
     pub fn __state2<
         'input,
@@ -217,9 +207,9 @@ mod __parse__Items {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, (0, _), _)) |
-            Some((_, (1, _), _)) => {
+            Some((_, (1, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym1.2.clone();
                 let __nt = super::__action2(input, __sym0, __sym1);
@@ -248,13 +238,9 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = Some(Spanned<"+">)
     //
-    //     Spanned<"+"> = "+" (*) [EOF]
-    //     Spanned<"+"> = "+" (*) ["+"]
-    //     Spanned<"+"> = "+" (*) ["-"]
+    //     Spanned<"+"> = "+" (*) ["+", "-", EOF]
     //
-    //   EOF -> Spanned<"+"> = "+" => ActionFn(10);
-    //   "+" -> Spanned<"+"> = "+" => ActionFn(10);
-    //   "-" -> Spanned<"+"> = "+" => ActionFn(10);
+    //   ["+", "-", EOF] -> Spanned<"+"> = "+" => ActionFn(10);
     //
     pub fn __state3<
         'input,
@@ -272,9 +258,9 @@ mod __parse__Items {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
             Some((_, (0, _), _)) |
-            Some((_, (1, _), _)) => {
+            Some((_, (1, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action10(input, __sym0);
@@ -303,13 +289,9 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = Some(Items)
     //
-    //     Items = Items "-" (*) [EOF]
-    //     Items = Items "-" (*) ["+"]
-    //     Items = Items "-" (*) ["-"]
+    //     Items = Items "-" (*) ["+", "-", EOF]
     //
-    //   EOF -> Items = Items, "-" => ActionFn(3);
-    //   "+" -> Items = Items, "-" => ActionFn(3);
-    //   "-" -> Items = Items, "-" => ActionFn(3);
+    //   ["+", "-", EOF] -> Items = Items, "-" => ActionFn(3);
     //
     pub fn __state4<
         'input,
@@ -328,9 +310,9 @@ mod __parse__Items {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
             Some((_, (0, _), _)) |
-            Some((_, (1, _), _)) => {
+            Some((_, (1, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym1.2.clone();
                 let __nt = super::__action3(input, __sym0, __sym1);

--- a/lalrpop-test/src/intern_tok.rs
+++ b/lalrpop-test/src/intern_tok.rs
@@ -43,7 +43,6 @@ mod __parse__Items {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -62,9 +61,9 @@ mod __parse__Items {
     //     Items = (*) Items "-" ["-"]
     //     __Items = (*) Items [EOF]
     //
-    //     EOF -> Reduce(Items =  => ActionFn(9);)
-    //     "+" -> Reduce(Items =  => ActionFn(9);)
-    //     "-" -> Reduce(Items =  => ActionFn(9);)
+    //   EOF -> Items =  => ActionFn(9);
+    //   "+" -> Items =  => ActionFn(9);
+    //   "-" -> Items =  => ActionFn(9);
     //
     //     Items -> S1
     pub fn __state0<
@@ -112,7 +111,6 @@ mod __parse__Items {
     }
 
     // State 1
-    //     Kind = None
     //     AllInputs = [Items]
     //     OptionalInputs = []
     //     FixedInputs = [Items]
@@ -131,9 +129,9 @@ mod __parse__Items {
     //     Spanned<"+"> = (*) "+" ["-"]
     //     __Items = Items (*) [EOF]
     //
-    //     EOF -> Reduce(__Items = Items => ActionFn(0);)
-    //     "+" -> Shift(S3)
-    //     "-" -> Shift(S4)
+    //   "+" -> S3
+    //   "-" -> S4
+    //   EOF -> __Items = Items => ActionFn(0);
     //
     //     Spanned<"+"> -> S2
     pub fn __state1<
@@ -150,11 +148,11 @@ mod __parse__Items {
         match __lookahead {
             Some((__loc1, (0, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym1));
+                __result = try!(__state3(input, __tokens, __sym1));
             }
             Some((__loc1, (1, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(input, __tokens, __sym0, __sym1));
+                __result = try!(__state4(input, __tokens, __sym0, __sym1));
                 return Ok(__result);
             }
             None => {
@@ -180,7 +178,7 @@ mod __parse__Items {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Spanned_3c_22_2b_22_3e(__sym1) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym0, __sym1));
+                    __result = try!(__state2(input, __tokens, __lookahead, __sym0, __sym1));
                     return Ok(__result);
                 }
                 _ => {
@@ -190,9 +188,23 @@ mod __parse__Items {
         }
     }
 
-    // Custom 0
-    //    Reduce Items = Items, Spanned<"+"> => ActionFn(2);
-    pub fn __custom0<
+    // State 2
+    //     AllInputs = [Items, Spanned<"+">]
+    //     OptionalInputs = []
+    //     FixedInputs = [Items, Spanned<"+">]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Items)
+    //
+    //     Items = Items Spanned<"+"> (*) [EOF]
+    //     Items = Items Spanned<"+"> (*) ["+"]
+    //     Items = Items Spanned<"+"> (*) ["-"]
+    //
+    //   EOF -> Items = Items, Spanned<"+"> => ActionFn(2);
+    //   "+" -> Items = Items, Spanned<"+"> => ActionFn(2);
+    //   "-" -> Items = Items, Spanned<"+"> => ActionFn(2);
+    //
+    pub fn __state2<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -204,21 +216,47 @@ mod __parse__Items {
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = super::__action2(input, __sym0, __sym1);
-        let __nt = __Nonterminal::Items((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, (0, _), _)) |
+            Some((_, (1, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action2(input, __sym0, __sym1);
+                let __nt = __Nonterminal::Items((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 1
-    //    Reduce Spanned<"+"> = "+" => ActionFn(10);
-    pub fn __custom1<
+    // State 3
+    //     AllInputs = ["+"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["+"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Spanned<"+">)
+    //
+    //     Spanned<"+"> = "+" (*) [EOF]
+    //     Spanned<"+"> = "+" (*) ["+"]
+    //     Spanned<"+"> = "+" (*) ["-"]
+    //
+    //   EOF -> Spanned<"+"> = "+" => ActionFn(10);
+    //   "+" -> Spanned<"+"> = "+" => ActionFn(10);
+    //   "-" -> Spanned<"+"> = "+" => ActionFn(10);
+    //
+    pub fn __state3<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -233,21 +271,47 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action10(input, __sym0);
-        let __nt = __Nonterminal::Spanned_3c_22_2b_22_3e((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, (0, _), _)) |
+            Some((_, (1, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action10(input, __sym0);
+                let __nt = __Nonterminal::Spanned_3c_22_2b_22_3e((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 2
-    //    Reduce Items = Items, "-" => ActionFn(3);
-    pub fn __custom2<
+    // State 4
+    //     AllInputs = [Items, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Items, "-"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Items)
+    //
+    //     Items = Items "-" (*) [EOF]
+    //     Items = Items "-" (*) ["+"]
+    //     Items = Items "-" (*) ["-"]
+    //
+    //   EOF -> Items = Items, "-" => ActionFn(3);
+    //   "+" -> Items = Items, "-" => ActionFn(3);
+    //   "-" -> Items = Items, "-" => ActionFn(3);
+    //
+    pub fn __state4<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -263,16 +327,28 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = super::__action3(input, __sym0, __sym1);
-        let __nt = __Nonterminal::Items((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, (0, _), _)) |
+            Some((_, (1, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action3(input, __sym0, __sym1);
+                let __nt = __Nonterminal::Items((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Items::parse_Items;

--- a/lalrpop-test/src/lifetime_tok.rs
+++ b/lalrpop-test/src/lifetime_tok.rs
@@ -54,14 +54,14 @@ mod __parse__Expr {
     //
     //     Expr = (*) [EOF]
     //     Expr = (*) Other+ [EOF]
-    //     Other+ = (*) Other+ Other [EOF]
     //     Other+ = (*) Other+ Other [Other]
-    //     Other+ = (*) Other [EOF]
+    //     Other+ = (*) Other+ Other [EOF]
     //     Other+ = (*) Other [Other]
+    //     Other+ = (*) Other [EOF]
     //     __Expr = (*) Expr [EOF]
     //
     //   Other -> S3
-    //   EOF -> Expr =  => ActionFn(6);
+    //   [EOF] -> Expr =  => ActionFn(6);
     //
     //     Expr -> S1
     //     Other+ -> S2
@@ -123,7 +123,7 @@ mod __parse__Expr {
     //
     //     __Expr = Expr (*) [EOF]
     //
-    //   EOF -> __Expr = Expr => ActionFn(0);
+    //   [EOF] -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         'input,
@@ -166,11 +166,10 @@ mod __parse__Expr {
     //     WillProduce = None
     //
     //     Expr = Other+ (*) [EOF]
-    //     Other+ = Other+ (*) Other [EOF]
-    //     Other+ = Other+ (*) Other [Other]
+    //     Other+ = Other+ (*) Other [Other, EOF]
     //
     //   Other -> S4
-    //   EOF -> Expr = Other+ => ActionFn(7);
+    //   [EOF] -> Expr = Other+ => ActionFn(7);
     //
     pub fn __state2<
         'input,
@@ -217,11 +216,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Other+)
     //
-    //     Other+ = Other (*) [EOF]
-    //     Other+ = Other (*) [Other]
+    //     Other+ = Other (*) [Other, EOF]
     //
-    //   EOF -> Other+ = Other => ActionFn(4);
-    //   Other -> Other+ = Other => ActionFn(4);
+    //   [Other, EOF] -> Other+ = Other => ActionFn(4);
     //
     pub fn __state3<
         'input,
@@ -238,8 +235,8 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
-            Some((_, LtTok::Other(_), _)) => {
+            Some((_, LtTok::Other(_), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action4(__sym0);
@@ -268,11 +265,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Other+)
     //
-    //     Other+ = Other+ Other (*) [EOF]
-    //     Other+ = Other+ Other (*) [Other]
+    //     Other+ = Other+ Other (*) [Other, EOF]
     //
-    //   EOF -> Other+ = Other+, Other => ActionFn(5);
-    //   Other -> Other+ = Other+, Other => ActionFn(5);
+    //   [Other, EOF] -> Other+ = Other+, Other => ActionFn(5);
     //
     pub fn __state4<
         'input,
@@ -290,8 +285,8 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
-            Some((_, LtTok::Other(_), _)) => {
+            Some((_, LtTok::Other(_), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym1.2.clone();
                 let __nt = super::__action5(__sym0, __sym1);

--- a/lalrpop-test/src/lifetime_tok.rs
+++ b/lalrpop-test/src/lifetime_tok.rs
@@ -45,7 +45,6 @@ mod __parse__Expr {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -61,8 +60,8 @@ mod __parse__Expr {
     //     Other+ = (*) Other [Other]
     //     __Expr = (*) Expr [EOF]
     //
-    //     EOF -> Reduce(Expr =  => ActionFn(6);)
-    //     Other -> Shift(S3)
+    //   Other -> S3
+    //   EOF -> Expr =  => ActionFn(6);
     //
     //     Expr -> S1
     //     Other+ -> S2
@@ -78,7 +77,7 @@ mod __parse__Expr {
         match __lookahead {
             Some((__loc1, LtTok::Other(__tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(__tokens, __sym0));
+                __result = try!(__state3(__tokens, __sym0));
             }
             None => {
                 let __start: () = ::std::default::Default::default();
@@ -102,7 +101,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Expr(__sym0) => {
-                    __result = try!(__custom0(__tokens, __lookahead, __sym0));
+                    __result = try!(__state1(__tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::Other_2b(__sym0) => {
                     __result = try!(__state2(__tokens, __lookahead, __sym0));
@@ -114,8 +113,51 @@ mod __parse__Expr {
         }
     }
 
+    // State 1
+    //     AllInputs = [Expr]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expr]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(__Expr)
+    //
+    //     __Expr = Expr (*) [EOF]
+    //
+    //   EOF -> __Expr = Expr => ActionFn(0);
+    //
+    pub fn __state1<
+        'input,
+        __TOKENS: Iterator<Item=Result<((), LtTok<'input>, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), LtTok<'input>, ())>,
+        __sym0: ((), Vec<&'input str>, ()),
+    ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __ParseError<(),LtTok<'input>,()>>
+    {
+        let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
+        match __lookahead {
+            None => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action0(__sym0);
+                let __nt = __Nonterminal::____Expr((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 2
-    //     Kind = None
     //     AllInputs = [Other+]
     //     OptionalInputs = []
     //     FixedInputs = [Other+]
@@ -127,8 +169,8 @@ mod __parse__Expr {
     //     Other+ = Other+ (*) Other [EOF]
     //     Other+ = Other+ (*) Other [Other]
     //
-    //     EOF -> Reduce(Expr = Other+ => ActionFn(7);)
-    //     Other -> Shift(S4)
+    //   Other -> S4
+    //   EOF -> Expr = Other+ => ActionFn(7);
     //
     pub fn __state2<
         'input,
@@ -143,7 +185,7 @@ mod __parse__Expr {
         match __lookahead {
             Some((__loc1, LtTok::Other(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(__tokens, __sym0, __sym1));
+                __result = try!(__state4(__tokens, __sym0, __sym1));
                 return Ok(__result);
             }
             None => {
@@ -167,33 +209,21 @@ mod __parse__Expr {
         }
     }
 
-    // Custom 0
-    //    Reduce __Expr = Expr => ActionFn(0);
-    pub fn __custom0<
-        'input,
-        __TOKENS: Iterator<Item=Result<((), LtTok<'input>, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), LtTok<'input>, ())>,
-        __sym0: ((), Vec<&'input str>, ()),
-    ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __ParseError<(),LtTok<'input>,()>>
-    {
-        let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action0(__sym0);
-        let __nt = __Nonterminal::____Expr((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce Other+ = Other => ActionFn(4);
-    pub fn __custom1<
+    // State 3
+    //     AllInputs = [Other]
+    //     OptionalInputs = []
+    //     FixedInputs = [Other]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Other+)
+    //
+    //     Other+ = Other (*) [EOF]
+    //     Other+ = Other (*) [Other]
+    //
+    //   EOF -> Other+ = Other => ActionFn(4);
+    //   Other -> Other+ = Other => ActionFn(4);
+    //
+    pub fn __state3<
         'input,
         __TOKENS: Iterator<Item=Result<((), LtTok<'input>, ()),()>>,
     >(
@@ -207,21 +237,44 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action4(__sym0);
-        let __nt = __Nonterminal::Other_2b((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, LtTok::Other(_), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action4(__sym0);
+                let __nt = __Nonterminal::Other_2b((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 2
-    //    Reduce Other+ = Other+, Other => ActionFn(5);
-    pub fn __custom2<
+    // State 4
+    //     AllInputs = [Other+, Other]
+    //     OptionalInputs = []
+    //     FixedInputs = [Other+, Other]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Other+)
+    //
+    //     Other+ = Other+ Other (*) [EOF]
+    //     Other+ = Other+ Other (*) [Other]
+    //
+    //   EOF -> Other+ = Other+, Other => ActionFn(5);
+    //   Other -> Other+ = Other+, Other => ActionFn(5);
+    //
+    pub fn __state4<
         'input,
         __TOKENS: Iterator<Item=Result<((), LtTok<'input>, ()),()>>,
     >(
@@ -236,16 +289,27 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = super::__action5(__sym0, __sym1);
-        let __nt = __Nonterminal::Other_2b((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, LtTok::Other(_), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action5(__sym0, __sym1);
+                let __nt = __Nonterminal::Other_2b((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/loc.rs
+++ b/lalrpop-test/src/loc.rs
@@ -45,7 +45,6 @@ mod __parse__Items {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -64,9 +63,9 @@ mod __parse__Items {
     //     Items = (*) Items "-" ["-"]
     //     __Items = (*) Items [EOF]
     //
-    //     EOF -> Reduce(Items =  => ActionFn(9);)
-    //     "+" -> Reduce(Items =  => ActionFn(9);)
-    //     "-" -> Reduce(Items =  => ActionFn(9);)
+    //   EOF -> Items =  => ActionFn(9);
+    //   "+" -> Items =  => ActionFn(9);
+    //   "-" -> Items =  => ActionFn(9);
     //
     //     Items -> S1
     pub fn __state0<
@@ -112,7 +111,6 @@ mod __parse__Items {
     }
 
     // State 1
-    //     Kind = None
     //     AllInputs = [Items]
     //     OptionalInputs = []
     //     FixedInputs = [Items]
@@ -131,9 +129,9 @@ mod __parse__Items {
     //     Spanned<"+"> = (*) "+" ["-"]
     //     __Items = Items (*) [EOF]
     //
-    //     EOF -> Reduce(__Items = Items => ActionFn(0);)
-    //     "+" -> Shift(S3)
-    //     "-" -> Shift(S4)
+    //   "+" -> S3
+    //   "-" -> S4
+    //   EOF -> __Items = Items => ActionFn(0);
     //
     //     Spanned<"+"> -> S2
     pub fn __state1<
@@ -148,11 +146,11 @@ mod __parse__Items {
         match __lookahead {
             Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                 let __sym1 = (__loc1, (__tok), __loc2);
-                __result = try!(__custom1(__tokens, __sym1));
+                __result = try!(__state3(__tokens, __sym1));
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                 let __sym1 = (__loc1, (__tok), __loc2);
-                __result = try!(__custom2(__tokens, __sym0, __sym1));
+                __result = try!(__state4(__tokens, __sym0, __sym1));
                 return Ok(__result);
             }
             None => {
@@ -178,7 +176,7 @@ mod __parse__Items {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Spanned_3c_22_2b_22_3e(__sym1) => {
-                    __result = try!(__custom0(__tokens, __lookahead, __sym0, __sym1));
+                    __result = try!(__state2(__tokens, __lookahead, __sym0, __sym1));
                     return Ok(__result);
                 }
                 _ => {
@@ -188,9 +186,23 @@ mod __parse__Items {
         }
     }
 
-    // Custom 0
-    //    Reduce Items = Items, Spanned<"+"> => ActionFn(2);
-    pub fn __custom0<
+    // State 2
+    //     AllInputs = [Items, Spanned<"+">]
+    //     OptionalInputs = []
+    //     FixedInputs = [Items, Spanned<"+">]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Items)
+    //
+    //     Items = Items Spanned<"+"> (*) [EOF]
+    //     Items = Items Spanned<"+"> (*) ["+"]
+    //     Items = Items Spanned<"+"> (*) ["-"]
+    //
+    //   EOF -> Items = Items, Spanned<"+"> => ActionFn(2);
+    //   "+" -> Items = Items, Spanned<"+"> => ActionFn(2);
+    //   "-" -> Items = Items, Spanned<"+"> => ActionFn(2);
+    //
+    pub fn __state2<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         __tokens: &mut __TOKENS,
@@ -200,21 +212,47 @@ mod __parse__Items {
     ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __ParseError<usize,Tok,()>>
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = super::__action2(__sym0, __sym1);
-        let __nt = __Nonterminal::Items((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action2(__sym0, __sym1);
+                let __nt = __Nonterminal::Items((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 1
-    //    Reduce Spanned<"+"> = "+" => ActionFn(10);
-    pub fn __custom1<
+    // State 3
+    //     AllInputs = ["+"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["+"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Spanned<"+">)
+    //
+    //     Spanned<"+"> = "+" (*) [EOF]
+    //     Spanned<"+"> = "+" (*) ["+"]
+    //     Spanned<"+"> = "+" (*) ["-"]
+    //
+    //   EOF -> Spanned<"+"> = "+" => ActionFn(10);
+    //   "+" -> Spanned<"+"> = "+" => ActionFn(10);
+    //   "-" -> Spanned<"+"> = "+" => ActionFn(10);
+    //
+    pub fn __state3<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         __tokens: &mut __TOKENS,
@@ -227,21 +265,47 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action10(__sym0);
-        let __nt = __Nonterminal::Spanned_3c_22_2b_22_3e((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action10(__sym0);
+                let __nt = __Nonterminal::Spanned_3c_22_2b_22_3e((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 2
-    //    Reduce Items = Items, "-" => ActionFn(3);
-    pub fn __custom2<
+    // State 4
+    //     AllInputs = [Items, "-"]
+    //     OptionalInputs = []
+    //     FixedInputs = [Items, "-"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Items)
+    //
+    //     Items = Items "-" (*) [EOF]
+    //     Items = Items "-" (*) ["+"]
+    //     Items = Items "-" (*) ["-"]
+    //
+    //   EOF -> Items = Items, "-" => ActionFn(3);
+    //   "+" -> Items = Items, "-" => ActionFn(3);
+    //   "-" -> Items = Items, "-" => ActionFn(3);
+    //
+    pub fn __state4<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
     >(
         __tokens: &mut __TOKENS,
@@ -255,16 +319,28 @@ mod __parse__Items {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = super::__action3(__sym0, __sym1);
-        let __nt = __Nonterminal::Items((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None |
+            Some((_, Tok::Plus, _)) |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action3(__sym0, __sym1);
+                let __nt = __Nonterminal::Items((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Items::parse_Items;

--- a/lalrpop-test/src/loc.rs
+++ b/lalrpop-test/src/loc.rs
@@ -52,20 +52,20 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Items = (*) [EOF]
     //     Items = (*) ["+"]
     //     Items = (*) ["-"]
-    //     Items = (*) Items Spanned<"+"> [EOF]
+    //     Items = (*) [EOF]
     //     Items = (*) Items Spanned<"+"> ["+"]
     //     Items = (*) Items Spanned<"+"> ["-"]
-    //     Items = (*) Items "-" [EOF]
+    //     Items = (*) Items Spanned<"+"> [EOF]
     //     Items = (*) Items "-" ["+"]
     //     Items = (*) Items "-" ["-"]
+    //     Items = (*) Items "-" [EOF]
     //     __Items = (*) Items [EOF]
     //
-    //   EOF -> Items =  => ActionFn(9);
-    //   "+" -> Items =  => ActionFn(9);
-    //   "-" -> Items =  => ActionFn(9);
+    //   ["+"] -> Items =  => ActionFn(9);
+    //   ["-"] -> Items =  => ActionFn(9);
+    //   [EOF] -> Items =  => ActionFn(9);
     //
     //     Items -> S1
     pub fn __state0<
@@ -77,9 +77,9 @@ mod __parse__Items {
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start: usize = ::std::default::Default::default();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action9(&__start, &__end);
@@ -118,20 +118,14 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Items = Items (*) Spanned<"+"> [EOF]
-    //     Items = Items (*) Spanned<"+"> ["+"]
-    //     Items = Items (*) Spanned<"+"> ["-"]
-    //     Items = Items (*) "-" [EOF]
-    //     Items = Items (*) "-" ["+"]
-    //     Items = Items (*) "-" ["-"]
-    //     Spanned<"+"> = (*) "+" [EOF]
-    //     Spanned<"+"> = (*) "+" ["+"]
-    //     Spanned<"+"> = (*) "+" ["-"]
+    //     Items = Items (*) Spanned<"+"> ["+", "-", EOF]
+    //     Items = Items (*) "-" ["+", "-", EOF]
+    //     Spanned<"+"> = (*) "+" ["+", "-", EOF]
     //     __Items = Items (*) [EOF]
     //
     //   "+" -> S3
     //   "-" -> S4
-    //   EOF -> __Items = Items => ActionFn(0);
+    //   [EOF] -> __Items = Items => ActionFn(0);
     //
     //     Spanned<"+"> -> S2
     pub fn __state1<
@@ -194,13 +188,9 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = Some(Items)
     //
-    //     Items = Items Spanned<"+"> (*) [EOF]
-    //     Items = Items Spanned<"+"> (*) ["+"]
-    //     Items = Items Spanned<"+"> (*) ["-"]
+    //     Items = Items Spanned<"+"> (*) ["+", "-", EOF]
     //
-    //   EOF -> Items = Items, Spanned<"+"> => ActionFn(2);
-    //   "+" -> Items = Items, Spanned<"+"> => ActionFn(2);
-    //   "-" -> Items = Items, Spanned<"+"> => ActionFn(2);
+    //   ["+", "-", EOF] -> Items = Items, Spanned<"+"> => ActionFn(2);
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
@@ -213,9 +203,9 @@ mod __parse__Items {
     {
         let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym1.2.clone();
                 let __nt = super::__action2(__sym0, __sym1);
@@ -244,13 +234,9 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = Some(Spanned<"+">)
     //
-    //     Spanned<"+"> = "+" (*) [EOF]
-    //     Spanned<"+"> = "+" (*) ["+"]
-    //     Spanned<"+"> = "+" (*) ["-"]
+    //     Spanned<"+"> = "+" (*) ["+", "-", EOF]
     //
-    //   EOF -> Spanned<"+"> = "+" => ActionFn(10);
-    //   "+" -> Spanned<"+"> = "+" => ActionFn(10);
-    //   "-" -> Spanned<"+"> = "+" => ActionFn(10);
+    //   ["+", "-", EOF] -> Spanned<"+"> = "+" => ActionFn(10);
     //
     pub fn __state3<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
@@ -266,9 +252,9 @@ mod __parse__Items {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action10(__sym0);
@@ -297,13 +283,9 @@ mod __parse__Items {
     //     WillPush = []
     //     WillProduce = Some(Items)
     //
-    //     Items = Items "-" (*) [EOF]
-    //     Items = Items "-" (*) ["+"]
-    //     Items = Items "-" (*) ["-"]
+    //     Items = Items "-" (*) ["+", "-", EOF]
     //
-    //   EOF -> Items = Items, "-" => ActionFn(3);
-    //   "+" -> Items = Items, "-" => ActionFn(3);
-    //   "-" -> Items = Items, "-" => ActionFn(3);
+    //   ["+", "-", EOF] -> Items = Items, "-" => ActionFn(3);
     //
     pub fn __state4<
         __TOKENS: Iterator<Item=Result<(usize, Tok, usize),()>>,
@@ -320,9 +302,9 @@ mod __parse__Items {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
             Some((_, Tok::Plus, _)) |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym1.2.clone();
                 let __nt = super::__action3(__sym0, __sym1);

--- a/lalrpop-test/src/loc_issue_90.rs
+++ b/lalrpop-test/src/loc_issue_90.rs
@@ -47,7 +47,6 @@ mod __parse__Expression2 {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -73,11 +72,11 @@ mod __parse__Expression2 {
     //     Wacky = (*) "wacky" ["*"]
     //     __Expression2 = (*) Expression2 [EOF]
     //
-    //     "&" -> Shift(S4)
-    //     "(" -> Shift(S5)
-    //     "wacky" -> Shift(S6)
-    //     "wonky" -> Shift(S7)
-    //     r#"\\w+"# -> Shift(S8)
+    //   "&" -> S4
+    //   "(" -> S5
+    //   "wacky" -> S6
+    //   "wonky" -> S7
+    //   r#"\\w+"# -> S8
     //
     //     Expression1 -> S1
     //     Expression2 -> S2
@@ -103,7 +102,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(input, __tokens, __sym0));
+                __result = try!(__state6(input, __tokens, __sym0));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
@@ -111,7 +110,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom3(input, __tokens, __sym0));
+                __result = try!(__state8(input, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -124,13 +123,13 @@ mod __parse__Expression2 {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Expression1(__sym0) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym0));
+                    __result = try!(__state1(input, __tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::Expression2(__sym0) => {
                     __result = try!(__state2(input, __tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::Wacky(__sym0) => {
-                    __result = try!(__custom1(input, __tokens, __lookahead, __sym0));
+                    __result = try!(__state3(input, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -139,8 +138,55 @@ mod __parse__Expression2 {
         }
     }
 
+    // State 1
+    //     AllInputs = [Expression1]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expression1]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression2)
+    //
+    //     Expression2 = Expression1 (*) [EOF]
+    //     Expression2 = Expression1 (*) ["*"]
+    //
+    //   EOF -> Expression2 = Expression1 => ActionFn(29);
+    //   "*" -> Expression2 = Expression1 => ActionFn(29);
+    //
+    pub fn __state1<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        match __lookahead {
+            None |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action29(input, __sym0);
+                let __nt = __Nonterminal::Expression2((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 2
-    //     Kind = None
     //     AllInputs = [Expression2]
     //     OptionalInputs = []
     //     FixedInputs = [Expression2]
@@ -157,8 +203,8 @@ mod __parse__Expression2 {
     //     Expression2Op = (*) "*" [r#"\\w+"#]
     //     __Expression2 = Expression2 (*) [EOF]
     //
-    //     EOF -> Reduce(__Expression2 = Expression2 => ActionFn(0);)
-    //     "*" -> Shift(S10)
+    //   "*" -> S10
+    //   EOF -> __Expression2 = Expression2 => ActionFn(0);
     //
     //     Expression2Op -> S9
     pub fn __state2<
@@ -175,7 +221,7 @@ mod __parse__Expression2 {
         match __lookahead {
             Some((__loc1, (3, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom4(input, __tokens, __sym1));
+                __result = try!(__state10(input, __tokens, __sym1));
             }
             None => {
                 let __start = __sym0.0.clone();
@@ -210,8 +256,55 @@ mod __parse__Expression2 {
         }
     }
 
+    // State 3
+    //     AllInputs = [Wacky]
+    //     OptionalInputs = []
+    //     FixedInputs = [Wacky]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression1)
+    //
+    //     Expression1 = Wacky (*) [EOF]
+    //     Expression1 = Wacky (*) ["*"]
+    //
+    //   EOF -> Expression1 = Wacky => ActionFn(8);
+    //   "*" -> Expression1 = Wacky => ActionFn(8);
+    //
+    pub fn __state3<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        match __lookahead {
+            None |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action8(input, __sym0);
+                let __nt = __Nonterminal::Expression1((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 4
-    //     Kind = None
     //     AllInputs = ["&"]
     //     OptionalInputs = []
     //     FixedInputs = ["&"]
@@ -232,12 +325,12 @@ mod __parse__Expression2 {
     //     Maybe = (*) "[" "]" ["wonky"]
     //     Maybe = (*) "[" "]" [r#"\\w+"#]
     //
-    //     "&" -> Reduce(Maybe =  => ActionFn(31);)
-    //     "(" -> Reduce(Maybe =  => ActionFn(31);)
-    //     "[" -> Shift(S12)
-    //     "wacky" -> Reduce(Maybe =  => ActionFn(31);)
-    //     "wonky" -> Reduce(Maybe =  => ActionFn(31);)
-    //     r#"\\w+"# -> Reduce(Maybe =  => ActionFn(31);)
+    //   "[" -> S12
+    //   "&" -> Maybe =  => ActionFn(31);
+    //   "(" -> Maybe =  => ActionFn(31);
+    //   "wacky" -> Maybe =  => ActionFn(31);
+    //   "wonky" -> Maybe =  => ActionFn(31);
+    //   r#"\\w+"# -> Maybe =  => ActionFn(31);
     //
     //     Maybe -> S11
     pub fn __state4<
@@ -297,7 +390,6 @@ mod __parse__Expression2 {
     }
 
     // State 5
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -324,11 +416,11 @@ mod __parse__Expression2 {
     //     Wacky = (*) "wacky" [")"]
     //     Wacky = (*) "wacky" ["*"]
     //
-    //     "&" -> Shift(S16)
-    //     "(" -> Shift(S17)
-    //     "wacky" -> Shift(S18)
-    //     "wonky" -> Shift(S19)
-    //     r#"\\w+"# -> Shift(S20)
+    //   "&" -> S16
+    //   "(" -> S17
+    //   "wacky" -> S18
+    //   "wonky" -> S19
+    //   r#"\\w+"# -> S20
     //
     //     Expression1 -> S13
     //     Expression2 -> S14
@@ -360,7 +452,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(input, __tokens, __sym1));
+                __result = try!(__state18(input, __tokens, __sym1));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
@@ -368,7 +460,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom3(input, __tokens, __sym1));
+                __result = try!(__state20(input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -384,13 +476,13 @@ mod __parse__Expression2 {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Expression1(__sym1) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state13(input, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Expression2(__sym1) => {
                     __result = try!(__state14(input, __tokens, __lookahead, __sym0, __sym1));
                 }
                 __Nonterminal::Wacky(__sym1) => {
-                    __result = try!(__custom1(input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state15(input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -399,8 +491,59 @@ mod __parse__Expression2 {
         }
     }
 
+    // State 6
+    //     AllInputs = ["wacky"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["wacky"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Wacky)
+    //
+    //     Wacky = "wacky" (*) [EOF]
+    //     Wacky = "wacky" (*) ["*"]
+    //
+    //   EOF -> Wacky = "wacky" => ActionFn(33);
+    //   "*" -> Wacky = "wacky" => ActionFn(33);
+    //
+    pub fn __state6<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            None |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action33(input, __sym0);
+                let __nt = __Nonterminal::Wacky((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 7
-    //     Kind = None
     //     AllInputs = ["wonky"]
     //     OptionalInputs = []
     //     FixedInputs = ["wonky"]
@@ -413,8 +556,8 @@ mod __parse__Expression2 {
     //     Wonky = (*) [EOF]
     //     Wonky = (*) ["*"]
     //
-    //     EOF -> Reduce(Wonky =  => ActionFn(34);)
-    //     "*" -> Reduce(Wonky =  => ActionFn(34);)
+    //   EOF -> Wonky =  => ActionFn(34);
+    //   "*" -> Wonky =  => ActionFn(34);
     //
     //     Wonky -> S21
     pub fn __state7<
@@ -456,7 +599,7 @@ mod __parse__Expression2 {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Wonky(__sym1) => {
-                    __result = try!(__custom5(input, __tokens, __lookahead, __sym0, __sym1));
+                    __result = try!(__state21(input, __tokens, __lookahead, __sym0, __sym1));
                     return Ok(__result);
                 }
                 _ => {
@@ -466,8 +609,59 @@ mod __parse__Expression2 {
         }
     }
 
+    // State 8
+    //     AllInputs = [r#"\\w+"#]
+    //     OptionalInputs = []
+    //     FixedInputs = [r#"\\w+"#]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression1)
+    //
+    //     Expression1 = r#"\\w+"# (*) [EOF]
+    //     Expression1 = r#"\\w+"# (*) ["*"]
+    //
+    //   EOF -> Expression1 = r#"\\w+"# => ActionFn(26);
+    //   "*" -> Expression1 = r#"\\w+"# => ActionFn(26);
+    //
+    pub fn __state8<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            None |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action26(input, __sym0);
+                let __nt = __Nonterminal::Expression1((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 9
-    //     Kind = None
     //     AllInputs = [Expression2, Expression2Op]
     //     OptionalInputs = []
     //     FixedInputs = [Expression2, Expression2Op]
@@ -490,11 +684,11 @@ mod __parse__Expression2 {
     //     Wacky = (*) "wacky" [EOF]
     //     Wacky = (*) "wacky" ["*"]
     //
-    //     "&" -> Shift(S4)
-    //     "(" -> Shift(S5)
-    //     "wacky" -> Shift(S6)
-    //     "wonky" -> Shift(S7)
-    //     r#"\\w+"# -> Shift(S8)
+    //   "&" -> S4
+    //   "(" -> S5
+    //   "wacky" -> S6
+    //   "wonky" -> S7
+    //   r#"\\w+"# -> S8
     //
     //     Expression1 -> S22
     //     Wacky -> S3
@@ -521,7 +715,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(input, __tokens, __sym2));
+                __result = try!(__state6(input, __tokens, __sym2));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
@@ -529,7 +723,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom3(input, __tokens, __sym2));
+                __result = try!(__state8(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -542,11 +736,11 @@ mod __parse__Expression2 {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Expression1(__sym2) => {
-                    __result = try!(__custom6(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state22(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 __Nonterminal::Wacky(__sym2) => {
-                    __result = try!(__custom1(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -555,8 +749,68 @@ mod __parse__Expression2 {
         }
     }
 
+    // State 10
+    //     AllInputs = ["*"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["*"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression2Op)
+    //
+    //     Expression2Op = "*" (*) ["&"]
+    //     Expression2Op = "*" (*) ["("]
+    //     Expression2Op = "*" (*) ["wacky"]
+    //     Expression2Op = "*" (*) ["wonky"]
+    //     Expression2Op = "*" (*) [r#"\\w+"#]
+    //
+    //   "&" -> Expression2Op = "*" => ActionFn(30);
+    //   "(" -> Expression2Op = "*" => ActionFn(30);
+    //   "wacky" -> Expression2Op = "*" => ActionFn(30);
+    //   "wonky" -> Expression2Op = "*" => ActionFn(30);
+    //   r#"\\w+"# -> Expression2Op = "*" => ActionFn(30);
+    //
+    pub fn __state10<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((_, (0, _), _)) |
+            Some((_, (1, _), _)) |
+            Some((_, (6, _), _)) |
+            Some((_, (7, _), _)) |
+            Some((_, (8, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action30(input, __sym0);
+                let __nt = __Nonterminal::Expression2Op((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 11
-    //     Kind = None
     //     AllInputs = ["&", Maybe]
     //     OptionalInputs = []
     //     FixedInputs = ["&", Maybe]
@@ -579,11 +833,11 @@ mod __parse__Expression2 {
     //     Wacky = (*) "wacky" [EOF]
     //     Wacky = (*) "wacky" ["*"]
     //
-    //     "&" -> Shift(S4)
-    //     "(" -> Shift(S5)
-    //     "wacky" -> Shift(S6)
-    //     "wonky" -> Shift(S7)
-    //     r#"\\w+"# -> Shift(S8)
+    //   "&" -> S4
+    //   "(" -> S5
+    //   "wacky" -> S6
+    //   "wonky" -> S7
+    //   r#"\\w+"# -> S8
     //
     //     Expression1 -> S23
     //     Wacky -> S3
@@ -610,7 +864,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(input, __tokens, __sym2));
+                __result = try!(__state6(input, __tokens, __sym2));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
@@ -618,7 +872,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom3(input, __tokens, __sym2));
+                __result = try!(__state8(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -631,11 +885,11 @@ mod __parse__Expression2 {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Expression1(__sym2) => {
-                    __result = try!(__custom7(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state23(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 __Nonterminal::Wacky(__sym2) => {
-                    __result = try!(__custom1(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -645,7 +899,6 @@ mod __parse__Expression2 {
     }
 
     // State 12
-    //     Kind = None
     //     AllInputs = ["["]
     //     OptionalInputs = []
     //     FixedInputs = ["["]
@@ -659,7 +912,7 @@ mod __parse__Expression2 {
     //     Maybe = "[" (*) "]" ["wonky"]
     //     Maybe = "[" (*) "]" [r#"\\w+"#]
     //
-    //     "]" -> Shift(S24)
+    //   "]" -> S24
     //
     pub fn __state12<
         'input,
@@ -679,7 +932,55 @@ mod __parse__Expression2 {
         match __lookahead {
             Some((__loc1, (5, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom8(input, __tokens, __sym0, __sym1));
+                __result = try!(__state24(input, __tokens, __sym0, __sym1));
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 13
+    //     AllInputs = [Expression1]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expression1]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression2)
+    //
+    //     Expression2 = Expression1 (*) [")"]
+    //     Expression2 = Expression1 (*) ["*"]
+    //
+    //   ")" -> Expression2 = Expression1 => ActionFn(29);
+    //   "*" -> Expression2 = Expression1 => ActionFn(29);
+    //
+    pub fn __state13<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        match __lookahead {
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action29(input, __sym0);
+                let __nt = __Nonterminal::Expression2((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
                 return Ok(__result);
             }
             _ => {
@@ -692,7 +993,6 @@ mod __parse__Expression2 {
     }
 
     // State 14
-    //     Kind = None
     //     AllInputs = ["(", Expression2]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expression2]
@@ -710,8 +1010,8 @@ mod __parse__Expression2 {
     //     Expression2Op = (*) "*" ["wonky"]
     //     Expression2Op = (*) "*" [r#"\\w+"#]
     //
-    //     ")" -> Shift(S26)
-    //     "*" -> Shift(S10)
+    //   ")" -> S26
+    //   "*" -> S10
     //
     //     Expression2Op -> S25
     pub fn __state14<
@@ -730,12 +1030,12 @@ mod __parse__Expression2 {
             Some((__loc1, (2, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom9(input, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state26(input, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom4(input, __tokens, __sym2));
+                __result = try!(__state10(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -758,8 +1058,55 @@ mod __parse__Expression2 {
         }
     }
 
+    // State 15
+    //     AllInputs = [Wacky]
+    //     OptionalInputs = []
+    //     FixedInputs = [Wacky]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression1)
+    //
+    //     Expression1 = Wacky (*) [")"]
+    //     Expression1 = Wacky (*) ["*"]
+    //
+    //   ")" -> Expression1 = Wacky => ActionFn(8);
+    //   "*" -> Expression1 = Wacky => ActionFn(8);
+    //
+    pub fn __state15<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        match __lookahead {
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action8(input, __sym0);
+                let __nt = __Nonterminal::Expression1((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 16
-    //     Kind = None
     //     AllInputs = ["&"]
     //     OptionalInputs = []
     //     FixedInputs = ["&"]
@@ -780,12 +1127,12 @@ mod __parse__Expression2 {
     //     Maybe = (*) "[" "]" ["wonky"]
     //     Maybe = (*) "[" "]" [r#"\\w+"#]
     //
-    //     "&" -> Reduce(Maybe =  => ActionFn(31);)
-    //     "(" -> Reduce(Maybe =  => ActionFn(31);)
-    //     "[" -> Shift(S12)
-    //     "wacky" -> Reduce(Maybe =  => ActionFn(31);)
-    //     "wonky" -> Reduce(Maybe =  => ActionFn(31);)
-    //     r#"\\w+"# -> Reduce(Maybe =  => ActionFn(31);)
+    //   "[" -> S12
+    //   "&" -> Maybe =  => ActionFn(31);
+    //   "(" -> Maybe =  => ActionFn(31);
+    //   "wacky" -> Maybe =  => ActionFn(31);
+    //   "wonky" -> Maybe =  => ActionFn(31);
+    //   r#"\\w+"# -> Maybe =  => ActionFn(31);
     //
     //     Maybe -> S27
     pub fn __state16<
@@ -845,7 +1192,6 @@ mod __parse__Expression2 {
     }
 
     // State 17
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -872,11 +1218,11 @@ mod __parse__Expression2 {
     //     Wacky = (*) "wacky" [")"]
     //     Wacky = (*) "wacky" ["*"]
     //
-    //     "&" -> Shift(S16)
-    //     "(" -> Shift(S17)
-    //     "wacky" -> Shift(S18)
-    //     "wonky" -> Shift(S19)
-    //     r#"\\w+"# -> Shift(S20)
+    //   "&" -> S16
+    //   "(" -> S17
+    //   "wacky" -> S18
+    //   "wonky" -> S19
+    //   r#"\\w+"# -> S20
     //
     //     Expression1 -> S13
     //     Expression2 -> S28
@@ -908,7 +1254,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(input, __tokens, __sym1));
+                __result = try!(__state18(input, __tokens, __sym1));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
@@ -916,7 +1262,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom3(input, __tokens, __sym1));
+                __result = try!(__state20(input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -932,13 +1278,13 @@ mod __parse__Expression2 {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Expression1(__sym1) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state13(input, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Expression2(__sym1) => {
                     __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1));
                 }
                 __Nonterminal::Wacky(__sym1) => {
-                    __result = try!(__custom1(input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state15(input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -947,8 +1293,59 @@ mod __parse__Expression2 {
         }
     }
 
+    // State 18
+    //     AllInputs = ["wacky"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["wacky"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Wacky)
+    //
+    //     Wacky = "wacky" (*) [")"]
+    //     Wacky = "wacky" (*) ["*"]
+    //
+    //   ")" -> Wacky = "wacky" => ActionFn(33);
+    //   "*" -> Wacky = "wacky" => ActionFn(33);
+    //
+    pub fn __state18<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action33(input, __sym0);
+                let __nt = __Nonterminal::Wacky((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 19
-    //     Kind = None
     //     AllInputs = ["wonky"]
     //     OptionalInputs = []
     //     FixedInputs = ["wonky"]
@@ -961,8 +1358,8 @@ mod __parse__Expression2 {
     //     Wonky = (*) [")"]
     //     Wonky = (*) ["*"]
     //
-    //     ")" -> Reduce(Wonky =  => ActionFn(34);)
-    //     "*" -> Reduce(Wonky =  => ActionFn(34);)
+    //   ")" -> Wonky =  => ActionFn(34);
+    //   "*" -> Wonky =  => ActionFn(34);
     //
     //     Wonky -> S29
     pub fn __state19<
@@ -1004,7 +1401,7 @@ mod __parse__Expression2 {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Wonky(__sym1) => {
-                    __result = try!(__custom5(input, __tokens, __lookahead, __sym0, __sym1));
+                    __result = try!(__state29(input, __tokens, __lookahead, __sym0, __sym1));
                     return Ok(__result);
                 }
                 _ => {
@@ -1014,8 +1411,270 @@ mod __parse__Expression2 {
         }
     }
 
+    // State 20
+    //     AllInputs = [r#"\\w+"#]
+    //     OptionalInputs = []
+    //     FixedInputs = [r#"\\w+"#]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression1)
+    //
+    //     Expression1 = r#"\\w+"# (*) [")"]
+    //     Expression1 = r#"\\w+"# (*) ["*"]
+    //
+    //   ")" -> Expression1 = r#"\\w+"# => ActionFn(26);
+    //   "*" -> Expression1 = r#"\\w+"# => ActionFn(26);
+    //
+    pub fn __state20<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action26(input, __sym0);
+                let __nt = __Nonterminal::Expression1((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 21
+    //     AllInputs = ["wonky", Wonky]
+    //     OptionalInputs = []
+    //     FixedInputs = ["wonky", Wonky]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression1)
+    //
+    //     Expression1 = "wonky" Wonky (*) [EOF]
+    //     Expression1 = "wonky" Wonky (*) ["*"]
+    //
+    //   EOF -> Expression1 = "wonky", Wonky => ActionFn(7);
+    //   "*" -> Expression1 = "wonky", Wonky => ActionFn(7);
+    //
+    pub fn __state21<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        match __lookahead {
+            None |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action7(input, __sym0, __sym1);
+                let __nt = __Nonterminal::Expression1((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 22
+    //     AllInputs = [Expression2, Expression2Op, Expression1]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expression2, Expression2Op, Expression1]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression2)
+    //
+    //     Expression2 = Expression2 Expression2Op Expression1 (*) [EOF]
+    //     Expression2 = Expression2 Expression2Op Expression1 (*) ["*"]
+    //
+    //   EOF -> Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
+    //   "*" -> Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
+    //
+    pub fn __state22<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, Box<Expr<'input>>, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
+        __sym2: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        match __lookahead {
+            None |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action28(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Expression2((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 23
+    //     AllInputs = ["&", Maybe, Expression1]
+    //     OptionalInputs = []
+    //     FixedInputs = ["&", Maybe, Expression1]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression1)
+    //
+    //     Expression1 = "&" Maybe Expression1 (*) [EOF]
+    //     Expression1 = "&" Maybe Expression1 (*) ["*"]
+    //
+    //   EOF -> Expression1 = "&", Maybe, Expression1 => ActionFn(27);
+    //   "*" -> Expression1 = "&", Maybe, Expression1 => ActionFn(27);
+    //
+    pub fn __state23<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
+        __sym2: (usize, Box<Expr<'input>>, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        match __lookahead {
+            None |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action27(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Expression1((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 24
+    //     AllInputs = ["[", "]"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["[", "]"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Maybe)
+    //
+    //     Maybe = "[" "]" (*) ["&"]
+    //     Maybe = "[" "]" (*) ["("]
+    //     Maybe = "[" "]" (*) ["wacky"]
+    //     Maybe = "[" "]" (*) ["wonky"]
+    //     Maybe = "[" "]" (*) [r#"\\w+"#]
+    //
+    //   "&" -> Maybe = "[", "]" => ActionFn(32);
+    //   "(" -> Maybe = "[", "]" => ActionFn(32);
+    //   "wacky" -> Maybe = "[", "]" => ActionFn(32);
+    //   "wonky" -> Maybe = "[", "]" => ActionFn(32);
+    //   r#"\\w+"# -> Maybe = "[", "]" => ActionFn(32);
+    //
+    pub fn __state24<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((_, (0, _), _)) |
+            Some((_, (1, _), _)) |
+            Some((_, (6, _), _)) |
+            Some((_, (7, _), _)) |
+            Some((_, (8, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action32(input, __sym0, __sym1);
+                let __nt = __Nonterminal::Maybe((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 25
-    //     Kind = None
     //     AllInputs = [Expression2, Expression2Op]
     //     OptionalInputs = []
     //     FixedInputs = [Expression2, Expression2Op]
@@ -1038,11 +1697,11 @@ mod __parse__Expression2 {
     //     Wacky = (*) "wacky" [")"]
     //     Wacky = (*) "wacky" ["*"]
     //
-    //     "&" -> Shift(S16)
-    //     "(" -> Shift(S17)
-    //     "wacky" -> Shift(S18)
-    //     "wonky" -> Shift(S19)
-    //     r#"\\w+"# -> Shift(S20)
+    //   "&" -> S16
+    //   "(" -> S17
+    //   "wacky" -> S18
+    //   "wonky" -> S19
+    //   r#"\\w+"# -> S20
     //
     //     Expression1 -> S30
     //     Wacky -> S15
@@ -1069,7 +1728,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(input, __tokens, __sym2));
+                __result = try!(__state18(input, __tokens, __sym2));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
@@ -1077,7 +1736,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom3(input, __tokens, __sym2));
+                __result = try!(__state20(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1090,11 +1749,11 @@ mod __parse__Expression2 {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Expression1(__sym2) => {
-                    __result = try!(__custom6(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state30(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 __Nonterminal::Wacky(__sym2) => {
-                    __result = try!(__custom1(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state15(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1103,8 +1762,61 @@ mod __parse__Expression2 {
         }
     }
 
+    // State 26
+    //     AllInputs = ["(", Expression2, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expression2, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression1)
+    //
+    //     Expression1 = "(" Expression2 ")" (*) [EOF]
+    //     Expression1 = "(" Expression2 ")" (*) ["*"]
+    //
+    //   EOF -> Expression1 = "(", Expression2, ")" => ActionFn(25);
+    //   "*" -> Expression1 = "(", Expression2, ")" => ActionFn(25);
+    //
+    pub fn __state26<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, Box<Expr<'input>>, usize),
+        __sym2: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            None |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action25(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Expression1((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 27
-    //     Kind = None
     //     AllInputs = ["&", Maybe]
     //     OptionalInputs = []
     //     FixedInputs = ["&", Maybe]
@@ -1127,11 +1839,11 @@ mod __parse__Expression2 {
     //     Wacky = (*) "wacky" [")"]
     //     Wacky = (*) "wacky" ["*"]
     //
-    //     "&" -> Shift(S16)
-    //     "(" -> Shift(S17)
-    //     "wacky" -> Shift(S18)
-    //     "wonky" -> Shift(S19)
-    //     r#"\\w+"# -> Shift(S20)
+    //   "&" -> S16
+    //   "(" -> S17
+    //   "wacky" -> S18
+    //   "wonky" -> S19
+    //   r#"\\w+"# -> S20
     //
     //     Expression1 -> S31
     //     Wacky -> S15
@@ -1158,7 +1870,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(input, __tokens, __sym2));
+                __result = try!(__state18(input, __tokens, __sym2));
             }
             Some((__loc1, (7, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
@@ -1166,7 +1878,7 @@ mod __parse__Expression2 {
             }
             Some((__loc1, (8, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom3(input, __tokens, __sym2));
+                __result = try!(__state20(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1179,11 +1891,11 @@ mod __parse__Expression2 {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Expression1(__sym2) => {
-                    __result = try!(__custom7(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state31(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 __Nonterminal::Wacky(__sym2) => {
-                    __result = try!(__custom1(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state15(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1193,7 +1905,6 @@ mod __parse__Expression2 {
     }
 
     // State 28
-    //     Kind = None
     //     AllInputs = ["(", Expression2]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expression2]
@@ -1211,8 +1922,8 @@ mod __parse__Expression2 {
     //     Expression2Op = (*) "*" ["wonky"]
     //     Expression2Op = (*) "*" [r#"\\w+"#]
     //
-    //     ")" -> Shift(S32)
-    //     "*" -> Shift(S10)
+    //   ")" -> S32
+    //   "*" -> S10
     //
     //     Expression2Op -> S25
     pub fn __state28<
@@ -1231,12 +1942,12 @@ mod __parse__Expression2 {
             Some((__loc1, (2, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom9(input, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state32(input, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom4(input, __tokens, __sym2));
+                __result = try!(__state10(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1259,146 +1970,21 @@ mod __parse__Expression2 {
         }
     }
 
-    // Custom 0
-    //    Reduce Expression2 = Expression1 => ActionFn(29);
-    pub fn __custom0<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: (usize, Box<Expr<'input>>, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action29(input, __sym0);
-        let __nt = __Nonterminal::Expression2((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce Expression1 = Wacky => ActionFn(8);
-    pub fn __custom1<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: (usize, Box<Expr<'input>>, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action8(input, __sym0);
-        let __nt = __Nonterminal::Expression1((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 2
-    //    Reduce Wacky = "wacky" => ActionFn(33);
-    pub fn __custom2<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, &'input str, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action33(input, __sym0);
-        let __nt = __Nonterminal::Wacky((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 3
-    //    Reduce Expression1 = r#"\\w+"# => ActionFn(26);
-    pub fn __custom3<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, &'input str, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action26(input, __sym0);
-        let __nt = __Nonterminal::Expression1((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 4
-    //    Reduce Expression2Op = "*" => ActionFn(30);
-    pub fn __custom4<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, &'input str, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action30(input, __sym0);
-        let __nt = __Nonterminal::Expression2Op((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 5
-    //    Reduce Expression1 = "wonky", Wonky => ActionFn(7);
-    pub fn __custom5<
+    // State 29
+    //     AllInputs = ["wonky", Wonky]
+    //     OptionalInputs = []
+    //     FixedInputs = ["wonky", Wonky]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression1)
+    //
+    //     Expression1 = "wonky" Wonky (*) [")"]
+    //     Expression1 = "wonky" Wonky (*) ["*"]
+    //
+    //   ")" -> Expression1 = "wonky", Wonky => ActionFn(7);
+    //   "*" -> Expression1 = "wonky", Wonky => ActionFn(7);
+    //
+    pub fn __state29<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -1410,21 +1996,44 @@ mod __parse__Expression2 {
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = super::__action7(input, __sym0, __sym1);
-        let __nt = __Nonterminal::Expression1((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action7(input, __sym0, __sym1);
+                let __nt = __Nonterminal::Expression1((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 6
-    //    Reduce Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
-    pub fn __custom6<
+    // State 30
+    //     AllInputs = [Expression2, Expression2Op, Expression1]
+    //     OptionalInputs = []
+    //     FixedInputs = [Expression2, Expression2Op, Expression1]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression2)
+    //
+    //     Expression2 = Expression2 Expression2Op Expression1 (*) [")"]
+    //     Expression2 = Expression2 Expression2Op Expression1 (*) ["*"]
+    //
+    //   ")" -> Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
+    //   "*" -> Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
+    //
+    pub fn __state30<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -1437,21 +2046,44 @@ mod __parse__Expression2 {
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action28(input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Expression2((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action28(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Expression2((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 7
-    //    Reduce Expression1 = "&", Maybe, Expression1 => ActionFn(27);
-    pub fn __custom7<
+    // State 31
+    //     AllInputs = ["&", Maybe, Expression1]
+    //     OptionalInputs = []
+    //     FixedInputs = ["&", Maybe, Expression1]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression1)
+    //
+    //     Expression1 = "&" Maybe Expression1 (*) [")"]
+    //     Expression1 = "&" Maybe Expression1 (*) ["*"]
+    //
+    //   ")" -> Expression1 = "&", Maybe, Expression1 => ActionFn(27);
+    //   "*" -> Expression1 = "&", Maybe, Expression1 => ActionFn(27);
+    //
+    pub fn __state31<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -1464,51 +2096,44 @@ mod __parse__Expression2 {
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action27(input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Expression1((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action27(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Expression1((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 8
-    //    Reduce Maybe = "[", "]" => ActionFn(32);
-    pub fn __custom8<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, &'input str, usize),
-        __sym1: (usize, &'input str, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = super::__action32(input, __sym0, __sym1);
-        let __nt = __Nonterminal::Maybe((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 9
-    //    Reduce Expression1 = "(", Expression2, ")" => ActionFn(25);
-    pub fn __custom9<
+    // State 32
+    //     AllInputs = ["(", Expression2, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expression2, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Expression1)
+    //
+    //     Expression1 = "(" Expression2 ")" (*) [")"]
+    //     Expression1 = "(" Expression2 ")" (*) ["*"]
+    //
+    //   ")" -> Expression1 = "(", Expression2, ")" => ActionFn(25);
+    //   "*" -> Expression1 = "(", Expression2, ")" => ActionFn(25);
+    //
+    pub fn __state32<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -1525,16 +2150,27 @@ mod __parse__Expression2 {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action25(input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Expression1((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action25(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Expression1((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Expression2::parse_Expression2;

--- a/lalrpop-test/src/loc_issue_90.rs
+++ b/lalrpop-test/src/loc_issue_90.rs
@@ -54,22 +54,22 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expression1 = (*) Wacky [EOF]
     //     Expression1 = (*) Wacky ["*"]
-    //     Expression1 = (*) "&" Maybe Expression1 [EOF]
+    //     Expression1 = (*) Wacky [EOF]
     //     Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //     Expression1 = (*) "(" Expression2 ")" [EOF]
+    //     Expression1 = (*) "&" Maybe Expression1 [EOF]
     //     Expression1 = (*) "(" Expression2 ")" ["*"]
-    //     Expression1 = (*) "wonky" Wonky [EOF]
+    //     Expression1 = (*) "(" Expression2 ")" [EOF]
     //     Expression1 = (*) "wonky" Wonky ["*"]
-    //     Expression1 = (*) r#"\\w+"# [EOF]
+    //     Expression1 = (*) "wonky" Wonky [EOF]
     //     Expression1 = (*) r#"\\w+"# ["*"]
-    //     Expression2 = (*) Expression1 [EOF]
+    //     Expression1 = (*) r#"\\w+"# [EOF]
     //     Expression2 = (*) Expression1 ["*"]
-    //     Expression2 = (*) Expression2 Expression2Op Expression1 [EOF]
+    //     Expression2 = (*) Expression1 [EOF]
     //     Expression2 = (*) Expression2 Expression2Op Expression1 ["*"]
-    //     Wacky = (*) "wacky" [EOF]
+    //     Expression2 = (*) Expression2 Expression2Op Expression1 [EOF]
     //     Wacky = (*) "wacky" ["*"]
+    //     Wacky = (*) "wacky" [EOF]
     //     __Expression2 = (*) Expression2 [EOF]
     //
     //   "&" -> S4
@@ -146,11 +146,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression2)
     //
-    //     Expression2 = Expression1 (*) [EOF]
-    //     Expression2 = Expression1 (*) ["*"]
+    //     Expression2 = Expression1 (*) ["*", EOF]
     //
-    //   EOF -> Expression2 = Expression1 => ActionFn(29);
-    //   "*" -> Expression2 = Expression1 => ActionFn(29);
+    //   ["*", EOF] -> Expression2 = Expression1 => ActionFn(29);
     //
     pub fn __state1<
         'input,
@@ -164,8 +162,8 @@ mod __parse__Expression2 {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
+            Some((_, (3, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action29(input, __sym0);
@@ -194,17 +192,12 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expression2 = Expression2 (*) Expression2Op Expression1 [EOF]
-    //     Expression2 = Expression2 (*) Expression2Op Expression1 ["*"]
-    //     Expression2Op = (*) "*" ["&"]
-    //     Expression2Op = (*) "*" ["("]
-    //     Expression2Op = (*) "*" ["wacky"]
-    //     Expression2Op = (*) "*" ["wonky"]
-    //     Expression2Op = (*) "*" [r#"\\w+"#]
+    //     Expression2 = Expression2 (*) Expression2Op Expression1 ["*", EOF]
+    //     Expression2Op = (*) "*" ["&", "(", "wacky", "wonky", r#"\\w+"#]
     //     __Expression2 = Expression2 (*) [EOF]
     //
     //   "*" -> S10
-    //   EOF -> __Expression2 = Expression2 => ActionFn(0);
+    //   [EOF] -> __Expression2 = Expression2 => ActionFn(0);
     //
     //     Expression2Op -> S9
     pub fn __state2<
@@ -264,11 +257,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = Wacky (*) [EOF]
-    //     Expression1 = Wacky (*) ["*"]
+    //     Expression1 = Wacky (*) ["*", EOF]
     //
-    //   EOF -> Expression1 = Wacky => ActionFn(8);
-    //   "*" -> Expression1 = Wacky => ActionFn(8);
+    //   ["*", EOF] -> Expression1 = Wacky => ActionFn(8);
     //
     pub fn __state3<
         'input,
@@ -282,8 +273,8 @@ mod __parse__Expression2 {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
+            Some((_, (3, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action8(input, __sym0);
@@ -312,25 +303,12 @@ mod __parse__Expression2 {
     //     WillPush = [Maybe, Expression1]
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = "&" (*) Maybe Expression1 [EOF]
-    //     Expression1 = "&" (*) Maybe Expression1 ["*"]
-    //     Maybe = (*) ["&"]
-    //     Maybe = (*) ["("]
-    //     Maybe = (*) ["wacky"]
-    //     Maybe = (*) ["wonky"]
-    //     Maybe = (*) [r#"\\w+"#]
-    //     Maybe = (*) "[" "]" ["&"]
-    //     Maybe = (*) "[" "]" ["("]
-    //     Maybe = (*) "[" "]" ["wacky"]
-    //     Maybe = (*) "[" "]" ["wonky"]
-    //     Maybe = (*) "[" "]" [r#"\\w+"#]
+    //     Expression1 = "&" (*) Maybe Expression1 ["*", EOF]
+    //     Maybe = (*) ["&", "(", "wacky", "wonky", r#"\\w+"#]
+    //     Maybe = (*) "[" "]" ["&", "(", "wacky", "wonky", r#"\\w+"#]
     //
     //   "[" -> S12
-    //   "&" -> Maybe =  => ActionFn(31);
-    //   "(" -> Maybe =  => ActionFn(31);
-    //   "wacky" -> Maybe =  => ActionFn(31);
-    //   "wonky" -> Maybe =  => ActionFn(31);
-    //   r#"\\w+"# -> Maybe =  => ActionFn(31);
+    //   ["&", "(", "wacky", "wonky", r#"\\w+"#] -> Maybe =  => ActionFn(31);
     //
     //     Maybe -> S11
     pub fn __state4<
@@ -403,8 +381,7 @@ mod __parse__Expression2 {
     //     Expression1 = (*) "&" Maybe Expression1 ["*"]
     //     Expression1 = (*) "(" Expression2 ")" [")"]
     //     Expression1 = (*) "(" Expression2 ")" ["*"]
-    //     Expression1 = "(" (*) Expression2 ")" [EOF]
-    //     Expression1 = "(" (*) Expression2 ")" ["*"]
+    //     Expression1 = "(" (*) Expression2 ")" ["*", EOF]
     //     Expression1 = (*) "wonky" Wonky [")"]
     //     Expression1 = (*) "wonky" Wonky ["*"]
     //     Expression1 = (*) r#"\\w+"# [")"]
@@ -499,11 +476,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Wacky)
     //
-    //     Wacky = "wacky" (*) [EOF]
-    //     Wacky = "wacky" (*) ["*"]
+    //     Wacky = "wacky" (*) ["*", EOF]
     //
-    //   EOF -> Wacky = "wacky" => ActionFn(33);
-    //   "*" -> Wacky = "wacky" => ActionFn(33);
+    //   ["*", EOF] -> Wacky = "wacky" => ActionFn(33);
     //
     pub fn __state6<
         'input,
@@ -521,8 +496,8 @@ mod __parse__Expression2 {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
+            Some((_, (3, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action33(input, __sym0);
@@ -551,13 +526,10 @@ mod __parse__Expression2 {
     //     WillPush = [Wonky]
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = "wonky" (*) Wonky [EOF]
-    //     Expression1 = "wonky" (*) Wonky ["*"]
-    //     Wonky = (*) [EOF]
-    //     Wonky = (*) ["*"]
+    //     Expression1 = "wonky" (*) Wonky ["*", EOF]
+    //     Wonky = (*) ["*", EOF]
     //
-    //   EOF -> Wonky =  => ActionFn(34);
-    //   "*" -> Wonky =  => ActionFn(34);
+    //   ["*", EOF] -> Wonky =  => ActionFn(34);
     //
     //     Wonky -> S21
     pub fn __state7<
@@ -576,8 +548,8 @@ mod __parse__Expression2 {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
+            Some((_, (3, _), _)) |
+            None => {
                 let __start = __sym0.2.clone();
                 let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
                 let __nt = super::__action34(input, &__start, &__end);
@@ -617,11 +589,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = r#"\\w+"# (*) [EOF]
-    //     Expression1 = r#"\\w+"# (*) ["*"]
+    //     Expression1 = r#"\\w+"# (*) ["*", EOF]
     //
-    //   EOF -> Expression1 = r#"\\w+"# => ActionFn(26);
-    //   "*" -> Expression1 = r#"\\w+"# => ActionFn(26);
+    //   ["*", EOF] -> Expression1 = r#"\\w+"# => ActionFn(26);
     //
     pub fn __state8<
         'input,
@@ -639,8 +609,8 @@ mod __parse__Expression2 {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
+            Some((_, (3, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action26(input, __sym0);
@@ -669,20 +639,13 @@ mod __parse__Expression2 {
     //     WillPush = [Expression1]
     //     WillProduce = Some(Expression2)
     //
-    //     Expression1 = (*) Wacky [EOF]
-    //     Expression1 = (*) Wacky ["*"]
-    //     Expression1 = (*) "&" Maybe Expression1 [EOF]
-    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //     Expression1 = (*) "(" Expression2 ")" [EOF]
-    //     Expression1 = (*) "(" Expression2 ")" ["*"]
-    //     Expression1 = (*) "wonky" Wonky [EOF]
-    //     Expression1 = (*) "wonky" Wonky ["*"]
-    //     Expression1 = (*) r#"\\w+"# [EOF]
-    //     Expression1 = (*) r#"\\w+"# ["*"]
-    //     Expression2 = Expression2 Expression2Op (*) Expression1 [EOF]
-    //     Expression2 = Expression2 Expression2Op (*) Expression1 ["*"]
-    //     Wacky = (*) "wacky" [EOF]
-    //     Wacky = (*) "wacky" ["*"]
+    //     Expression1 = (*) Wacky ["*", EOF]
+    //     Expression1 = (*) "&" Maybe Expression1 ["*", EOF]
+    //     Expression1 = (*) "(" Expression2 ")" ["*", EOF]
+    //     Expression1 = (*) "wonky" Wonky ["*", EOF]
+    //     Expression1 = (*) r#"\\w+"# ["*", EOF]
+    //     Expression2 = Expression2 Expression2Op (*) Expression1 ["*", EOF]
+    //     Wacky = (*) "wacky" ["*", EOF]
     //
     //   "&" -> S4
     //   "(" -> S5
@@ -757,17 +720,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression2Op)
     //
-    //     Expression2Op = "*" (*) ["&"]
-    //     Expression2Op = "*" (*) ["("]
-    //     Expression2Op = "*" (*) ["wacky"]
-    //     Expression2Op = "*" (*) ["wonky"]
-    //     Expression2Op = "*" (*) [r#"\\w+"#]
+    //     Expression2Op = "*" (*) ["&", "(", "wacky", "wonky", r#"\\w+"#]
     //
-    //   "&" -> Expression2Op = "*" => ActionFn(30);
-    //   "(" -> Expression2Op = "*" => ActionFn(30);
-    //   "wacky" -> Expression2Op = "*" => ActionFn(30);
-    //   "wonky" -> Expression2Op = "*" => ActionFn(30);
-    //   r#"\\w+"# -> Expression2Op = "*" => ActionFn(30);
+    //   ["&", "(", "wacky", "wonky", r#"\\w+"#] -> Expression2Op = "*" => ActionFn(30);
     //
     pub fn __state10<
         'input,
@@ -818,20 +773,13 @@ mod __parse__Expression2 {
     //     WillPush = [Expression1]
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = (*) Wacky [EOF]
-    //     Expression1 = (*) Wacky ["*"]
-    //     Expression1 = (*) "&" Maybe Expression1 [EOF]
-    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //     Expression1 = "&" Maybe (*) Expression1 [EOF]
-    //     Expression1 = "&" Maybe (*) Expression1 ["*"]
-    //     Expression1 = (*) "(" Expression2 ")" [EOF]
-    //     Expression1 = (*) "(" Expression2 ")" ["*"]
-    //     Expression1 = (*) "wonky" Wonky [EOF]
-    //     Expression1 = (*) "wonky" Wonky ["*"]
-    //     Expression1 = (*) r#"\\w+"# [EOF]
-    //     Expression1 = (*) r#"\\w+"# ["*"]
-    //     Wacky = (*) "wacky" [EOF]
-    //     Wacky = (*) "wacky" ["*"]
+    //     Expression1 = (*) Wacky ["*", EOF]
+    //     Expression1 = (*) "&" Maybe Expression1 ["*", EOF]
+    //     Expression1 = "&" Maybe (*) Expression1 ["*", EOF]
+    //     Expression1 = (*) "(" Expression2 ")" ["*", EOF]
+    //     Expression1 = (*) "wonky" Wonky ["*", EOF]
+    //     Expression1 = (*) r#"\\w+"# ["*", EOF]
+    //     Wacky = (*) "wacky" ["*", EOF]
     //
     //   "&" -> S4
     //   "(" -> S5
@@ -906,11 +854,7 @@ mod __parse__Expression2 {
     //     WillPush = ["]"]
     //     WillProduce = Some(Maybe)
     //
-    //     Maybe = "[" (*) "]" ["&"]
-    //     Maybe = "[" (*) "]" ["("]
-    //     Maybe = "[" (*) "]" ["wacky"]
-    //     Maybe = "[" (*) "]" ["wonky"]
-    //     Maybe = "[" (*) "]" [r#"\\w+"#]
+    //     Maybe = "[" (*) "]" ["&", "(", "wacky", "wonky", r#"\\w+"#]
     //
     //   "]" -> S24
     //
@@ -952,11 +896,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression2)
     //
-    //     Expression2 = Expression1 (*) [")"]
-    //     Expression2 = Expression1 (*) ["*"]
+    //     Expression2 = Expression1 (*) [")", "*"]
     //
-    //   ")" -> Expression2 = Expression1 => ActionFn(29);
-    //   "*" -> Expression2 = Expression1 => ActionFn(29);
+    //   [")", "*"] -> Expression2 = Expression1 => ActionFn(29);
     //
     pub fn __state13<
         'input,
@@ -1000,15 +942,9 @@ mod __parse__Expression2 {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expression1 = "(" Expression2 (*) ")" [EOF]
-    //     Expression1 = "(" Expression2 (*) ")" ["*"]
-    //     Expression2 = Expression2 (*) Expression2Op Expression1 [")"]
-    //     Expression2 = Expression2 (*) Expression2Op Expression1 ["*"]
-    //     Expression2Op = (*) "*" ["&"]
-    //     Expression2Op = (*) "*" ["("]
-    //     Expression2Op = (*) "*" ["wacky"]
-    //     Expression2Op = (*) "*" ["wonky"]
-    //     Expression2Op = (*) "*" [r#"\\w+"#]
+    //     Expression1 = "(" Expression2 (*) ")" ["*", EOF]
+    //     Expression2 = Expression2 (*) Expression2Op Expression1 [")", "*"]
+    //     Expression2Op = (*) "*" ["&", "(", "wacky", "wonky", r#"\\w+"#]
     //
     //   ")" -> S26
     //   "*" -> S10
@@ -1066,11 +1002,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = Wacky (*) [")"]
-    //     Expression1 = Wacky (*) ["*"]
+    //     Expression1 = Wacky (*) [")", "*"]
     //
-    //   ")" -> Expression1 = Wacky => ActionFn(8);
-    //   "*" -> Expression1 = Wacky => ActionFn(8);
+    //   [")", "*"] -> Expression1 = Wacky => ActionFn(8);
     //
     pub fn __state15<
         'input,
@@ -1114,25 +1048,12 @@ mod __parse__Expression2 {
     //     WillPush = [Maybe, Expression1]
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = "&" (*) Maybe Expression1 [")"]
-    //     Expression1 = "&" (*) Maybe Expression1 ["*"]
-    //     Maybe = (*) ["&"]
-    //     Maybe = (*) ["("]
-    //     Maybe = (*) ["wacky"]
-    //     Maybe = (*) ["wonky"]
-    //     Maybe = (*) [r#"\\w+"#]
-    //     Maybe = (*) "[" "]" ["&"]
-    //     Maybe = (*) "[" "]" ["("]
-    //     Maybe = (*) "[" "]" ["wacky"]
-    //     Maybe = (*) "[" "]" ["wonky"]
-    //     Maybe = (*) "[" "]" [r#"\\w+"#]
+    //     Expression1 = "&" (*) Maybe Expression1 [")", "*"]
+    //     Maybe = (*) ["&", "(", "wacky", "wonky", r#"\\w+"#]
+    //     Maybe = (*) "[" "]" ["&", "(", "wacky", "wonky", r#"\\w+"#]
     //
     //   "[" -> S12
-    //   "&" -> Maybe =  => ActionFn(31);
-    //   "(" -> Maybe =  => ActionFn(31);
-    //   "wacky" -> Maybe =  => ActionFn(31);
-    //   "wonky" -> Maybe =  => ActionFn(31);
-    //   r#"\\w+"# -> Maybe =  => ActionFn(31);
+    //   ["&", "(", "wacky", "wonky", r#"\\w+"#] -> Maybe =  => ActionFn(31);
     //
     //     Maybe -> S27
     pub fn __state16<
@@ -1205,8 +1126,7 @@ mod __parse__Expression2 {
     //     Expression1 = (*) "&" Maybe Expression1 ["*"]
     //     Expression1 = (*) "(" Expression2 ")" [")"]
     //     Expression1 = (*) "(" Expression2 ")" ["*"]
-    //     Expression1 = "(" (*) Expression2 ")" [")"]
-    //     Expression1 = "(" (*) Expression2 ")" ["*"]
+    //     Expression1 = "(" (*) Expression2 ")" [")", "*"]
     //     Expression1 = (*) "wonky" Wonky [")"]
     //     Expression1 = (*) "wonky" Wonky ["*"]
     //     Expression1 = (*) r#"\\w+"# [")"]
@@ -1301,11 +1221,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Wacky)
     //
-    //     Wacky = "wacky" (*) [")"]
-    //     Wacky = "wacky" (*) ["*"]
+    //     Wacky = "wacky" (*) [")", "*"]
     //
-    //   ")" -> Wacky = "wacky" => ActionFn(33);
-    //   "*" -> Wacky = "wacky" => ActionFn(33);
+    //   [")", "*"] -> Wacky = "wacky" => ActionFn(33);
     //
     pub fn __state18<
         'input,
@@ -1353,13 +1271,10 @@ mod __parse__Expression2 {
     //     WillPush = [Wonky]
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = "wonky" (*) Wonky [")"]
-    //     Expression1 = "wonky" (*) Wonky ["*"]
-    //     Wonky = (*) [")"]
-    //     Wonky = (*) ["*"]
+    //     Expression1 = "wonky" (*) Wonky [")", "*"]
+    //     Wonky = (*) [")", "*"]
     //
-    //   ")" -> Wonky =  => ActionFn(34);
-    //   "*" -> Wonky =  => ActionFn(34);
+    //   [")", "*"] -> Wonky =  => ActionFn(34);
     //
     //     Wonky -> S29
     pub fn __state19<
@@ -1419,11 +1334,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = r#"\\w+"# (*) [")"]
-    //     Expression1 = r#"\\w+"# (*) ["*"]
+    //     Expression1 = r#"\\w+"# (*) [")", "*"]
     //
-    //   ")" -> Expression1 = r#"\\w+"# => ActionFn(26);
-    //   "*" -> Expression1 = r#"\\w+"# => ActionFn(26);
+    //   [")", "*"] -> Expression1 = r#"\\w+"# => ActionFn(26);
     //
     pub fn __state20<
         'input,
@@ -1471,11 +1384,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = "wonky" Wonky (*) [EOF]
-    //     Expression1 = "wonky" Wonky (*) ["*"]
+    //     Expression1 = "wonky" Wonky (*) ["*", EOF]
     //
-    //   EOF -> Expression1 = "wonky", Wonky => ActionFn(7);
-    //   "*" -> Expression1 = "wonky", Wonky => ActionFn(7);
+    //   ["*", EOF] -> Expression1 = "wonky", Wonky => ActionFn(7);
     //
     pub fn __state21<
         'input,
@@ -1490,8 +1401,8 @@ mod __parse__Expression2 {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
+            Some((_, (3, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym1.2.clone();
                 let __nt = super::__action7(input, __sym0, __sym1);
@@ -1520,11 +1431,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression2)
     //
-    //     Expression2 = Expression2 Expression2Op Expression1 (*) [EOF]
-    //     Expression2 = Expression2 Expression2Op Expression1 (*) ["*"]
+    //     Expression2 = Expression2 Expression2Op Expression1 (*) ["*", EOF]
     //
-    //   EOF -> Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
-    //   "*" -> Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
+    //   ["*", EOF] -> Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
     //
     pub fn __state22<
         'input,
@@ -1540,8 +1449,8 @@ mod __parse__Expression2 {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
+            Some((_, (3, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action28(input, __sym0, __sym1, __sym2);
@@ -1570,11 +1479,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = "&" Maybe Expression1 (*) [EOF]
-    //     Expression1 = "&" Maybe Expression1 (*) ["*"]
+    //     Expression1 = "&" Maybe Expression1 (*) ["*", EOF]
     //
-    //   EOF -> Expression1 = "&", Maybe, Expression1 => ActionFn(27);
-    //   "*" -> Expression1 = "&", Maybe, Expression1 => ActionFn(27);
+    //   ["*", EOF] -> Expression1 = "&", Maybe, Expression1 => ActionFn(27);
     //
     pub fn __state23<
         'input,
@@ -1590,8 +1497,8 @@ mod __parse__Expression2 {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
         match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
+            Some((_, (3, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action27(input, __sym0, __sym1, __sym2);
@@ -1620,17 +1527,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Maybe)
     //
-    //     Maybe = "[" "]" (*) ["&"]
-    //     Maybe = "[" "]" (*) ["("]
-    //     Maybe = "[" "]" (*) ["wacky"]
-    //     Maybe = "[" "]" (*) ["wonky"]
-    //     Maybe = "[" "]" (*) [r#"\\w+"#]
+    //     Maybe = "[" "]" (*) ["&", "(", "wacky", "wonky", r#"\\w+"#]
     //
-    //   "&" -> Maybe = "[", "]" => ActionFn(32);
-    //   "(" -> Maybe = "[", "]" => ActionFn(32);
-    //   "wacky" -> Maybe = "[", "]" => ActionFn(32);
-    //   "wonky" -> Maybe = "[", "]" => ActionFn(32);
-    //   r#"\\w+"# -> Maybe = "[", "]" => ActionFn(32);
+    //   ["&", "(", "wacky", "wonky", r#"\\w+"#] -> Maybe = "[", "]" => ActionFn(32);
     //
     pub fn __state24<
         'input,
@@ -1682,20 +1581,13 @@ mod __parse__Expression2 {
     //     WillPush = [Expression1]
     //     WillProduce = Some(Expression2)
     //
-    //     Expression1 = (*) Wacky [")"]
-    //     Expression1 = (*) Wacky ["*"]
-    //     Expression1 = (*) "&" Maybe Expression1 [")"]
-    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //     Expression1 = (*) "(" Expression2 ")" [")"]
-    //     Expression1 = (*) "(" Expression2 ")" ["*"]
-    //     Expression1 = (*) "wonky" Wonky [")"]
-    //     Expression1 = (*) "wonky" Wonky ["*"]
-    //     Expression1 = (*) r#"\\w+"# [")"]
-    //     Expression1 = (*) r#"\\w+"# ["*"]
-    //     Expression2 = Expression2 Expression2Op (*) Expression1 [")"]
-    //     Expression2 = Expression2 Expression2Op (*) Expression1 ["*"]
-    //     Wacky = (*) "wacky" [")"]
-    //     Wacky = (*) "wacky" ["*"]
+    //     Expression1 = (*) Wacky [")", "*"]
+    //     Expression1 = (*) "&" Maybe Expression1 [")", "*"]
+    //     Expression1 = (*) "(" Expression2 ")" [")", "*"]
+    //     Expression1 = (*) "wonky" Wonky [")", "*"]
+    //     Expression1 = (*) r#"\\w+"# [")", "*"]
+    //     Expression2 = Expression2 Expression2Op (*) Expression1 [")", "*"]
+    //     Wacky = (*) "wacky" [")", "*"]
     //
     //   "&" -> S16
     //   "(" -> S17
@@ -1770,11 +1662,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = "(" Expression2 ")" (*) [EOF]
-    //     Expression1 = "(" Expression2 ")" (*) ["*"]
+    //     Expression1 = "(" Expression2 ")" (*) ["*", EOF]
     //
-    //   EOF -> Expression1 = "(", Expression2, ")" => ActionFn(25);
-    //   "*" -> Expression1 = "(", Expression2, ")" => ActionFn(25);
+    //   ["*", EOF] -> Expression1 = "(", Expression2, ")" => ActionFn(25);
     //
     pub fn __state26<
         'input,
@@ -1794,8 +1684,8 @@ mod __parse__Expression2 {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
-            Some((_, (3, _), _)) => {
+            Some((_, (3, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action25(input, __sym0, __sym1, __sym2);
@@ -1824,20 +1714,13 @@ mod __parse__Expression2 {
     //     WillPush = [Expression1]
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = (*) Wacky [")"]
-    //     Expression1 = (*) Wacky ["*"]
-    //     Expression1 = (*) "&" Maybe Expression1 [")"]
-    //     Expression1 = (*) "&" Maybe Expression1 ["*"]
-    //     Expression1 = "&" Maybe (*) Expression1 [")"]
-    //     Expression1 = "&" Maybe (*) Expression1 ["*"]
-    //     Expression1 = (*) "(" Expression2 ")" [")"]
-    //     Expression1 = (*) "(" Expression2 ")" ["*"]
-    //     Expression1 = (*) "wonky" Wonky [")"]
-    //     Expression1 = (*) "wonky" Wonky ["*"]
-    //     Expression1 = (*) r#"\\w+"# [")"]
-    //     Expression1 = (*) r#"\\w+"# ["*"]
-    //     Wacky = (*) "wacky" [")"]
-    //     Wacky = (*) "wacky" ["*"]
+    //     Expression1 = (*) Wacky [")", "*"]
+    //     Expression1 = (*) "&" Maybe Expression1 [")", "*"]
+    //     Expression1 = "&" Maybe (*) Expression1 [")", "*"]
+    //     Expression1 = (*) "(" Expression2 ")" [")", "*"]
+    //     Expression1 = (*) "wonky" Wonky [")", "*"]
+    //     Expression1 = (*) r#"\\w+"# [")", "*"]
+    //     Wacky = (*) "wacky" [")", "*"]
     //
     //   "&" -> S16
     //   "(" -> S17
@@ -1912,15 +1795,9 @@ mod __parse__Expression2 {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expression1 = "(" Expression2 (*) ")" [")"]
-    //     Expression1 = "(" Expression2 (*) ")" ["*"]
-    //     Expression2 = Expression2 (*) Expression2Op Expression1 [")"]
-    //     Expression2 = Expression2 (*) Expression2Op Expression1 ["*"]
-    //     Expression2Op = (*) "*" ["&"]
-    //     Expression2Op = (*) "*" ["("]
-    //     Expression2Op = (*) "*" ["wacky"]
-    //     Expression2Op = (*) "*" ["wonky"]
-    //     Expression2Op = (*) "*" [r#"\\w+"#]
+    //     Expression1 = "(" Expression2 (*) ")" [")", "*"]
+    //     Expression2 = Expression2 (*) Expression2Op Expression1 [")", "*"]
+    //     Expression2Op = (*) "*" ["&", "(", "wacky", "wonky", r#"\\w+"#]
     //
     //   ")" -> S32
     //   "*" -> S10
@@ -1978,11 +1855,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = "wonky" Wonky (*) [")"]
-    //     Expression1 = "wonky" Wonky (*) ["*"]
+    //     Expression1 = "wonky" Wonky (*) [")", "*"]
     //
-    //   ")" -> Expression1 = "wonky", Wonky => ActionFn(7);
-    //   "*" -> Expression1 = "wonky", Wonky => ActionFn(7);
+    //   [")", "*"] -> Expression1 = "wonky", Wonky => ActionFn(7);
     //
     pub fn __state29<
         'input,
@@ -2027,11 +1902,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression2)
     //
-    //     Expression2 = Expression2 Expression2Op Expression1 (*) [")"]
-    //     Expression2 = Expression2 Expression2Op Expression1 (*) ["*"]
+    //     Expression2 = Expression2 Expression2Op Expression1 (*) [")", "*"]
     //
-    //   ")" -> Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
-    //   "*" -> Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
+    //   [")", "*"] -> Expression2 = Expression2, Expression2Op, Expression1 => ActionFn(28);
     //
     pub fn __state30<
         'input,
@@ -2077,11 +1950,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = "&" Maybe Expression1 (*) [")"]
-    //     Expression1 = "&" Maybe Expression1 (*) ["*"]
+    //     Expression1 = "&" Maybe Expression1 (*) [")", "*"]
     //
-    //   ")" -> Expression1 = "&", Maybe, Expression1 => ActionFn(27);
-    //   "*" -> Expression1 = "&", Maybe, Expression1 => ActionFn(27);
+    //   [")", "*"] -> Expression1 = "&", Maybe, Expression1 => ActionFn(27);
     //
     pub fn __state31<
         'input,
@@ -2127,11 +1998,9 @@ mod __parse__Expression2 {
     //     WillPush = []
     //     WillProduce = Some(Expression1)
     //
-    //     Expression1 = "(" Expression2 ")" (*) [")"]
-    //     Expression1 = "(" Expression2 ")" (*) ["*"]
+    //     Expression1 = "(" Expression2 ")" (*) [")", "*"]
     //
-    //   ")" -> Expression1 = "(", Expression2, ")" => ActionFn(25);
-    //   "*" -> Expression1 = "(", Expression2, ")" => ActionFn(25);
+    //   [")", "*"] -> Expression1 = "(", Expression2, ")" => ActionFn(25);
     //
     pub fn __state32<
         'input,

--- a/lalrpop-test/src/sub.rs
+++ b/lalrpop-test/src/sub.rs
@@ -44,7 +44,6 @@ mod __parse__S {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -63,8 +62,8 @@ mod __parse__S {
     //     T = (*) Num ["-"]
     //     __S = (*) S [EOF]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     E -> S1
     //     S -> S2
@@ -84,7 +83,7 @@ mod __parse__S {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(__tokens, __sym0));
+                __result = try!(__state5(__tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -100,10 +99,10 @@ mod __parse__S {
                     __result = try!(__state1(__tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::S(__sym0) => {
-                    __result = try!(__custom0(__tokens, __lookahead, __sym0));
+                    __result = try!(__state2(__tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::T(__sym0) => {
-                    __result = try!(__custom1(__tokens, __lookahead, __sym0));
+                    __result = try!(__state3(__tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -113,7 +112,6 @@ mod __parse__S {
     }
 
     // State 1
-    //     Kind = None
     //     AllInputs = [E]
     //     OptionalInputs = []
     //     FixedInputs = [E]
@@ -125,8 +123,8 @@ mod __parse__S {
     //     E = E (*) "-" T ["-"]
     //     S = E (*) [EOF]
     //
-    //     EOF -> Reduce(S = E => ActionFn(1);)
-    //     "-" -> Shift(S6)
+    //   "-" -> S6
+    //   EOF -> S = E => ActionFn(1);
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -164,8 +162,96 @@ mod __parse__S {
         }
     }
 
+    // State 2
+    //     AllInputs = [S]
+    //     OptionalInputs = []
+    //     FixedInputs = [S]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(__S)
+    //
+    //     __S = S (*) [EOF]
+    //
+    //   EOF -> __S = S => ActionFn(0);
+    //
+    pub fn __state2<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        match __lookahead {
+            None => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action0(__sym0);
+                let __nt = __Nonterminal::____S((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 3
+    //     AllInputs = [T]
+    //     OptionalInputs = []
+    //     FixedInputs = [T]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(E)
+    //
+    //     E = T (*) [EOF]
+    //     E = T (*) ["-"]
+    //
+    //   EOF -> E = T => ActionFn(3);
+    //   "-" -> E = T => ActionFn(3);
+    //
+    pub fn __state3<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action3(__sym0);
+                let __nt = __Nonterminal::E((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 4
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -184,8 +270,8 @@ mod __parse__S {
     //     T = (*) Num [")"]
     //     T = (*) Num ["-"]
     //
-    //     "(" -> Shift(S9)
-    //     Num -> Shift(S10)
+    //   "(" -> S9
+    //   Num -> S10
     //
     //     E -> S7
     //     T -> S8
@@ -210,7 +296,7 @@ mod __parse__S {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(__tokens, __sym1));
+                __result = try!(__state10(__tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -229,7 +315,7 @@ mod __parse__S {
                     __result = try!(__state7(__tokens, __lookahead, __sym0, __sym1));
                 }
                 __Nonterminal::T(__sym1) => {
-                    __result = try!(__custom1(__tokens, __lookahead, __sym1));
+                    __result = try!(__state8(__tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -238,8 +324,57 @@ mod __parse__S {
         }
     }
 
+    // State 5
+    //     AllInputs = [Num]
+    //     OptionalInputs = []
+    //     FixedInputs = [Num]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(T)
+    //
+    //     T = Num (*) [EOF]
+    //     T = Num (*) ["-"]
+    //
+    //   EOF -> T = Num => ActionFn(4);
+    //   "-" -> T = Num => ActionFn(4);
+    //
+    pub fn __state5<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            None |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action4(__sym0);
+                let __nt = __Nonterminal::T((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 6
-    //     Kind = None
     //     AllInputs = [E, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [E, "-"]
@@ -254,8 +389,8 @@ mod __parse__S {
     //     T = (*) Num [EOF]
     //     T = (*) Num ["-"]
     //
-    //     "(" -> Shift(S4)
-    //     Num -> Shift(S5)
+    //   "(" -> S4
+    //   Num -> S5
     //
     //     T -> S11
     pub fn __state6<
@@ -279,7 +414,7 @@ mod __parse__S {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(__tokens, __sym2));
+                __result = try!(__state5(__tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -292,7 +427,7 @@ mod __parse__S {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::T(__sym2) => {
-                    __result = try!(__custom3(__tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state11(__tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -303,7 +438,6 @@ mod __parse__S {
     }
 
     // State 7
-    //     Kind = None
     //     AllInputs = ["(", E]
     //     OptionalInputs = ["("]
     //     FixedInputs = [E]
@@ -316,8 +450,8 @@ mod __parse__S {
     //     T = "(" E (*) ")" [EOF]
     //     T = "(" E (*) ")" ["-"]
     //
-    //     ")" -> Shift(S12)
-    //     "-" -> Shift(S13)
+    //   ")" -> S12
+    //   "-" -> S13
     //
     pub fn __state7<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -333,7 +467,7 @@ mod __parse__S {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(__tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state12(__tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
@@ -350,8 +484,53 @@ mod __parse__S {
         }
     }
 
+    // State 8
+    //     AllInputs = [T]
+    //     OptionalInputs = []
+    //     FixedInputs = [T]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(E)
+    //
+    //     E = T (*) [")"]
+    //     E = T (*) ["-"]
+    //
+    //   ")" -> E = T => ActionFn(3);
+    //   "-" -> E = T => ActionFn(3);
+    //
+    pub fn __state8<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action3(__sym0);
+                let __nt = __Nonterminal::E((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 9
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -370,8 +549,8 @@ mod __parse__S {
     //     T = (*) Num [")"]
     //     T = (*) Num ["-"]
     //
-    //     "(" -> Shift(S9)
-    //     Num -> Shift(S10)
+    //   "(" -> S9
+    //   Num -> S10
     //
     //     E -> S14
     //     T -> S8
@@ -396,7 +575,7 @@ mod __parse__S {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(__tokens, __sym1));
+                __result = try!(__state10(__tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -415,7 +594,7 @@ mod __parse__S {
                     __result = try!(__state14(__tokens, __lookahead, __sym0, __sym1));
                 }
                 __Nonterminal::T(__sym1) => {
-                    __result = try!(__custom1(__tokens, __lookahead, __sym1));
+                    __result = try!(__state8(__tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -424,8 +603,157 @@ mod __parse__S {
         }
     }
 
+    // State 10
+    //     AllInputs = [Num]
+    //     OptionalInputs = []
+    //     FixedInputs = [Num]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(T)
+    //
+    //     T = Num (*) [")"]
+    //     T = Num (*) ["-"]
+    //
+    //   ")" -> T = Num => ActionFn(4);
+    //   "-" -> T = Num => ActionFn(4);
+    //
+    pub fn __state10<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action4(__sym0);
+                let __nt = __Nonterminal::T((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 11
+    //     AllInputs = [E, "-", T]
+    //     OptionalInputs = []
+    //     FixedInputs = [E, "-", T]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(E)
+    //
+    //     E = E "-" T (*) [EOF]
+    //     E = E "-" T (*) ["-"]
+    //
+    //   EOF -> E = E, "-", T => ActionFn(2);
+    //   "-" -> E = E, "-", T => ActionFn(2);
+    //
+    pub fn __state11<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+        __sym1: ((), Tok, ()),
+        __sym2: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action2(__sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::E((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 12
+    //     AllInputs = ["(", E, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", E, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(T)
+    //
+    //     T = "(" E ")" (*) [EOF]
+    //     T = "(" E ")" (*) ["-"]
+    //
+    //   EOF -> T = "(", E, ")" => ActionFn(5);
+    //   "-" -> T = "(", E, ")" => ActionFn(5);
+    //
+    pub fn __state12<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __sym0: ((), Tok, ()),
+        __sym1: ((), i32, ()),
+        __sym2: ((), Tok, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(__ParseError::User { error: e }),
+        };
+        match __lookahead {
+            None |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(__sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::T((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 13
-    //     Kind = None
     //     AllInputs = [E, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [E, "-"]
@@ -440,8 +768,8 @@ mod __parse__S {
     //     T = (*) Num [")"]
     //     T = (*) Num ["-"]
     //
-    //     "(" -> Shift(S9)
-    //     Num -> Shift(S10)
+    //   "(" -> S9
+    //   Num -> S10
     //
     //     T -> S15
     pub fn __state13<
@@ -465,7 +793,7 @@ mod __parse__S {
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom2(__tokens, __sym2));
+                __result = try!(__state10(__tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -478,7 +806,7 @@ mod __parse__S {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::T(__sym2) => {
-                    __result = try!(__custom3(__tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state15(__tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -489,7 +817,6 @@ mod __parse__S {
     }
 
     // State 14
-    //     Kind = None
     //     AllInputs = ["(", E]
     //     OptionalInputs = ["("]
     //     FixedInputs = [E]
@@ -502,8 +829,8 @@ mod __parse__S {
     //     T = "(" E (*) ")" [")"]
     //     T = "(" E (*) ")" ["-"]
     //
-    //     ")" -> Shift(S16)
-    //     "-" -> Shift(S13)
+    //   ")" -> S16
+    //   "-" -> S13
     //
     pub fn __state14<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -519,7 +846,7 @@ mod __parse__S {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(__tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state16(__tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
@@ -536,82 +863,21 @@ mod __parse__S {
         }
     }
 
-    // Custom 0
-    //    Reduce __S = S => ActionFn(0);
-    pub fn __custom0<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: ((), i32, ()),
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action0(__sym0);
-        let __nt = __Nonterminal::____S((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce E = T => ActionFn(3);
-    pub fn __custom1<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: ((), i32, ()),
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action3(__sym0);
-        let __nt = __Nonterminal::E((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 2
-    //    Reduce T = Num => ActionFn(4);
-    pub fn __custom2<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __sym0: ((), i32, ()),
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(__ParseError::User { error: e }),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action4(__sym0);
-        let __nt = __Nonterminal::T((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 3
-    //    Reduce E = E, "-", T => ActionFn(2);
-    pub fn __custom3<
+    // State 15
+    //     AllInputs = [E, "-", T]
+    //     OptionalInputs = []
+    //     FixedInputs = [E, "-", T]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(E)
+    //
+    //     E = E "-" T (*) [")"]
+    //     E = E "-" T (*) ["-"]
+    //
+    //   ")" -> E = E, "-", T => ActionFn(2);
+    //   "-" -> E = E, "-", T => ActionFn(2);
+    //
+    pub fn __state15<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
@@ -622,21 +888,44 @@ mod __parse__S {
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action2(__sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::E((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action2(__sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::E((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 4
-    //    Reduce T = "(", E, ")" => ActionFn(5);
-    pub fn __custom4<
+    // State 16
+    //     AllInputs = ["(", E, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", E, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(T)
+    //
+    //     T = "(" E ")" (*) [")"]
+    //     T = "(" E ")" (*) ["-"]
+    //
+    //   ")" -> T = "(", E, ")" => ActionFn(5);
+    //   "-" -> T = "(", E, ")" => ActionFn(5);
+    //
+    pub fn __state16<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
@@ -651,16 +940,27 @@ mod __parse__S {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action5(__sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::T((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, Tok::RParen, _)) |
+            Some((_, Tok::Minus, _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(__sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::T((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__S::parse_S;

--- a/lalrpop-test/src/sub.rs
+++ b/lalrpop-test/src/sub.rs
@@ -51,15 +51,15 @@ mod __parse__S {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     E = (*) E "-" T [EOF]
     //     E = (*) E "-" T ["-"]
-    //     E = (*) T [EOF]
+    //     E = (*) E "-" T [EOF]
     //     E = (*) T ["-"]
+    //     E = (*) T [EOF]
     //     S = (*) E [EOF]
-    //     T = (*) "(" E ")" [EOF]
     //     T = (*) "(" E ")" ["-"]
-    //     T = (*) Num [EOF]
+    //     T = (*) "(" E ")" [EOF]
     //     T = (*) Num ["-"]
+    //     T = (*) Num [EOF]
     //     __S = (*) S [EOF]
     //
     //   "(" -> S4
@@ -119,12 +119,11 @@ mod __parse__S {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     E = E (*) "-" T [EOF]
-    //     E = E (*) "-" T ["-"]
+    //     E = E (*) "-" T ["-", EOF]
     //     S = E (*) [EOF]
     //
     //   "-" -> S6
-    //   EOF -> S = E => ActionFn(1);
+    //   [EOF] -> S = E => ActionFn(1);
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -172,7 +171,7 @@ mod __parse__S {
     //
     //     __S = S (*) [EOF]
     //
-    //   EOF -> __S = S => ActionFn(0);
+    //   [EOF] -> __S = S => ActionFn(0);
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -213,11 +212,9 @@ mod __parse__S {
     //     WillPush = []
     //     WillProduce = Some(E)
     //
-    //     E = T (*) [EOF]
-    //     E = T (*) ["-"]
+    //     E = T (*) ["-", EOF]
     //
-    //   EOF -> E = T => ActionFn(3);
-    //   "-" -> E = T => ActionFn(3);
+    //   ["-", EOF] -> E = T => ActionFn(3);
     //
     pub fn __state3<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -229,8 +226,8 @@ mod __parse__S {
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
-            None |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(__sym0);
@@ -265,8 +262,7 @@ mod __parse__S {
     //     E = (*) T ["-"]
     //     T = (*) "(" E ")" [")"]
     //     T = (*) "(" E ")" ["-"]
-    //     T = "(" (*) E ")" [EOF]
-    //     T = "(" (*) E ")" ["-"]
+    //     T = "(" (*) E ")" ["-", EOF]
     //     T = (*) Num [")"]
     //     T = (*) Num ["-"]
     //
@@ -332,11 +328,9 @@ mod __parse__S {
     //     WillPush = []
     //     WillProduce = Some(T)
     //
-    //     T = Num (*) [EOF]
-    //     T = Num (*) ["-"]
+    //     T = Num (*) ["-", EOF]
     //
-    //   EOF -> T = Num => ActionFn(4);
-    //   "-" -> T = Num => ActionFn(4);
+    //   ["-", EOF] -> T = Num => ActionFn(4);
     //
     pub fn __state5<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -352,8 +346,8 @@ mod __parse__S {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action4(__sym0);
@@ -382,12 +376,9 @@ mod __parse__S {
     //     WillPush = [T]
     //     WillProduce = Some(E)
     //
-    //     E = E "-" (*) T [EOF]
-    //     E = E "-" (*) T ["-"]
-    //     T = (*) "(" E ")" [EOF]
-    //     T = (*) "(" E ")" ["-"]
-    //     T = (*) Num [EOF]
-    //     T = (*) Num ["-"]
+    //     E = E "-" (*) T ["-", EOF]
+    //     T = (*) "(" E ")" ["-", EOF]
+    //     T = (*) Num ["-", EOF]
     //
     //   "(" -> S4
     //   Num -> S5
@@ -445,10 +436,8 @@ mod __parse__S {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     E = E (*) "-" T [")"]
-    //     E = E (*) "-" T ["-"]
-    //     T = "(" E (*) ")" [EOF]
-    //     T = "(" E (*) ")" ["-"]
+    //     E = E (*) "-" T [")", "-"]
+    //     T = "(" E (*) ")" ["-", EOF]
     //
     //   ")" -> S12
     //   "-" -> S13
@@ -492,11 +481,9 @@ mod __parse__S {
     //     WillPush = []
     //     WillProduce = Some(E)
     //
-    //     E = T (*) [")"]
-    //     E = T (*) ["-"]
+    //     E = T (*) [")", "-"]
     //
-    //   ")" -> E = T => ActionFn(3);
-    //   "-" -> E = T => ActionFn(3);
+    //   [")", "-"] -> E = T => ActionFn(3);
     //
     pub fn __state8<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -544,8 +531,7 @@ mod __parse__S {
     //     E = (*) T ["-"]
     //     T = (*) "(" E ")" [")"]
     //     T = (*) "(" E ")" ["-"]
-    //     T = "(" (*) E ")" [")"]
-    //     T = "(" (*) E ")" ["-"]
+    //     T = "(" (*) E ")" [")", "-"]
     //     T = (*) Num [")"]
     //     T = (*) Num ["-"]
     //
@@ -611,11 +597,9 @@ mod __parse__S {
     //     WillPush = []
     //     WillProduce = Some(T)
     //
-    //     T = Num (*) [")"]
-    //     T = Num (*) ["-"]
+    //     T = Num (*) [")", "-"]
     //
-    //   ")" -> T = Num => ActionFn(4);
-    //   "-" -> T = Num => ActionFn(4);
+    //   [")", "-"] -> T = Num => ActionFn(4);
     //
     pub fn __state10<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -661,11 +645,9 @@ mod __parse__S {
     //     WillPush = []
     //     WillProduce = Some(E)
     //
-    //     E = E "-" T (*) [EOF]
-    //     E = E "-" T (*) ["-"]
+    //     E = E "-" T (*) ["-", EOF]
     //
-    //   EOF -> E = E, "-", T => ActionFn(2);
-    //   "-" -> E = E, "-", T => ActionFn(2);
+    //   ["-", EOF] -> E = E, "-", T => ActionFn(2);
     //
     pub fn __state11<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -679,8 +661,8 @@ mod __parse__S {
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
-            None |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action2(__sym0, __sym1, __sym2);
@@ -709,11 +691,9 @@ mod __parse__S {
     //     WillPush = []
     //     WillProduce = Some(T)
     //
-    //     T = "(" E ")" (*) [EOF]
-    //     T = "(" E ")" (*) ["-"]
+    //     T = "(" E ")" (*) ["-", EOF]
     //
-    //   EOF -> T = "(", E, ")" => ActionFn(5);
-    //   "-" -> T = "(", E, ")" => ActionFn(5);
+    //   ["-", EOF] -> T = "(", E, ")" => ActionFn(5);
     //
     pub fn __state12<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -731,8 +711,8 @@ mod __parse__S {
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
         match __lookahead {
-            None |
-            Some((_, Tok::Minus, _)) => {
+            Some((_, Tok::Minus, _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action5(__sym0, __sym1, __sym2);
@@ -761,12 +741,9 @@ mod __parse__S {
     //     WillPush = [T]
     //     WillProduce = Some(E)
     //
-    //     E = E "-" (*) T [")"]
-    //     E = E "-" (*) T ["-"]
-    //     T = (*) "(" E ")" [")"]
-    //     T = (*) "(" E ")" ["-"]
-    //     T = (*) Num [")"]
-    //     T = (*) Num ["-"]
+    //     E = E "-" (*) T [")", "-"]
+    //     T = (*) "(" E ")" [")", "-"]
+    //     T = (*) Num [")", "-"]
     //
     //   "(" -> S9
     //   Num -> S10
@@ -824,10 +801,8 @@ mod __parse__S {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     E = E (*) "-" T [")"]
-    //     E = E (*) "-" T ["-"]
-    //     T = "(" E (*) ")" [")"]
-    //     T = "(" E (*) ")" ["-"]
+    //     E = E (*) "-" T [")", "-"]
+    //     T = "(" E (*) ")" [")", "-"]
     //
     //   ")" -> S16
     //   "-" -> S13
@@ -871,11 +846,9 @@ mod __parse__S {
     //     WillPush = []
     //     WillProduce = Some(E)
     //
-    //     E = E "-" T (*) [")"]
-    //     E = E "-" T (*) ["-"]
+    //     E = E "-" T (*) [")", "-"]
     //
-    //   ")" -> E = E, "-", T => ActionFn(2);
-    //   "-" -> E = E, "-", T => ActionFn(2);
+    //   [")", "-"] -> E = E, "-", T => ActionFn(2);
     //
     pub fn __state15<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -919,11 +892,9 @@ mod __parse__S {
     //     WillPush = []
     //     WillProduce = Some(T)
     //
-    //     T = "(" E ")" (*) [")"]
-    //     T = "(" E ")" (*) ["-"]
+    //     T = "(" E ")" (*) [")", "-"]
     //
-    //   ")" -> T = "(", E, ")" => ActionFn(5);
-    //   "-" -> T = "(", E, ")" => ActionFn(5);
+    //   [")", "-"] -> T = "(", E, ")" => ActionFn(5);
     //
     pub fn __state16<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,

--- a/lalrpop-test/src/unit.rs
+++ b/lalrpop-test/src/unit.rs
@@ -40,7 +40,6 @@ mod __parse__Expr {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -84,8 +83,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["/"]
     //     __Expr = (*) Expr [EOF]
     //
-    //     "(" -> Shift(S4)
-    //     r#"\\d+"# -> Shift(S5)
+    //   "(" -> S4
+    //   r#"\\d+"# -> S5
     //
     //     Expr -> S1
     //     Factor -> S2
@@ -107,7 +106,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym0));
+                __result = try!(__state5(input, __tokens, __sym0));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -126,7 +125,7 @@ mod __parse__Expr {
                     __result = try!(__state2(input, __tokens, __lookahead, __sym0));
                 }
                 __Nonterminal::Term(__sym0) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym0));
+                    __result = try!(__state3(input, __tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -136,7 +135,6 @@ mod __parse__Expr {
     }
 
     // State 1
-    //     Kind = None
     //     AllInputs = [Expr]
     //     OptionalInputs = []
     //     FixedInputs = [Expr]
@@ -152,9 +150,9 @@ mod __parse__Expr {
     //     Expr = Expr (*) "-" Factor ["-"]
     //     __Expr = Expr (*) [EOF]
     //
-    //     EOF -> Reduce(__Expr = Expr => ActionFn(0);)
-    //     "+" -> Shift(S6)
-    //     "-" -> Shift(S7)
+    //   "+" -> S6
+    //   "-" -> S7
+    //   EOF -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         'input,
@@ -200,7 +198,6 @@ mod __parse__Expr {
     }
 
     // State 2
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -222,11 +219,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         'input,
@@ -273,8 +270,64 @@ mod __parse__Expr {
         }
     }
 
+    // State 3
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [EOF]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   EOF -> Factor = Term => ActionFn(6);
+    //   "*" -> Factor = Term => ActionFn(6);
+    //   "+" -> Factor = Term => ActionFn(6);
+    //   "-" -> Factor = Term => ActionFn(6);
+    //   "/" -> Factor = Term => ActionFn(6);
+    //
+    pub fn __state3<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action6(input, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 4
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -322,8 +375,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"\\d+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"\\d+"# -> S14
     //
     //     Expr -> S10
     //     Factor -> S11
@@ -351,7 +404,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym1));
+                __result = try!(__state14(input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -373,7 +426,7 @@ mod __parse__Expr {
                     __result = try!(__state11(input, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state12(input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -382,8 +435,68 @@ mod __parse__Expr {
         }
     }
 
+    // State 5
+    //     AllInputs = [r#"\\d+"#]
+    //     OptionalInputs = []
+    //     FixedInputs = [r#"\\d+"#]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = r#"\\d+"# (*) [EOF]
+    //     Term = r#"\\d+"# (*) ["*"]
+    //     Term = r#"\\d+"# (*) ["+"]
+    //     Term = r#"\\d+"# (*) ["-"]
+    //     Term = r#"\\d+"# (*) ["/"]
+    //
+    //   EOF -> Term = r#"\\d+"# => ActionFn(7);
+    //   "*" -> Term = r#"\\d+"# => ActionFn(7);
+    //   "+" -> Term = r#"\\d+"# => ActionFn(7);
+    //   "-" -> Term = r#"\\d+"# => ActionFn(7);
+    //   "/" -> Term = r#"\\d+"# => ActionFn(7);
+    //
+    pub fn __state5<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(input, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 6
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -420,8 +533,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     r#"\\d+"# -> Shift(S5)
+    //   "(" -> S4
+    //   r#"\\d+"# -> S5
     //
     //     Factor -> S15
     //     Term -> S3
@@ -450,7 +563,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state5(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -469,7 +582,7 @@ mod __parse__Expr {
                     __result = try!(__state15(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -479,7 +592,6 @@ mod __parse__Expr {
     }
 
     // State 7
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -516,8 +628,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     r#"\\d+"# -> Shift(S5)
+    //   "(" -> S4
+    //   r#"\\d+"# -> S5
     //
     //     Factor -> S16
     //     Term -> S3
@@ -546,7 +658,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state5(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -565,7 +677,7 @@ mod __parse__Expr {
                     __result = try!(__state16(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state3(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -575,7 +687,6 @@ mod __parse__Expr {
     }
 
     // State 8
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -599,8 +710,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     r#"\\d+"# -> Shift(S5)
+    //   "(" -> S4
+    //   r#"\\d+"# -> S5
     //
     //     Term -> S17
     pub fn __state8<
@@ -626,7 +737,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state5(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -639,7 +750,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom2(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state17(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -650,7 +761,6 @@ mod __parse__Expr {
     }
 
     // State 9
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -674,8 +784,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
-    //     "(" -> Shift(S4)
-    //     r#"\\d+"# -> Shift(S5)
+    //   "(" -> S4
+    //   r#"\\d+"# -> S5
     //
     //     Term -> S18
     pub fn __state9<
@@ -701,7 +811,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state5(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -714,7 +824,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state18(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -725,7 +835,6 @@ mod __parse__Expr {
     }
 
     // State 10
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -745,9 +854,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S19)
-    //     "+" -> Shift(S20)
-    //     "-" -> Shift(S21)
+    //   ")" -> S19
+    //   "+" -> S20
+    //   "-" -> S21
     //
     pub fn __state10<
         'input,
@@ -765,7 +874,7 @@ mod __parse__Expr {
             Some((__loc1, (1, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(input, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state19(input, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
@@ -788,7 +897,6 @@ mod __parse__Expr {
     }
 
     // State 11
-    //     Kind = None
     //     AllInputs = [Factor]
     //     OptionalInputs = []
     //     FixedInputs = [Factor]
@@ -810,11 +918,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "*" -> Shift(S22)
-    //     "+" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "-" -> Reduce(Expr = Factor => ActionFn(3);)
-    //     "/" -> Shift(S23)
+    //   "*" -> S22
+    //   "/" -> S23
+    //   ")" -> Expr = Factor => ActionFn(3);
+    //   "+" -> Expr = Factor => ActionFn(3);
+    //   "-" -> Expr = Factor => ActionFn(3);
     //
     pub fn __state11<
         'input,
@@ -861,8 +969,64 @@ mod __parse__Expr {
         }
     }
 
+    // State 12
+    //     AllInputs = [Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Term (*) [")"]
+    //     Factor = Term (*) ["*"]
+    //     Factor = Term (*) ["+"]
+    //     Factor = Term (*) ["-"]
+    //     Factor = Term (*) ["/"]
+    //
+    //   ")" -> Factor = Term => ActionFn(6);
+    //   "*" -> Factor = Term => ActionFn(6);
+    //   "+" -> Factor = Term => ActionFn(6);
+    //   "-" -> Factor = Term => ActionFn(6);
+    //   "/" -> Factor = Term => ActionFn(6);
+    //
+    pub fn __state12<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action6(input, __sym0);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 13
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -910,8 +1074,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"\\d+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"\\d+"# -> S14
     //
     //     Expr -> S24
     //     Factor -> S11
@@ -939,7 +1103,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym1));
+                __result = try!(__state14(input, __tokens, __sym1));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -961,7 +1125,7 @@ mod __parse__Expr {
                     __result = try!(__state11(input, __tokens, __lookahead, __sym1));
                 }
                 __Nonterminal::Term(__sym1) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym1));
+                    __result = try!(__state12(input, __tokens, __lookahead, __sym1));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -970,8 +1134,68 @@ mod __parse__Expr {
         }
     }
 
+    // State 14
+    //     AllInputs = [r#"\\d+"#]
+    //     OptionalInputs = []
+    //     FixedInputs = [r#"\\d+"#]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = r#"\\d+"# (*) [")"]
+    //     Term = r#"\\d+"# (*) ["*"]
+    //     Term = r#"\\d+"# (*) ["+"]
+    //     Term = r#"\\d+"# (*) ["-"]
+    //     Term = r#"\\d+"# (*) ["/"]
+    //
+    //   ")" -> Term = r#"\\d+"# => ActionFn(7);
+    //   "*" -> Term = r#"\\d+"# => ActionFn(7);
+    //   "+" -> Term = r#"\\d+"# => ActionFn(7);
+    //   "-" -> Term = r#"\\d+"# => ActionFn(7);
+    //   "/" -> Term = r#"\\d+"# => ActionFn(7);
+    //
+    pub fn __state14<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action7(input, __sym0);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 15
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -993,11 +1217,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state15<
         'input,
@@ -1049,7 +1273,6 @@ mod __parse__Expr {
     }
 
     // State 16
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -1071,11 +1294,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     EOF -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S8)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S9)
+    //   "*" -> S8
+    //   "/" -> S9
+    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state16<
         'input,
@@ -1126,8 +1349,188 @@ mod __parse__Expr {
         }
     }
 
+    // State 17
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [EOF]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state17<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 18
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [EOF]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state18<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<(usize, (usize, &'input str), usize)>,
+        __sym0: (usize, (), usize),
+        __sym1: (usize, &'input str, usize),
+        __sym2: (usize, (), usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
+    // State 19
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [EOF]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   EOF -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //
+    pub fn __state19<
+        'input,
+        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
+    >(
+        input: &'input str,
+        __tokens: &mut __TOKENS,
+        __sym0: (usize, &'input str, usize),
+        __sym1: (usize, (), usize),
+        __sym2: (usize, &'input str, usize),
+    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
+    {
+        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+        let __lookahead = match __tokens.next() {
+            Some(Ok(v)) => Some(v),
+            None => None,
+            Some(Err(e)) => return Err(e),
+        };
+        match __lookahead {
+            None |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action8(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 20
-    //     Kind = None
     //     AllInputs = [Expr, "+"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "+"]
@@ -1164,8 +1567,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"\\d+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"\\d+"# -> S14
     //
     //     Factor -> S25
     //     Term -> S12
@@ -1194,7 +1597,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state14(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1213,7 +1616,7 @@ mod __parse__Expr {
                     __result = try!(__state25(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state12(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1223,7 +1626,6 @@ mod __parse__Expr {
     }
 
     // State 21
-    //     Kind = None
     //     AllInputs = [Expr, "-"]
     //     OptionalInputs = []
     //     FixedInputs = [Expr, "-"]
@@ -1260,8 +1662,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"\\d+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"\\d+"# -> S14
     //
     //     Factor -> S26
     //     Term -> S12
@@ -1290,7 +1692,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state14(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1309,7 +1711,7 @@ mod __parse__Expr {
                     __result = try!(__state26(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                 }
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom0(input, __tokens, __lookahead, __sym2));
+                    __result = try!(__state12(input, __tokens, __lookahead, __sym2));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -1319,7 +1721,6 @@ mod __parse__Expr {
     }
 
     // State 22
-    //     Kind = None
     //     AllInputs = [Factor, "*"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "*"]
@@ -1343,8 +1744,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"\\d+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"\\d+"# -> S14
     //
     //     Term -> S27
     pub fn __state22<
@@ -1370,7 +1771,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state14(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1383,7 +1784,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom2(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state27(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -1394,7 +1795,6 @@ mod __parse__Expr {
     }
 
     // State 23
-    //     Kind = None
     //     AllInputs = [Factor, "/"]
     //     OptionalInputs = []
     //     FixedInputs = [Factor, "/"]
@@ -1418,8 +1818,8 @@ mod __parse__Expr {
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
-    //     "(" -> Shift(S13)
-    //     r#"\\d+"# -> Shift(S14)
+    //   "(" -> S13
+    //   r#"\\d+"# -> S14
     //
     //     Term -> S28
     pub fn __state23<
@@ -1445,7 +1845,7 @@ mod __parse__Expr {
             }
             Some((__loc1, (6, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__custom1(input, __tokens, __sym2));
+                __result = try!(__state14(input, __tokens, __sym2));
             }
             _ => {
                 return Err(__ParseError::UnrecognizedToken {
@@ -1458,7 +1858,7 @@ mod __parse__Expr {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::Term(__sym2) => {
-                    __result = try!(__custom3(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
                     return Ok(__result);
                 }
                 _ => {
@@ -1469,7 +1869,6 @@ mod __parse__Expr {
     }
 
     // State 24
-    //     Kind = None
     //     AllInputs = ["(", Expr]
     //     OptionalInputs = ["("]
     //     FixedInputs = [Expr]
@@ -1489,9 +1888,9 @@ mod __parse__Expr {
     //     Term = "(" Expr (*) ")" ["-"]
     //     Term = "(" Expr (*) ")" ["/"]
     //
-    //     ")" -> Shift(S29)
-    //     "+" -> Shift(S20)
-    //     "-" -> Shift(S21)
+    //   ")" -> S29
+    //   "+" -> S20
+    //   "-" -> S21
     //
     pub fn __state24<
         'input,
@@ -1509,7 +1908,7 @@ mod __parse__Expr {
             Some((__loc1, (1, __tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__custom4(input, __tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state29(input, __tokens, __sym0, __sym1, __sym2));
                 return Ok(__result);
             }
             Some((__loc1, (3, __tok0), __loc2)) => {
@@ -1532,7 +1931,6 @@ mod __parse__Expr {
     }
 
     // State 25
-    //     Kind = None
     //     AllInputs = [Expr, "+", Factor]
     //     OptionalInputs = [Expr, "+"]
     //     FixedInputs = [Factor]
@@ -1554,11 +1952,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "*" -> Shift(S22)
-    //     "+" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "-" -> Reduce(Expr = Expr, "+", Factor => ActionFn(2);)
-    //     "/" -> Shift(S23)
+    //   "*" -> S22
+    //   "/" -> S23
+    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state25<
         'input,
@@ -1610,7 +2008,6 @@ mod __parse__Expr {
     }
 
     // State 26
-    //     Kind = None
     //     AllInputs = [Expr, "-", Factor]
     //     OptionalInputs = [Expr, "-"]
     //     FixedInputs = [Factor]
@@ -1632,11 +2029,11 @@ mod __parse__Expr {
     //     Factor = Factor (*) "/" Term ["-"]
     //     Factor = Factor (*) "/" Term ["/"]
     //
-    //     ")" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "*" -> Shift(S22)
-    //     "+" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "-" -> Reduce(Expr = Expr, "-", Factor => ActionFn(1);)
-    //     "/" -> Shift(S23)
+    //   "*" -> S22
+    //   "/" -> S23
+    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state26<
         'input,
@@ -1687,63 +2084,27 @@ mod __parse__Expr {
         }
     }
 
-    // Custom 0
-    //    Reduce Factor = Term => ActionFn(6);
-    pub fn __custom0<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<(usize, (usize, &'input str), usize)>,
-        __sym0: (usize, (), usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action6(input, __sym0);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce Term = r#"\\d+"# => ActionFn(7);
-    pub fn __custom1<
-        'input,
-        __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
-    >(
-        input: &'input str,
-        __tokens: &mut __TOKENS,
-        __sym0: (usize, &'input str, usize),
-    ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
-    {
-        let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __lookahead = match __tokens.next() {
-            Some(Ok(v)) => Some(v),
-            None => None,
-            Some(Err(e)) => return Err(e),
-        };
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action7(input, __sym0);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 2
-    //    Reduce Factor = Factor, "*", Term => ActionFn(4);
-    pub fn __custom2<
+    // State 27
+    //     AllInputs = [Factor, "*", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "*", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "*" Term (*) [")"]
+    //     Factor = Factor "*" Term (*) ["*"]
+    //     Factor = Factor "*" Term (*) ["+"]
+    //     Factor = Factor "*" Term (*) ["-"]
+    //     Factor = Factor "*" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //
+    pub fn __state27<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -1756,21 +2117,53 @@ mod __parse__Expr {
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action4(input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action4(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 3
-    //    Reduce Factor = Factor, "/", Term => ActionFn(5);
-    pub fn __custom3<
+    // State 28
+    //     AllInputs = [Factor, "/", Term]
+    //     OptionalInputs = []
+    //     FixedInputs = [Factor, "/", Term]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Factor)
+    //
+    //     Factor = Factor "/" Term (*) [")"]
+    //     Factor = Factor "/" Term (*) ["*"]
+    //     Factor = Factor "/" Term (*) ["+"]
+    //     Factor = Factor "/" Term (*) ["-"]
+    //     Factor = Factor "/" Term (*) ["/"]
+    //
+    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //
+    pub fn __state28<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -1783,21 +2176,53 @@ mod __parse__Expr {
     ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __ParseError<usize,(usize, &'input str),()>>
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action5(input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Factor((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action5(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Factor((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 
-    // Custom 4
-    //    Reduce Term = "(", Expr, ")" => ActionFn(8);
-    pub fn __custom4<
+    // State 29
+    //     AllInputs = ["(", Expr, ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", Expr, ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(Term)
+    //
+    //     Term = "(" Expr ")" (*) [")"]
+    //     Term = "(" Expr ")" (*) ["*"]
+    //     Term = "(" Expr ")" (*) ["+"]
+    //     Term = "(" Expr ")" (*) ["-"]
+    //     Term = "(" Expr ")" (*) ["/"]
+    //
+    //   ")" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //
+    pub fn __state29<
         'input,
         __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__ParseError<usize,(usize, &'input str),()>>>,
     >(
@@ -1814,16 +2239,30 @@ mod __parse__Expr {
             None => None,
             Some(Err(e)) => return Err(e),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym2.2.clone();
-        let __nt = super::__action8(input, __sym0, __sym1, __sym2);
-        let __nt = __Nonterminal::Term((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            Some((_, (1, _), _)) |
+            Some((_, (2, _), _)) |
+            Some((_, (3, _), _)) |
+            Some((_, (4, _), _)) |
+            Some((_, (5, _), _)) => {
+                let __start = __sym0.0.clone();
+                let __end = __sym2.2.clone();
+                let __nt = super::__action8(input, __sym0, __sym1, __sym2);
+                let __nt = __Nonterminal::Term((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__Expr::parse_Expr;

--- a/lalrpop-test/src/unit.rs
+++ b/lalrpop-test/src/unit.rs
@@ -47,40 +47,40 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = (*) Expr "+" Factor [EOF]
     //     Expr = (*) Expr "+" Factor ["+"]
     //     Expr = (*) Expr "+" Factor ["-"]
-    //     Expr = (*) Expr "-" Factor [EOF]
+    //     Expr = (*) Expr "+" Factor [EOF]
     //     Expr = (*) Expr "-" Factor ["+"]
     //     Expr = (*) Expr "-" Factor ["-"]
-    //     Expr = (*) Factor [EOF]
+    //     Expr = (*) Expr "-" Factor [EOF]
     //     Expr = (*) Factor ["+"]
     //     Expr = (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = (*) Factor [EOF]
     //     Factor = (*) Factor "*" Term ["*"]
     //     Factor = (*) Factor "*" Term ["+"]
     //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
+    //     Factor = (*) Factor "*" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
     //     Factor = (*) Factor "/" Term ["+"]
     //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
+    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Term ["*"]
     //     Factor = (*) Term ["+"]
     //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
+    //     Factor = (*) Term [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"\\d+"# [EOF]
+    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) r#"\\d+"# ["*"]
     //     Term = (*) r#"\\d+"# ["+"]
     //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
+    //     Term = (*) r#"\\d+"# [EOF]
     //     __Expr = (*) Expr [EOF]
     //
     //   "(" -> S4
@@ -142,17 +142,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [EOF]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [EOF]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
+    //     Expr = Expr (*) "+" Factor ["+", "-", EOF]
+    //     Expr = Expr (*) "-" Factor ["+", "-", EOF]
     //     __Expr = Expr (*) [EOF]
     //
     //   "+" -> S6
     //   "-" -> S7
-    //   EOF -> __Expr = Expr => ActionFn(0);
+    //   [EOF] -> __Expr = Expr => ActionFn(0);
     //
     pub fn __state1<
         'input,
@@ -205,25 +201,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [EOF]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   ["+", "-", EOF] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state2<
         'input,
@@ -247,9 +231,9 @@ mod __parse__Expr {
                 __result = try!(__state9(input, __tokens, __sym0, __sym1));
                 return Ok(__result);
             }
-            None |
             Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) => {
+            Some((_, (4, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action3(input, __sym0);
@@ -278,17 +262,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [EOF]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Term => ActionFn(6);
-    //   "*" -> Factor = Term => ActionFn(6);
-    //   "+" -> Factor = Term => ActionFn(6);
-    //   "-" -> Factor = Term => ActionFn(6);
-    //   "/" -> Factor = Term => ActionFn(6);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Term => ActionFn(6);
     //
     pub fn __state3<
         'input,
@@ -302,11 +278,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action6(input, __sym0);
@@ -364,11 +340,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [EOF]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" ["*", "+", "-", "/", EOF]
     //     Term = (*) r#"\\d+"# [")"]
     //     Term = (*) r#"\\d+"# ["*"]
     //     Term = (*) r#"\\d+"# ["+"]
@@ -443,17 +415,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = r#"\\d+"# (*) [EOF]
-    //     Term = r#"\\d+"# (*) ["*"]
-    //     Term = r#"\\d+"# (*) ["+"]
-    //     Term = r#"\\d+"# (*) ["-"]
-    //     Term = r#"\\d+"# (*) ["/"]
+    //     Term = r#"\\d+"# (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = r#"\\d+"# => ActionFn(7);
-    //   "*" -> Term = r#"\\d+"# => ActionFn(7);
-    //   "+" -> Term = r#"\\d+"# => ActionFn(7);
-    //   "-" -> Term = r#"\\d+"# => ActionFn(7);
-    //   "/" -> Term = r#"\\d+"# => ActionFn(7);
+    //   ["*", "+", "-", "/", EOF] -> Term = r#"\\d+"# => ActionFn(7);
     //
     pub fn __state5<
         'input,
@@ -471,11 +435,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
                 let __nt = super::__action7(input, __sym0);
@@ -504,33 +468,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [EOF]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = Expr "+" (*) Factor ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["+", "-", EOF]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["+", "-", EOF]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["+", "-", EOF]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"\\d+"# [EOF]
     //     Term = (*) r#"\\d+"# ["*"]
-    //     Term = (*) r#"\\d+"# ["+"]
-    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["+", "-", EOF]
     //     Term = (*) r#"\\d+"# ["/"]
     //
     //   "(" -> S4
@@ -599,33 +551,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [EOF]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [EOF]
+    //     Expr = Expr "-" (*) Factor ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
+    //     Factor = (*) Factor "*" Term ["+", "-", EOF]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [EOF]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
+    //     Factor = (*) Factor "/" Term ["+", "-", EOF]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [EOF]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
+    //     Factor = (*) Term ["+", "-", EOF]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
+    //     Term = (*) "(" Expr ")" ["+", "-", EOF]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"\\d+"# [EOF]
     //     Term = (*) r#"\\d+"# ["*"]
-    //     Term = (*) r#"\\d+"# ["+"]
-    //     Term = (*) r#"\\d+"# ["-"]
+    //     Term = (*) r#"\\d+"# ["+", "-", EOF]
     //     Term = (*) r#"\\d+"# ["/"]
     //
     //   "(" -> S4
@@ -694,21 +634,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [EOF]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"\\d+"# [EOF]
-    //     Term = (*) r#"\\d+"# ["*"]
-    //     Term = (*) r#"\\d+"# ["+"]
-    //     Term = (*) r#"\\d+"# ["-"]
-    //     Term = (*) r#"\\d+"# ["/"]
+    //     Factor = Factor "*" (*) Term ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
+    //     Term = (*) r#"\\d+"# ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   r#"\\d+"# -> S5
@@ -768,21 +696,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [EOF]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [EOF]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"\\d+"# [EOF]
-    //     Term = (*) r#"\\d+"# ["*"]
-    //     Term = (*) r#"\\d+"# ["+"]
-    //     Term = (*) r#"\\d+"# ["-"]
-    //     Term = (*) r#"\\d+"# ["/"]
+    //     Factor = Factor "/" (*) Term ["*", "+", "-", "/", EOF]
+    //     Term = (*) "(" Expr ")" ["*", "+", "-", "/", EOF]
+    //     Term = (*) r#"\\d+"# ["*", "+", "-", "/", EOF]
     //
     //   "(" -> S4
     //   r#"\\d+"# -> S5
@@ -842,17 +758,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [EOF]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" ["*", "+", "-", "/", EOF]
     //
     //   ")" -> S19
     //   "+" -> S20
@@ -904,25 +812,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Factor (*) [")"]
-    //     Expr = Factor (*) ["+"]
-    //     Expr = Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S22
     //   "/" -> S23
-    //   ")" -> Expr = Factor => ActionFn(3);
-    //   "+" -> Expr = Factor => ActionFn(3);
-    //   "-" -> Expr = Factor => ActionFn(3);
+    //   [")", "+", "-"] -> Expr = Factor => ActionFn(3);
     //
     pub fn __state11<
         'input,
@@ -977,17 +873,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Term (*) [")"]
-    //     Factor = Term (*) ["*"]
-    //     Factor = Term (*) ["+"]
-    //     Factor = Term (*) ["-"]
-    //     Factor = Term (*) ["/"]
+    //     Factor = Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Term => ActionFn(6);
-    //   "*" -> Factor = Term => ActionFn(6);
-    //   "+" -> Factor = Term => ActionFn(6);
-    //   "-" -> Factor = Term => ActionFn(6);
-    //   "/" -> Factor = Term => ActionFn(6);
+    //   [")", "*", "+", "-", "/"] -> Factor = Term => ActionFn(6);
     //
     pub fn __state12<
         'input,
@@ -1063,11 +951,7 @@ mod __parse__Expr {
     //     Term = (*) "(" Expr ")" ["+"]
     //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = "(" (*) Expr ")" [")"]
-    //     Term = "(" (*) Expr ")" ["*"]
-    //     Term = "(" (*) Expr ")" ["+"]
-    //     Term = "(" (*) Expr ")" ["-"]
-    //     Term = "(" (*) Expr ")" ["/"]
+    //     Term = "(" (*) Expr ")" [")", "*", "+", "-", "/"]
     //     Term = (*) r#"\\d+"# [")"]
     //     Term = (*) r#"\\d+"# ["*"]
     //     Term = (*) r#"\\d+"# ["+"]
@@ -1142,17 +1026,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = r#"\\d+"# (*) [")"]
-    //     Term = r#"\\d+"# (*) ["*"]
-    //     Term = r#"\\d+"# (*) ["+"]
-    //     Term = r#"\\d+"# (*) ["-"]
-    //     Term = r#"\\d+"# (*) ["/"]
+    //     Term = r#"\\d+"# (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Term = r#"\\d+"# => ActionFn(7);
-    //   "*" -> Term = r#"\\d+"# => ActionFn(7);
-    //   "+" -> Term = r#"\\d+"# => ActionFn(7);
-    //   "-" -> Term = r#"\\d+"# => ActionFn(7);
-    //   "/" -> Term = r#"\\d+"# => ActionFn(7);
+    //   [")", "*", "+", "-", "/"] -> Term = r#"\\d+"# => ActionFn(7);
     //
     pub fn __state14<
         'input,
@@ -1203,25 +1079,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [EOF]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   ["+", "-", EOF] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state15<
         'input,
@@ -1247,9 +1111,9 @@ mod __parse__Expr {
                 __result = try!(__state9(input, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) => {
+            Some((_, (4, _), _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1280,25 +1144,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [EOF]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [EOF]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [EOF]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) ["+", "-", EOF]
+    //     Factor = Factor (*) "*" Term ["*", "+", "-", "/", EOF]
+    //     Factor = Factor (*) "/" Term ["*", "+", "-", "/", EOF]
     //
     //   "*" -> S8
     //   "/" -> S9
-    //   EOF -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   ["+", "-", EOF] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state16<
         'input,
@@ -1324,9 +1176,9 @@ mod __parse__Expr {
                 __result = try!(__state9(input, __tokens, __sym2, __sym3));
                 return Ok(__result);
             }
-            None |
             Some((_, (3, _), _)) |
-            Some((_, (4, _), _)) => {
+            Some((_, (4, _), _)) |
+            None => {
                 let __sym0 = __sym0.take().unwrap();
                 let __sym1 = __sym1.take().unwrap();
                 let __start = __sym0.0.clone();
@@ -1357,17 +1209,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [EOF]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state17<
         'input,
@@ -1383,11 +1227,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action4(input, __sym0, __sym1, __sym2);
@@ -1416,17 +1260,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [EOF]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   ["*", "+", "-", "/", EOF] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state18<
         'input,
@@ -1442,11 +1278,11 @@ mod __parse__Expr {
     {
         let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action5(input, __sym0, __sym1, __sym2);
@@ -1475,17 +1311,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [EOF]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) ["*", "+", "-", "/", EOF]
     //
-    //   EOF -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   ["*", "+", "-", "/", EOF] -> Term = "(", Expr, ")" => ActionFn(8);
     //
     pub fn __state19<
         'input,
@@ -1505,11 +1333,11 @@ mod __parse__Expr {
             Some(Err(e)) => return Err(e),
         };
         match __lookahead {
-            None |
             Some((_, (2, _), _)) |
             Some((_, (3, _), _)) |
             Some((_, (4, _), _)) |
-            Some((_, (5, _), _)) => {
+            Some((_, (5, _), _)) |
+            None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
                 let __nt = super::__action8(input, __sym0, __sym1, __sym2);
@@ -1538,33 +1366,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "+" (*) Factor [")"]
-    //     Expr = Expr "+" (*) Factor ["+"]
-    //     Expr = Expr "+" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "+" (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"\\d+"# [")"]
+    //     Term = (*) r#"\\d+"# [")", "+", "-"]
     //     Term = (*) r#"\\d+"# ["*"]
-    //     Term = (*) r#"\\d+"# ["+"]
-    //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
     //   "(" -> S13
@@ -1633,33 +1449,21 @@ mod __parse__Expr {
     //     WillPush = [Factor]
     //     WillProduce = Some(Expr)
     //
-    //     Expr = Expr "-" (*) Factor [")"]
-    //     Expr = Expr "-" (*) Factor ["+"]
-    //     Expr = Expr "-" (*) Factor ["-"]
-    //     Factor = (*) Factor "*" Term [")"]
+    //     Expr = Expr "-" (*) Factor [")", "+", "-"]
+    //     Factor = (*) Factor "*" Term [")", "+", "-"]
     //     Factor = (*) Factor "*" Term ["*"]
-    //     Factor = (*) Factor "*" Term ["+"]
-    //     Factor = (*) Factor "*" Term ["-"]
     //     Factor = (*) Factor "*" Term ["/"]
-    //     Factor = (*) Factor "/" Term [")"]
+    //     Factor = (*) Factor "/" Term [")", "+", "-"]
     //     Factor = (*) Factor "/" Term ["*"]
-    //     Factor = (*) Factor "/" Term ["+"]
-    //     Factor = (*) Factor "/" Term ["-"]
     //     Factor = (*) Factor "/" Term ["/"]
-    //     Factor = (*) Term [")"]
+    //     Factor = (*) Term [")", "+", "-"]
     //     Factor = (*) Term ["*"]
-    //     Factor = (*) Term ["+"]
-    //     Factor = (*) Term ["-"]
     //     Factor = (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
+    //     Term = (*) "(" Expr ")" [")", "+", "-"]
     //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
     //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"\\d+"# [")"]
+    //     Term = (*) r#"\\d+"# [")", "+", "-"]
     //     Term = (*) r#"\\d+"# ["*"]
-    //     Term = (*) r#"\\d+"# ["+"]
-    //     Term = (*) r#"\\d+"# ["-"]
     //     Term = (*) r#"\\d+"# ["/"]
     //
     //   "(" -> S13
@@ -1728,21 +1532,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" (*) Term [")"]
-    //     Factor = Factor "*" (*) Term ["*"]
-    //     Factor = Factor "*" (*) Term ["+"]
-    //     Factor = Factor "*" (*) Term ["-"]
-    //     Factor = Factor "*" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"\\d+"# [")"]
-    //     Term = (*) r#"\\d+"# ["*"]
-    //     Term = (*) r#"\\d+"# ["+"]
-    //     Term = (*) r#"\\d+"# ["-"]
-    //     Term = (*) r#"\\d+"# ["/"]
+    //     Factor = Factor "*" (*) Term [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
+    //     Term = (*) r#"\\d+"# [")", "*", "+", "-", "/"]
     //
     //   "(" -> S13
     //   r#"\\d+"# -> S14
@@ -1802,21 +1594,9 @@ mod __parse__Expr {
     //     WillPush = [Term]
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" (*) Term [")"]
-    //     Factor = Factor "/" (*) Term ["*"]
-    //     Factor = Factor "/" (*) Term ["+"]
-    //     Factor = Factor "/" (*) Term ["-"]
-    //     Factor = Factor "/" (*) Term ["/"]
-    //     Term = (*) "(" Expr ")" [")"]
-    //     Term = (*) "(" Expr ")" ["*"]
-    //     Term = (*) "(" Expr ")" ["+"]
-    //     Term = (*) "(" Expr ")" ["-"]
-    //     Term = (*) "(" Expr ")" ["/"]
-    //     Term = (*) r#"\\d+"# [")"]
-    //     Term = (*) r#"\\d+"# ["*"]
-    //     Term = (*) r#"\\d+"# ["+"]
-    //     Term = (*) r#"\\d+"# ["-"]
-    //     Term = (*) r#"\\d+"# ["/"]
+    //     Factor = Factor "/" (*) Term [")", "*", "+", "-", "/"]
+    //     Term = (*) "(" Expr ")" [")", "*", "+", "-", "/"]
+    //     Term = (*) r#"\\d+"# [")", "*", "+", "-", "/"]
     //
     //   "(" -> S13
     //   r#"\\d+"# -> S14
@@ -1876,17 +1656,9 @@ mod __parse__Expr {
     //     WillPush = [")"]
     //     WillProduce = None
     //
-    //     Expr = Expr (*) "+" Factor [")"]
-    //     Expr = Expr (*) "+" Factor ["+"]
-    //     Expr = Expr (*) "+" Factor ["-"]
-    //     Expr = Expr (*) "-" Factor [")"]
-    //     Expr = Expr (*) "-" Factor ["+"]
-    //     Expr = Expr (*) "-" Factor ["-"]
-    //     Term = "(" Expr (*) ")" [")"]
-    //     Term = "(" Expr (*) ")" ["*"]
-    //     Term = "(" Expr (*) ")" ["+"]
-    //     Term = "(" Expr (*) ")" ["-"]
-    //     Term = "(" Expr (*) ")" ["/"]
+    //     Expr = Expr (*) "+" Factor [")", "+", "-"]
+    //     Expr = Expr (*) "-" Factor [")", "+", "-"]
+    //     Term = "(" Expr (*) ")" [")", "*", "+", "-", "/"]
     //
     //   ")" -> S29
     //   "+" -> S20
@@ -1938,25 +1710,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "+" Factor (*) [")"]
-    //     Expr = Expr "+" Factor (*) ["+"]
-    //     Expr = Expr "+" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "+" Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S22
     //   "/" -> S23
-    //   ")" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "+" -> Expr = Expr, "+", Factor => ActionFn(2);
-    //   "-" -> Expr = Expr, "+", Factor => ActionFn(2);
+    //   [")", "+", "-"] -> Expr = Expr, "+", Factor => ActionFn(2);
     //
     pub fn __state25<
         'input,
@@ -2015,25 +1775,13 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = None
     //
-    //     Expr = Expr "-" Factor (*) [")"]
-    //     Expr = Expr "-" Factor (*) ["+"]
-    //     Expr = Expr "-" Factor (*) ["-"]
-    //     Factor = Factor (*) "*" Term [")"]
-    //     Factor = Factor (*) "*" Term ["*"]
-    //     Factor = Factor (*) "*" Term ["+"]
-    //     Factor = Factor (*) "*" Term ["-"]
-    //     Factor = Factor (*) "*" Term ["/"]
-    //     Factor = Factor (*) "/" Term [")"]
-    //     Factor = Factor (*) "/" Term ["*"]
-    //     Factor = Factor (*) "/" Term ["+"]
-    //     Factor = Factor (*) "/" Term ["-"]
-    //     Factor = Factor (*) "/" Term ["/"]
+    //     Expr = Expr "-" Factor (*) [")", "+", "-"]
+    //     Factor = Factor (*) "*" Term [")", "*", "+", "-", "/"]
+    //     Factor = Factor (*) "/" Term [")", "*", "+", "-", "/"]
     //
     //   "*" -> S22
     //   "/" -> S23
-    //   ")" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "+" -> Expr = Expr, "-", Factor => ActionFn(1);
-    //   "-" -> Expr = Expr, "-", Factor => ActionFn(1);
+    //   [")", "+", "-"] -> Expr = Expr, "-", Factor => ActionFn(1);
     //
     pub fn __state26<
         'input,
@@ -2092,17 +1840,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "*" Term (*) [")"]
-    //     Factor = Factor "*" Term (*) ["*"]
-    //     Factor = Factor "*" Term (*) ["+"]
-    //     Factor = Factor "*" Term (*) ["-"]
-    //     Factor = Factor "*" Term (*) ["/"]
+    //     Factor = Factor "*" Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "*" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "+" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "-" -> Factor = Factor, "*", Term => ActionFn(4);
-    //   "/" -> Factor = Factor, "*", Term => ActionFn(4);
+    //   [")", "*", "+", "-", "/"] -> Factor = Factor, "*", Term => ActionFn(4);
     //
     pub fn __state27<
         'input,
@@ -2151,17 +1891,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Factor)
     //
-    //     Factor = Factor "/" Term (*) [")"]
-    //     Factor = Factor "/" Term (*) ["*"]
-    //     Factor = Factor "/" Term (*) ["+"]
-    //     Factor = Factor "/" Term (*) ["-"]
-    //     Factor = Factor "/" Term (*) ["/"]
+    //     Factor = Factor "/" Term (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "*" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "+" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "-" -> Factor = Factor, "/", Term => ActionFn(5);
-    //   "/" -> Factor = Factor, "/", Term => ActionFn(5);
+    //   [")", "*", "+", "-", "/"] -> Factor = Factor, "/", Term => ActionFn(5);
     //
     pub fn __state28<
         'input,
@@ -2210,17 +1942,9 @@ mod __parse__Expr {
     //     WillPush = []
     //     WillProduce = Some(Term)
     //
-    //     Term = "(" Expr ")" (*) [")"]
-    //     Term = "(" Expr ")" (*) ["*"]
-    //     Term = "(" Expr ")" (*) ["+"]
-    //     Term = "(" Expr ")" (*) ["-"]
-    //     Term = "(" Expr ")" (*) ["/"]
+    //     Term = "(" Expr ")" (*) [")", "*", "+", "-", "/"]
     //
-    //   ")" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "*" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "+" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "-" -> Term = "(", Expr, ")" => ActionFn(8);
-    //   "/" -> Term = "(", Expr, ")" => ActionFn(8);
+    //   [")", "*", "+", "-", "/"] -> Term = "(", Expr, ")" => ActionFn(8);
     //
     pub fn __state29<
         'input,

--- a/lalrpop-test/src/use_super.rs
+++ b/lalrpop-test/src/use_super.rs
@@ -42,7 +42,6 @@ mod __parse__S {
     }
 
     // State 0
-    //     Kind = None
     //     AllInputs = []
     //     OptionalInputs = []
     //     FixedInputs = []
@@ -53,7 +52,7 @@ mod __parse__S {
     //     S = (*) "(" ")" [EOF]
     //     __S = (*) S [EOF]
     //
-    //     "(" -> Shift(S2)
+    //   "(" -> S2
     //
     //     S -> S1
     pub fn __state0<
@@ -80,7 +79,7 @@ mod __parse__S {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::S(__sym0) => {
-                    __result = try!(__custom0(__tokens, __lookahead, __sym0));
+                    __result = try!(__state1(__tokens, __lookahead, __sym0));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -89,8 +88,50 @@ mod __parse__S {
         }
     }
 
+    // State 1
+    //     AllInputs = [S]
+    //     OptionalInputs = []
+    //     FixedInputs = [S]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(__S)
+    //
+    //     __S = S (*) [EOF]
+    //
+    //   EOF -> __S = S => ActionFn(0);
+    //
+    pub fn __state1<
+        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
+    >(
+        __tokens: &mut __TOKENS,
+        __lookahead: Option<((), Tok, ())>,
+        __sym0: ((), i32, ()),
+    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
+    {
+        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
+        match __lookahead {
+            None => {
+                let __start = __sym0.0.clone();
+                let __end = __sym0.2.clone();
+                let __nt = super::__action0(__sym0);
+                let __nt = __Nonterminal::____S((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
+    }
+
     // State 2
-    //     Kind = None
     //     AllInputs = ["("]
     //     OptionalInputs = []
     //     FixedInputs = ["("]
@@ -100,7 +141,7 @@ mod __parse__S {
     //
     //     S = "(" (*) ")" [EOF]
     //
-    //     ")" -> Shift(S3)
+    //   ")" -> S3
     //
     pub fn __state2<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -118,7 +159,7 @@ mod __parse__S {
         match __lookahead {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym1 = (__loc1, (__tok), __loc2);
-                __result = try!(__custom1(__tokens, __sym0, __sym1));
+                __result = try!(__state3(__tokens, __sym0, __sym1));
                 return Ok(__result);
             }
             _ => {
@@ -130,32 +171,19 @@ mod __parse__S {
         }
     }
 
-    // Custom 0
-    //    Reduce __S = S => ActionFn(0);
-    pub fn __custom0<
-        __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
-    >(
-        __tokens: &mut __TOKENS,
-        __lookahead: Option<((), Tok, ())>,
-        __sym0: ((), i32, ()),
-    ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __ParseError<(),Tok,()>>
-    {
-        let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
-        let __start = __sym0.0.clone();
-        let __end = __sym0.2.clone();
-        let __nt = super::__action0(__sym0);
-        let __nt = __Nonterminal::____S((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
-    }
-
-    // Custom 1
-    //    Reduce S = "(", ")" => ActionFn(1);
-    pub fn __custom1<
+    // State 3
+    //     AllInputs = ["(", ")"]
+    //     OptionalInputs = []
+    //     FixedInputs = ["(", ")"]
+    //     WillPushLen = 0
+    //     WillPush = []
+    //     WillProduce = Some(S)
+    //
+    //     S = "(" ")" (*) [EOF]
+    //
+    //   EOF -> S = "(", ")" => ActionFn(1);
+    //
+    pub fn __state3<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
     >(
         __tokens: &mut __TOKENS,
@@ -169,16 +197,26 @@ mod __parse__S {
             None => None,
             Some(Err(e)) => return Err(__ParseError::User { error: e }),
         };
-        let __start = __sym0.0.clone();
-        let __end = __sym1.2.clone();
-        let __nt = super::__action1(__sym0, __sym1);
-        let __nt = __Nonterminal::S((
-            __start,
-            __nt,
-            __end,
-        ));
-        __result = (__lookahead, __nt);
-        return Ok(__result);
+        match __lookahead {
+            None => {
+                let __start = __sym0.0.clone();
+                let __end = __sym1.2.clone();
+                let __nt = super::__action1(__sym0, __sym1);
+                let __nt = __Nonterminal::S((
+                    __start,
+                    __nt,
+                    __end,
+                ));
+                __result = (__lookahead, __nt);
+                return Ok(__result);
+            }
+            _ => {
+                return Err(__ParseError::UnrecognizedToken {
+                    token: __lookahead,
+                    expected: vec![],
+                });
+            }
+        }
     }
 }
 pub use self::__parse__S::parse_S;

--- a/lalrpop-test/src/use_super.rs
+++ b/lalrpop-test/src/use_super.rs
@@ -98,7 +98,7 @@ mod __parse__S {
     //
     //     __S = S (*) [EOF]
     //
-    //   EOF -> __S = S => ActionFn(0);
+    //   [EOF] -> __S = S => ActionFn(0);
     //
     pub fn __state1<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,
@@ -181,7 +181,7 @@ mod __parse__S {
     //
     //     S = "(" ")" (*) [EOF]
     //
-    //   EOF -> S = "(", ")" => ActionFn(1);
+    //   [EOF] -> S = "(", ")" => ActionFn(1);
     //
     pub fn __state3<
         __TOKENS: Iterator<Item=Result<((), Tok, ()),()>>,

--- a/lalrpop/src/collections/mod.rs
+++ b/lalrpop/src/collections/mod.rs
@@ -3,5 +3,5 @@ mod multimap;
 mod set;
 
 pub use self::map::{map, Map};
-pub use self::multimap::Multimap;
+pub use self::multimap::{Collection, Multimap};
 pub use self::set::{set, Set};

--- a/lalrpop/src/collections/multimap.rs
+++ b/lalrpop/src/collections/multimap.rs
@@ -28,6 +28,14 @@ impl<K: Ord, C: Collection> Multimap<K, C> {
         self.map.entry(key).or_insert_with(|| C::default()).push(value);
     }
 
+    pub fn get(&self, key: &K) -> Option<&C> {
+        self.map.get(key)
+    }
+
+    pub fn iter(&self) -> btree_map::Iter<K, C> {
+        self.map.iter()
+    }
+
     pub fn into_iter(self) -> btree_map::IntoIter<K, C> {
         self.map.into_iter()
     }

--- a/lalrpop/src/collections/multimap.rs
+++ b/lalrpop/src/collections/multimap.rs
@@ -49,6 +49,14 @@ impl<K: Ord, C: Collection> IntoIterator for Multimap<K, C> {
     }
 }
 
+impl<'iter, K: Ord, C: Collection> IntoIterator for &'iter Multimap<K, C> {
+    type Item = (&'iter K, &'iter C);
+    type IntoIter = btree_map::Iter<'iter, K, C>;
+    fn into_iter(self) -> btree_map::Iter<'iter, K, C> {
+        self.iter()
+    }
+}
+
 impl<K: Ord, C: Collection> FromIterator<(K, C::Item)> for Multimap<K, C> {
     fn from_iter<T>(iterator: T) -> Self
         where T: IntoIterator<Item = (K, C::Item)>
@@ -82,3 +90,13 @@ impl<K: Ord, C: Collection> Default for Multimap<K, C> {
         Multimap::new()
     }
 }
+
+impl<K: Ord, C: Collection<Item=I>, I> Collection for Multimap<K, C> {
+    type Item = (K, I);
+
+    fn push(&mut self, item: (K, I)) {
+        let (key, value) = item;
+        self.push(key, value);
+    }
+}
+

--- a/lalrpop/src/collections/multimap.rs
+++ b/lalrpop/src/collections/multimap.rs
@@ -68,3 +68,9 @@ impl<T: Ord> Collection for Set<T> {
         self.insert(item);
     }
 }
+
+impl<K: Ord, C: Collection> Default for Multimap<K, C> {
+    fn default() -> Self {
+        Multimap::new()
+    }
+}

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -53,14 +53,19 @@ pub struct Grammar {
     // the grammar proper:
 
     pub action_fn_defns: Vec<ActionFnDefn>,
+    pub terminals: TerminalSet,
     pub nonterminals: Map<NonterminalString, NonterminalData>,
     pub token_span: Span,
     pub conversions: Map<TerminalString, Pattern<TypeRepr>>,
     pub types: Types,
+}
 
-    // for each terminal, we map it to a small integer from 0 to N
-    pub all_terminals: Vec<TerminalString>,
-    pub terminal_bits: Map<TerminalString, usize>,
+/// For each terminal, we map it to a small integer from 0 to N.
+/// This struct contains the mappings to go back and forth.
+#[derive(Clone, Debug)]
+pub struct TerminalSet {
+    pub all: Vec<TerminalString>,
+    pub bits: Map<TerminalString, usize>,
 }
 
 #[derive(Clone, Debug)]

--- a/lalrpop/src/lr1/ascent.rs
+++ b/lalrpop/src/lr1/ascent.rs
@@ -347,7 +347,7 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
             for (terminal, action) in &this_state.shifts {
                 rust!(self.out, "//   {:?} -> {:?}", terminal, action);
             }
-            for (token, action) in &this_state.reductions {
+            for &(token, action) in &this_state.reductions {
                 rust!(self.out, "//   {:?} -> {:?}", token, action);
             }
             rust!(self.out, "//");
@@ -384,7 +384,7 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
         // production that we are going to be reducing.
         let reductions: Multimap<_, Vec<_>> =
             this_state.reductions.iter()
-                                 .map(|(&token, &production)| (production, token))
+                                 .map(|&(token, production)| (production, token))
                                  .collect();
         for (production, tokens) in reductions {
             for (index, &token) in tokens.iter().enumerate() {

--- a/lalrpop/src/lr1/ascent.rs
+++ b/lalrpop/src/lr1/ascent.rs
@@ -21,7 +21,7 @@ pub fn compile<'grammar,W:Write>(
     grammar: &'grammar Grammar,
     user_start_symbol: NonterminalString,
     start_symbol: NonterminalString,
-    states: &[State<'grammar>],
+    states: &[LR1State<'grammar>],
     out: &mut RustWrite<W>)
     -> io::Result<()>
 {
@@ -50,7 +50,7 @@ struct RecursiveAscent<'ascent,'grammar:'ascent,W:Write+'ascent> {
     start_symbol: NonterminalString,
 
     /// the vector of states
-    states: &'ascent [State<'grammar>],
+    states: &'ascent [LR1State<'grammar>],
 
     /// for each state, the set of symbols that it will require for
     /// input
@@ -129,7 +129,7 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
            user_start_symbol: NonterminalString,
            start_symbol: NonterminalString,
            graph: &'ascent StateGraph,
-           states: &'ascent [State<'grammar>],
+           states: &'ascent [LR1State<'grammar>],
            out: &'ascent mut RustWrite<W>)
            -> RecursiveAscent<'ascent,'grammar,W>
     {
@@ -170,7 +170,7 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
     }
 
     /// Compute the stack suffix that the state expects on entry.
-    fn state_input_for(state: &'ascent State<'grammar>)
+    fn state_input_for(state: &'ascent LR1State<'grammar>)
                        -> StackSuffix<'grammar>
     {
         let max_prefix = state.max_prefix();

--- a/lalrpop/src/lr1/ascent.rs
+++ b/lalrpop/src/lr1/ascent.rs
@@ -10,7 +10,7 @@ use grammar::repr::{Grammar,
                     TerminalString, TypeParameter, TypeRepr, Types};
 use itertools::Itertools;
 use lr1::core::*;
-use lr1::lookahead::Lookahead;
+use lr1::lookahead::Token;
 use lr1::state_graph::StateGraph;
 use rust::RustWrite;
 use std::io::{self, Write};
@@ -370,11 +370,11 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
                              .filter_map(|(token, action)| action.shift().map(|n| (token, n)))
         {
             match *token {
-                Lookahead::Terminal(s) => {
+                Token::Terminal(s) => {
                     let sym_name = format!("{}sym{}", self.prefix, inputs.len());
                     try!(self.consume_terminal(s, sym_name));
                 }
-                Lookahead::EOF =>
+                Token::EOF =>
                     unreachable!("should never have to shift EOF")
             }
 
@@ -396,8 +396,8 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
         for (production, tokens) in reductions {
             for (index, &token) in tokens.iter().enumerate() {
                 let pattern = match token {
-                    Lookahead::Terminal(s) => format!("Some({})", self.match_terminal_pattern(s)),
-                    Lookahead::EOF => format!("None"),
+                    Token::Terminal(s) => format!("Some({})", self.match_terminal_pattern(s)),
+                    Token::EOF => format!("None"),
                 };
                 if index < tokens.len() - 1 {
                     rust!(self.out, "{} |", pattern);

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -5,7 +5,7 @@ use kernel_set;
 use grammar::repr::*;
 use lr1::core::*;
 use lr1::first;
-use lr1::lookahead::Lookahead;
+use lr1::lookahead::Token;
 use std::rc::Rc;
 use tls::Tls;
 
@@ -49,7 +49,7 @@ impl<'grammar> LR1<'grammar> {
         let mut errors = 0;
 
         // create the starting state
-        kernel_set.add_state(Kernel::start(self.items(start_nt, 0, Lookahead::EOF)));
+        kernel_set.add_state(Kernel::start(self.items(start_nt, 0, Token::EOF)));
 
         while let Some(Kernel { items: seed_items }) = kernel_set.next() {
             let items = self.transitive_closure(seed_items);
@@ -82,7 +82,7 @@ impl<'grammar> LR1<'grammar> {
                 match symbol {
                     Symbol::Terminal(s) => {
                         let action = Action::Shift(next_state);
-                        let prev = this_state.tokens.insert(Lookahead::Terminal(s), action);
+                        let prev = this_state.tokens.insert(Token::Terminal(s), action);
                         assert!(prev.is_none()); // cannot have a shift/shift conflict
                     }
 
@@ -131,7 +131,7 @@ impl<'grammar> LR1<'grammar> {
     fn items(&self,
              id: NonterminalString,
              index: usize,
-             lookahead: Lookahead)
+             lookahead: Token)
              -> Vec<LR1Item<'grammar>>
     {
         self.grammar.productions_for(id)

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -279,8 +279,7 @@ impl LookaheadBuild for Token {
                                lookahead: Self)
                                -> Vec<LR1Item<'grammar>>
     {
-        let (first_set, _) =
-            lr.first_sets.first(lr.grammar, remainder, lookahead);
+        let first_set = lr.first_sets.first1(lr.grammar, remainder, lookahead);
         first_set.iter(lr.grammar)
                  .flat_map(|l| lr.items(nt, 0, l))
                  .collect::<Vec<_>>()

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -14,7 +14,7 @@ mod test;
 
 pub fn build_lr1_states<'grammar>(grammar: &'grammar Grammar,
                                   start: NonterminalString)
-                                  -> Result<Vec<State<'grammar>>,
+                                  -> Result<Vec<LR1State<'grammar>>,
                                             TableConstructionError<'grammar>>
 {
     profile! {
@@ -41,7 +41,7 @@ impl<'grammar> LR1<'grammar> {
     }
 
     fn build_states(&self, start_nt: NonterminalString)
-                    -> Result<Vec<State<'grammar>>, TableConstructionError<'grammar>>
+                    -> Result<Vec<LR1State<'grammar>>, TableConstructionError<'grammar>>
     {
         let session = Tls::session();
         let mut kernel_set = kernel_set::KernelSet::new();
@@ -65,7 +65,7 @@ impl<'grammar> LR1<'grammar> {
 
             // group the items that we can transition into by shifting
             // over a term or nonterm
-            let transitions: Multimap<Symbol, Vec<Item<'grammar>>> =
+            let transitions: Multimap<Symbol, Vec<LR1Item<'grammar>>> =
                 items.vec
                      .iter()
                      .filter_map(|item| item.shifted_item())
@@ -132,7 +132,7 @@ impl<'grammar> LR1<'grammar> {
              id: NonterminalString,
              index: usize,
              lookahead: Lookahead)
-             -> Vec<Item<'grammar>>
+             -> Vec<LR1Item<'grammar>>
     {
         self.grammar.productions_for(id)
                     .iter()
@@ -146,12 +146,12 @@ impl<'grammar> LR1<'grammar> {
     }
 
     // expands `state` with epsilon moves
-    fn transitive_closure(&self, mut items: Vec<Item<'grammar>>)
-                          -> Items<'grammar>
+    fn transitive_closure(&self, mut items: Vec<LR1Item<'grammar>>)
+                          -> LR1Items<'grammar>
     {
         let mut counter = 0;
 
-        let mut set: Set<Item<'grammar>> =
+        let mut set: Set<LR1Item<'grammar>> =
             items.iter().cloned().collect();
 
         while counter < items.len() {
@@ -211,17 +211,17 @@ impl<'grammar> LR1<'grammar> {
 /// item found in a kernel set.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct Kernel<'grammar> {
-    items: Vec<Item<'grammar>>
+    items: Vec<LR1Item<'grammar>>
 }
 
 impl<'grammar> Kernel<'grammar> {
-    pub fn start(items: Vec<Item<'grammar>>) -> Kernel<'grammar> {
+    pub fn start(items: Vec<LR1Item<'grammar>>) -> Kernel<'grammar> {
         // In start state, kernel should have only items with `index == 0`.
         debug_assert!(items.iter().all(|item| item.index == 0));
         Kernel { items: items }
     }
 
-    pub fn shifted(items: Vec<Item<'grammar>>) -> Kernel<'grammar> {
+    pub fn shifted(items: Vec<LR1Item<'grammar>>) -> Kernel<'grammar> {
         // Assert that this kernel consists only of shifted items
         // where `index > 0`. This assertion could cost real time to
         // check so only do it in debug mode.

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -5,6 +5,7 @@ use kernel_set;
 use grammar::repr::*;
 use lr1::core::*;
 use lr1::first;
+use lr1::lane_table::*;
 use lr1::lookahead::*;
 use std::rc::Rc;
 use tls::Tls;
@@ -16,6 +17,12 @@ pub fn build_lr1_states<'grammar>(grammar: &'grammar Grammar,
                                   start: NonterminalString)
                                   -> LR1Result<'grammar>
 {
+    // this is just here to squash dead code warnings while work on
+    // lane-table proceeds
+    if false {
+        let _ = build_lane_table_states(grammar, start);
+    }
+
     profile! {
         &Tls::session(),
         "LR(1) state construction",

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -14,8 +14,7 @@ mod test;
 
 pub fn build_lr1_states<'grammar>(grammar: &'grammar Grammar,
                                   start: NonterminalString)
-                                  -> Result<Vec<LR1State<'grammar>>,
-                                            LR1TableConstructionError<'grammar>>
+                                  -> LR1Result<'grammar>
 {
     profile! {
         &Tls::session(),

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -326,8 +326,8 @@ impl LookaheadBuild for Token {
                                lookahead: Self)
                                -> Vec<LR1Item<'grammar>>
     {
-        let first_set = lr.first_sets.first1(lr.grammar, remainder, lookahead);
-        first_set.iter(lr.grammar)
+        let first_set = lr.first_sets.first1(remainder, lookahead);
+        first_set.iter()
                  .flat_map(|l| lr.items(nt, 0, l))
                  .collect::<Vec<_>>()
     }

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -302,7 +302,7 @@ impl LookaheadBuild for Nil {
                                    this_state: &mut State<'grammar, Self>)
     {
         let index = this_state.index;
-        for (&_terminal, &next_state) in &this_state.shifts {
+        for (&terminal, &next_state) in &this_state.shifts {
             this_state.conflicts.extend(
                 this_state.reductions
                           .values()
@@ -310,7 +310,7 @@ impl LookaheadBuild for Nil {
                               state: index,
                               lookahead: Nil,
                               production: production,
-                              action: Action::Shift(next_state),
+                              action: Action::Shift(terminal, next_state),
                           }));
         }
     }
@@ -339,7 +339,7 @@ impl LookaheadBuild for Token {
                     state: this_state.index,
                     lookahead: token,
                     production: production,
-                    action: Action::Shift(next_state),
+                    action: Action::Shift(terminal, next_state),
                 });
             }
         }

--- a/lalrpop/src/lr1/build/mod.rs
+++ b/lalrpop/src/lr1/build/mod.rs
@@ -291,7 +291,7 @@ trait LookaheadBuild: Lookahead {
 impl LookaheadBuild for Nil {
     fn epsilon_moves<'grammar>(lr: &LR<'grammar, Self>,
                                nt: NonterminalString,
-                               remainder: &[Symbol],
+                               _remainder: &[Symbol],
                                lookahead: Nil)
                                -> Vec<LR0Item<'grammar>>
     {
@@ -302,7 +302,7 @@ impl LookaheadBuild for Nil {
                                    this_state: &mut State<'grammar, Self>)
     {
         let index = this_state.index;
-        for (&terminal, &next_state) in &this_state.shifts {
+        for (&_terminal, &next_state) in &this_state.shifts {
             this_state.conflicts.extend(
                 this_state.reductions
                           .values()

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -16,7 +16,9 @@ fn nt(t: &str) -> NonterminalString {
 
 const ITERATIONS: usize = 22;
 
-fn random_test<'g>(grammar: &Grammar, states: &'g [State<'g>], start_symbol: NonterminalString) {
+fn random_test<'g>(grammar: &Grammar,
+                   states: &'g [LR1State<'g>],
+                   start_symbol: NonterminalString) {
     for i in 0..ITERATIONS {
         let input_tree = generate::random_parse_tree(grammar, start_symbol);
         let output_tree = interpret(&states, input_tree.terminals()).unwrap();
@@ -36,7 +38,7 @@ macro_rules! tokens {
 }
 
 fn items<'g>(grammar: &'g Grammar, nonterminal: &str, index: usize, la: Lookahead)
-             -> Items<'g>
+             -> LR1Items<'g>
 {
     let lr1 = LR1::new(&grammar);
     let items =

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -8,7 +8,7 @@ use lr1::lookahead::Token;
 use lr1::lookahead::Token::EOF;
 use tls::Tls;
 
-use super::{LR1, build_lr1_states};
+use super::{LR, build_lr1_states};
 
 fn nt(t: &str) -> NonterminalString {
     NonterminalString(intern(t))
@@ -40,7 +40,7 @@ macro_rules! tokens {
 fn items<'g>(grammar: &'g Grammar, nonterminal: &str, index: usize, la: Token)
              -> LR1Items<'g>
 {
-    let lr1 = LR1::new(&grammar);
+    let lr1: LR<Token> = LR::new(&grammar, nt(nonterminal), la);
     let items =
         lr1.transitive_closure(
             lr1.items(nt(nonterminal), index, la));

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -6,6 +6,7 @@ use lr1::core::*;
 use lr1::interpret::interpret;
 use lr1::lookahead::Token;
 use lr1::lookahead::Token::EOF;
+use lr1::tls::Lr1Tls;
 use tls::Tls;
 
 use super::{LR, build_lr0_states, build_lr1_states};
@@ -58,6 +59,7 @@ grammar;
         () => None
     };
 "#);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let items = items(&grammar, "A", 0, EOF);
     expect_debug(items.vec, r#"[
     A = (*) B "C" [EOF],
@@ -81,6 +83,8 @@ C: Option<u32> = {
     () => None
 };
 "#);
+
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
 
     expect_debug(items(&grammar, "A", 0, EOF).vec, r#"[
     A = (*) B C [EOF],
@@ -118,6 +122,8 @@ grammar;
         "(" E ")" => ()
     };
 "#);
+
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
 
     // for now, just test that process does not result in an error
     // and yields expected number of states.
@@ -191,6 +197,8 @@ fn shift_reduce_conflict1() {
         };
     "#);
 
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
+
     assert!(build_lr1_states(&grammar, nt("E")).is_err());
 }
 
@@ -214,6 +222,8 @@ T: () = {
     "(" E ")",
 };
 "#);
+
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
 
     // for now, just test that process does not result in an error
     // and yields expected number of states.
@@ -242,6 +252,8 @@ T: () = {
     "(" E ")",
 };
 "#);
+
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
 
     build_lr0_states(&grammar, nt("S")).unwrap_err();
 }

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -4,8 +4,8 @@ use grammar::repr::*;
 use test_util::{compare, expect_debug, normalized_grammar};
 use lr1::core::*;
 use lr1::interpret::interpret;
-use lr1::lookahead::Lookahead;
-use lr1::lookahead::Lookahead::EOF;
+use lr1::lookahead::Token;
+use lr1::lookahead::Token::EOF;
 use tls::Tls;
 
 use super::{LR1, build_lr1_states};
@@ -37,7 +37,7 @@ macro_rules! tokens {
     }
 }
 
-fn items<'g>(grammar: &'g Grammar, nonterminal: &str, index: usize, la: Lookahead)
+fn items<'g>(grammar: &'g Grammar, nonterminal: &str, index: usize, la: Token)
              -> LR1Items<'g>
 {
     let lr1 = LR1::new(&grammar);

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -6,6 +6,7 @@ use lr1::core::*;
 use lr1::interpret::interpret;
 use lr1::lookahead::Token;
 use lr1::lookahead::Token::EOF;
+use lr1::lookahead::TokenSet;
 use lr1::tls::Lr1Tls;
 use tls::Tls;
 
@@ -41,10 +42,11 @@ macro_rules! tokens {
 fn items<'g>(grammar: &'g Grammar, nonterminal: &str, index: usize, la: Token)
              -> LR1Items<'g>
 {
-    let lr1: LR<Token> = LR::new(&grammar, nt(nonterminal), la);
+    let set = TokenSet::from(la);
+    let lr1: LR<TokenSet> = LR::new(&grammar, nt(nonterminal), set.clone());
     let items =
         lr1.transitive_closure(
-            lr1.items(nt(nonterminal), index, la));
+            lr1.items(nt(nonterminal), index, &set));
     items
 }
 
@@ -88,10 +90,8 @@ C: Option<u32> = {
 
     expect_debug(items(&grammar, "A", 0, EOF).vec, r#"[
     A = (*) B C [EOF],
-    B = (*) [EOF],
-    B = (*) ["C1"],
-    B = (*) "B1" [EOF],
-    B = (*) "B1" ["C1"]
+    B = (*) ["C1", EOF],
+    B = (*) "B1" ["C1", EOF]
 ]"#);
 
     expect_debug(items(&grammar, "A", 1, EOF).vec, r#"[

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use lr1::build;
 use lr1::core::*;
 use lr1::core::Action::{Reduce, Shift};
-use lr1::lookahead::Lookahead;
+use lr1::lookahead::Token;
 use grammar::repr::*;
 use std::rc::Rc;
 use tls::Tls;
@@ -20,9 +20,9 @@ mod test;
 struct LALR1State<'grammar> {
     index: StateIndex,
     items: Vec<LR1Item<'grammar>>,
-    tokens: Map<Lookahead, Action<'grammar>>,
+    tokens: Map<Token, Action<'grammar>>,
     gotos: Map<NonterminalString, StateIndex>,
-    conflicts: Map<Lookahead, Vec<Conflict<'grammar>>>,
+    conflicts: Map<Token, Vec<Conflict<'grammar>>>,
 }
 
 pub fn build_lalr_states<'grammar>(grammar: &'grammar Grammar,

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -137,16 +137,16 @@ pub fn collapse_to_lalr_states<'grammar>(lr_states: &[LR1State<'grammar>])
                                                  .map(|(p, ts)| (ts, p))
                                                  .collect(),
                         gotos: lr.gotos,
-                        conflicts: vec![],
                     })
                     .collect();
 
-    for lr1_state in &mut lr1_states {
-        TokenSet::find_conflicts(lr1_state);
-    }
+    let conflicts: Vec<_> =
+        lr1_states.iter()
+                  .flat_map(|s| TokenSet::conflicts(s))
+                  .collect();
 
-    if lr1_states.iter().any(|s| !s.conflicts.is_empty()) {
-        Err(TableConstructionError { states: lr1_states })
+    if !conflicts.is_empty() {
+        Err(TableConstructionError { states: lr1_states, conflicts: conflicts })
     } else {
         Ok(lr1_states)
     }

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -28,7 +28,7 @@ struct LALR1State<'grammar> {
 pub fn build_lalr_states<'grammar>(grammar: &'grammar Grammar,
                                    start: NonterminalString)
                                    -> Result<Vec<LR1State<'grammar>>,
-                                             TableConstructionError<'grammar>>
+                                             LR1TableConstructionError<'grammar>>
 {
     // First build the LR(1) states
     let lr_states = try!(build::build_lr1_states(grammar, start));
@@ -42,7 +42,7 @@ pub fn build_lalr_states<'grammar>(grammar: &'grammar Grammar,
 
 pub fn collapse_to_lalr_states<'grammar>(lr_states: &[LR1State<'grammar>])
                                          -> Result<Vec<LR1State<'grammar>>,
-                                                   TableConstructionError<'grammar>>
+                                                   LR1TableConstructionError<'grammar>>
 {
     // Now compress them. This vector stores, for each state, the
     // LALR(1) state to which we will remap it.

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -19,7 +19,7 @@ mod test;
 // set of actions, as well.
 struct LALR1State<'grammar> {
     index: StateIndex,
-    items: Vec<Item<'grammar>>,
+    items: Vec<LR1Item<'grammar>>,
     tokens: Map<Lookahead, Action<'grammar>>,
     gotos: Map<NonterminalString, StateIndex>,
     conflicts: Map<Lookahead, Vec<Conflict<'grammar>>>,
@@ -27,7 +27,7 @@ struct LALR1State<'grammar> {
 
 pub fn build_lalr_states<'grammar>(grammar: &'grammar Grammar,
                                    start: NonterminalString)
-                                   -> Result<Vec<State<'grammar>>,
+                                   -> Result<Vec<LR1State<'grammar>>,
                                              TableConstructionError<'grammar>>
 {
     // First build the LR(1) states
@@ -40,8 +40,8 @@ pub fn build_lalr_states<'grammar>(grammar: &'grammar Grammar,
     }
 }
 
-pub fn collapse_to_lalr_states<'grammar>(lr_states: &[State<'grammar>])
-                                         -> Result<Vec<State<'grammar>>,
+pub fn collapse_to_lalr_states<'grammar>(lr_states: &[LR1State<'grammar>])
+                                         -> Result<Vec<LR1State<'grammar>>,
                                                    TableConstructionError<'grammar>>
 {
     // Now compress them. This vector stores, for each state, the
@@ -53,10 +53,7 @@ pub fn collapse_to_lalr_states<'grammar>(lr_states: &[State<'grammar>])
     for (lr1_index, lr1_state) in lr_states.iter().enumerate() {
         let lr0_kernel: Vec<_> =
             lr1_state.items.vec.iter()
-                               .map(|item| LR0Item {
-                                   production: item.production,
-                                   index: item.index,
-                               })
+                               .map(|item| item.to_lr0())
                                .dedup()
                                .collect();
 

--- a/lalrpop/src/lr1/build_lalr/mod.rs
+++ b/lalrpop/src/lr1/build_lalr/mod.rs
@@ -9,7 +9,6 @@ use grammar::repr::*;
 use std::rc::Rc;
 use std::mem;
 use tls::Tls;
-use util::map::Entry;
 
 #[cfg(test)]
 mod test;
@@ -104,7 +103,6 @@ pub fn collapse_to_lalr_states<'grammar>(lr_states: &[LR1State<'grammar>])
     }
 
     // Now that items are fully built, create the actions
-    let reductions: Multimap<&'grammar Production, TokenSet> = Multimap::new();
     for (lr1_index, lr1_state) in lr_states.iter().enumerate() {
         let lalr1_index = remap[lr1_index];
         let lalr1_state = &mut lalr1_states[lalr1_index.0];
@@ -127,7 +125,7 @@ pub fn collapse_to_lalr_states<'grammar>(lr_states: &[LR1State<'grammar>])
     }
 
     // Finally, create the new states and detect conflicts
-    let mut lr1_states: Vec<_> =
+    let lr1_states: Vec<_> =
         lalr1_states.into_iter()
                     .map(|lr| State {
                         index: lr.index,

--- a/lalrpop/src/lr1/build_lalr/test.rs
+++ b/lalrpop/src/lr1/build_lalr/test.rs
@@ -39,7 +39,8 @@ fn figure9_23() {
     let states = build_lalr_states(&grammar, nt("S")).unwrap();
     println!("{:#?}", states);
 
-    let tree = interpret(&states, tokens!["N", "-", "(", "N", "-", "N", ")"]).unwrap();
+    let tree = interpret(&states, tokens!["N", "-", "(", "N", "-", "N", ")"])
+        .unwrap();
     assert_eq!(
         &format!("{:?}", tree)[..],
         r#"[S: [E: [E: [T: "N"]], "-", [T: "(", [E: [E: [T: "N"]], "-", [T: "N"]], ")"]]]"#);

--- a/lalrpop/src/lr1/build_lalr/test.rs
+++ b/lalrpop/src/lr1/build_lalr/test.rs
@@ -1,5 +1,6 @@
 use intern::intern;
 use grammar::repr::*;
+use lr1::tls::Lr1Tls;
 use test_util::{normalized_grammar};
 use tls::Tls;
 use super::build_lalr_states;
@@ -32,6 +33,8 @@ fn figure9_23() {
             "(" E ")"   => ()
         };
    "#);
+
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
 
     let states = build_lalr_states(&grammar, nt("S")).unwrap();
     println!("{:#?}", states);

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -60,6 +60,13 @@ impl<'grammar, L: Lookahead> Item<'grammar, L> {
         self.index < self.production.symbols.len()
     }
 
+    pub fn can_shift_nonterminal(&self, nt: NonterminalString) -> bool {
+        match self.shift_symbol() {
+            Some((Symbol::Nonterminal(shifted), _)) => shifted == nt,
+            _ => false,
+        }
+    }
+
     pub fn can_reduce(&self) -> bool {
         self.index == self.production.symbols.len()
     }

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Formatter, Error};
 use std::rc::Rc;
 use util::Prefix;
 
-use super::lookahead::Lookahead;
+use super::lookahead::Token;
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Item<'grammar, L: Clone> {
@@ -19,7 +19,7 @@ pub struct Item<'grammar, L: Clone> {
 
 pub type LR0Item<'grammar> = Item<'grammar, ()>;
 
-pub type LR1Item<'grammar> = Item<'grammar, Lookahead>;
+pub type LR1Item<'grammar> = Item<'grammar, Token>;
 
 impl<'grammar> Item<'grammar, ()> {
     #[cfg(test)]
@@ -93,19 +93,19 @@ pub struct Items<'grammar, L: Clone> {
 }
 
 pub type LR0Items<'grammar> = Items<'grammar, ()>;
-pub type LR1Items<'grammar> = Items<'grammar, Lookahead>;
+pub type LR1Items<'grammar> = Items<'grammar, Token>;
 
 #[derive(Debug)]
 pub struct State<'grammar, L: Clone> {
     pub index: StateIndex,
     pub items: Items<'grammar, L>,
-    pub tokens: Map<Lookahead, Action<'grammar>>,
-    pub conflicts: Map<Lookahead, Vec<Conflict<'grammar>>>,
+    pub tokens: Map<Token, Action<'grammar>>,
+    pub conflicts: Map<Token, Vec<Conflict<'grammar>>>,
     pub gotos: Map<NonterminalString, StateIndex>,
 }
 
 pub type LR0State<'grammar> = State<'grammar, ()>;
-pub type LR1State<'grammar> = State<'grammar, Lookahead>;
+pub type LR1State<'grammar> = State<'grammar, Token>;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Action<'grammar> {
@@ -148,11 +148,11 @@ impl<'grammar, L: Clone+Debug> Debug for Item<'grammar, L> {
     }
 }
 
-impl Debug for Lookahead {
+impl Debug for Token {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match *self {
-            Lookahead::EOF => write!(fmt, "EOF"),
-            Lookahead::Terminal(s) => write!(fmt, "{}", s),
+            Token::EOF => write!(fmt, "EOF"),
+            Token::Terminal(s) => write!(fmt, "{}", s),
         }
     }
 }

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -133,10 +133,12 @@ pub type LR0Conflict<'grammar> = Conflict<'grammar, Nil>;
 pub type LR1Conflict<'grammar> = Conflict<'grammar, Token>;
 
 #[derive(Debug)]
-pub struct TableConstructionError<'grammar> {
+pub struct TableConstructionError<'grammar, L: Lookahead> {
     // LR(1) state set. Some of these states are in error.
-    pub states: Vec<LR1State<'grammar>>,
+    pub states: Vec<State<'grammar, L>>,
 }
+
+pub type LR1TableConstructionError<'grammar> = TableConstructionError<'grammar, Token>;
 
 impl<'grammar, L: Lookahead> Debug for Item<'grammar, L> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -122,7 +122,6 @@ pub struct State<'grammar, L: Lookahead> {
     pub items: Items<'grammar, L>,
     pub shifts: Map<TerminalString, StateIndex>,
     pub reductions: Vec<(L, &'grammar Production)>,
-    pub conflicts: Vec<Conflict<'grammar, L>>,
     pub gotos: Map<NonterminalString, StateIndex>,
 }
 
@@ -155,8 +154,12 @@ pub type LR1Conflict<'grammar> = Conflict<'grammar, TokenSet>;
 
 #[derive(Debug)]
 pub struct TableConstructionError<'grammar, L: Lookahead> {
-    // LR(1) state set. Some of these states are in error.
+    // LR(1) state set, possibly incomplete if construction is
+    // configured to terminate early.
     pub states: Vec<State<'grammar, L>>,
+
+    // Conflicts (non-empty) found in those states.
+    pub conflicts: Vec<Conflict<'grammar, L>>,
 }
 
 pub type LR0TableConstructionError<'grammar> = TableConstructionError<'grammar, Nil>;

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -164,6 +164,8 @@ pub struct TableConstructionError<'grammar, L: Lookahead> {
 
 pub type LR0TableConstructionError<'grammar> = TableConstructionError<'grammar, Nil>;
 pub type LR1TableConstructionError<'grammar> = TableConstructionError<'grammar, TokenSet>;
+pub type LR1Result<'grammar> = Result<Vec<LR1State<'grammar>>,
+                                      LR1TableConstructionError<'grammar>>;
 
 impl<'grammar, L: Lookahead> Debug for Item<'grammar, L> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -117,7 +117,7 @@ pub type LR1State<'grammar> = State<'grammar, Token>;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Action<'grammar> {
-    Shift(StateIndex),
+    Shift(TerminalString, StateIndex),
     Reduce(&'grammar Production),
 }
 

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -19,7 +19,7 @@ pub struct Item<'grammar, L: Lookahead> {
 
 pub type LR0Item<'grammar> = Item<'grammar, Nil>;
 
-pub type LR1Item<'grammar> = Item<'grammar, Token>;
+pub type LR1Item<'grammar> = Item<'grammar, TokenSet>;
 
 impl<'grammar> Item<'grammar, Nil> {
     pub fn lr0(production: &'grammar Production,
@@ -30,6 +30,14 @@ impl<'grammar> Item<'grammar, Nil> {
 }
 
 impl<'grammar, L: Lookahead> Item<'grammar, L> {
+    pub fn with_lookahead<L1: Lookahead>(&self, l: L1) -> Item<'grammar, L1> {
+        Item {
+            production: self.production,
+            index: self.index,
+            lookahead: l
+        }
+    }
+
     pub fn prefix(&self) -> &'grammar [Symbol] {
         &self.production.symbols[..self.index]
     }
@@ -106,7 +114,7 @@ pub struct Items<'grammar, L: Lookahead> {
 }
 
 pub type LR0Items<'grammar> = Items<'grammar, Nil>;
-pub type LR1Items<'grammar> = Items<'grammar, Token>;
+pub type LR1Items<'grammar> = Items<'grammar, TokenSet>;
 
 #[derive(Debug)]
 pub struct State<'grammar, L: Lookahead> {
@@ -119,7 +127,7 @@ pub struct State<'grammar, L: Lookahead> {
 }
 
 pub type LR0State<'grammar> = State<'grammar, Nil>;
-pub type LR1State<'grammar> = State<'grammar, Token>;
+pub type LR1State<'grammar> = State<'grammar, TokenSet>;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Action<'grammar> {
@@ -128,7 +136,7 @@ pub enum Action<'grammar> {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct Conflict<'grammar, L: Lookahead> {
+pub struct Conflict<'grammar, L> {
     // when in this state...
     pub state: StateIndex,
 
@@ -143,7 +151,7 @@ pub struct Conflict<'grammar, L: Lookahead> {
 }
 
 pub type LR0Conflict<'grammar> = Conflict<'grammar, Nil>;
-pub type LR1Conflict<'grammar> = Conflict<'grammar, Token>;
+pub type LR1Conflict<'grammar> = Conflict<'grammar, TokenSet>;
 
 #[derive(Debug)]
 pub struct TableConstructionError<'grammar, L: Lookahead> {
@@ -152,7 +160,7 @@ pub struct TableConstructionError<'grammar, L: Lookahead> {
 }
 
 pub type LR0TableConstructionError<'grammar> = TableConstructionError<'grammar, Nil>;
-pub type LR1TableConstructionError<'grammar> = TableConstructionError<'grammar, Token>;
+pub type LR1TableConstructionError<'grammar> = TableConstructionError<'grammar, TokenSet>;
 
 impl<'grammar, L: Lookahead> Debug for Item<'grammar, L> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -145,6 +145,7 @@ pub struct TableConstructionError<'grammar, L: Lookahead> {
     pub states: Vec<State<'grammar, L>>,
 }
 
+pub type LR0TableConstructionError<'grammar> = TableConstructionError<'grammar, Nil>;
 pub type LR1TableConstructionError<'grammar> = TableConstructionError<'grammar, Token>;
 
 impl<'grammar, L: Lookahead> Debug for Item<'grammar, L> {

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -22,7 +22,6 @@ pub type LR0Item<'grammar> = Item<'grammar, Nil>;
 pub type LR1Item<'grammar> = Item<'grammar, Token>;
 
 impl<'grammar> Item<'grammar, Nil> {
-    #[cfg(test)]
     pub fn lr0(production: &'grammar Production,
                index: usize)
                -> Self {
@@ -63,6 +62,13 @@ impl<'grammar, L: Lookahead> Item<'grammar, L> {
     pub fn can_shift_nonterminal(&self, nt: NonterminalString) -> bool {
         match self.shift_symbol() {
             Some((Symbol::Nonterminal(shifted), _)) => shifted == nt,
+            _ => false,
+        }
+    }
+
+    pub fn can_shift_terminal(&self, term: TerminalString) -> bool {
+        match self.shift_symbol() {
+            Some((Symbol::Terminal(shifted), _)) => shifted == term,
             _ => false,
         }
     }

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -113,7 +113,7 @@ pub struct State<'grammar, L: Lookahead> {
     pub index: StateIndex,
     pub items: Items<'grammar, L>,
     pub shifts: Map<TerminalString, StateIndex>,
-    pub reductions: Map<L, &'grammar Production>,
+    pub reductions: Vec<(L, &'grammar Production)>,
     pub conflicts: Vec<Conflict<'grammar, L>>,
     pub gotos: Map<NonterminalString, StateIndex>,
 }

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -15,7 +15,7 @@ use tls::Tls;
 #[cfg(test)] mod test;
 
 pub fn report_error(grammar: &Grammar,
-                    error: &TableConstructionError)
+                    error: &LR1TableConstructionError)
                     -> Vec<Message>
 {
     let mut cx = ErrorReportingCx::new(grammar, &error.states);

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -25,7 +25,7 @@ pub fn report_error(grammar: &Grammar,
 struct ErrorReportingCx<'cx, 'grammar: 'cx> {
     grammar: &'grammar Grammar,
     first_sets: FirstSets,
-    states: &'cx [State<'grammar>],
+    states: &'cx [LR1State<'grammar>],
 }
 
 #[derive(Debug)]
@@ -62,7 +62,7 @@ enum ConflictClassification {
 
 impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
     fn new(grammar: &'grammar Grammar,
-           states: &'cx [State<'grammar>])
+           states: &'cx [LR1State<'grammar>])
            -> Self {
         ErrorReportingCx {
             grammar: grammar,
@@ -768,7 +768,7 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
     }
 
     fn conflicting_shift_items(&self,
-                               state: &State<'grammar>,
+                               state: &LR1State<'grammar>,
                                lookahead: Lookahead,
                                _conflict: &Conflict<'grammar>)
                                -> Map<LR0Item<'grammar>, LookaheadSet> {

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -668,9 +668,9 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
                         // potentially overlapping, though we could
                         // supply the actual lookahead for more precision.
                         let shift_first =
-                            self.first_sets.first0(self.grammar, &[shift_sym]);
+                            self.first_sets.first0(&[shift_sym]);
                         let reduce_first =
-                            self.first_sets.first0(self.grammar, &[reduce_sym]);
+                            self.first_sets.first0(&[reduce_sym]);
                         if shift_first.is_disjoint(reduce_first) {
                             Some(true)
                         } else {

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -732,7 +732,7 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
             lookahead: lookahead
         };
         let tracer = Tracer::new(self.grammar, self.states);
-        let reduce_trace = tracer.backtrace_reduce(state, item);
+        let reduce_trace = tracer.backtrace_reduce(state, item.to_lr0());
         reduce_trace.examples(item.to_lr0()).collect()
     }
 

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -703,7 +703,7 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
         conflicting_items
             .into_iter()
             .flat_map(|item| {
-                let tracer = Tracer::new(self.grammar, &self.first_sets, self.states);
+                let tracer = Tracer::new(&self.first_sets, self.states);
                 let shift_trace =
                     tracer.backtrace_shift(conflict.state, item);
                 let local_examples: Vec<Example> =
@@ -724,9 +724,9 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
             index: production.symbols.len(),
             lookahead: TokenSet::from(lookahead),
         };
-        let tracer = Tracer::new(self.grammar, &self.first_sets, self.states);
+        let tracer = Tracer::new(&self.first_sets, self.states);
         let reduce_trace = tracer.backtrace_reduce(state, item.to_lr0());
-        reduce_trace.lr1_examples(self.grammar, &self.first_sets, &item)
+        reduce_trace.lr1_examples(&self.first_sets, &item)
                     .collect()
     }
 

--- a/lalrpop/src/lr1/error/mod.rs
+++ b/lalrpop/src/lr1/error/mod.rs
@@ -673,18 +673,15 @@ impl<'cx, 'grammar> ErrorReportingCx<'cx, 'grammar> {
                         // same symbol on both; we'll be able to shift them
                         None
                     } else {
-                        // different symbols: for this to
-                        // work, must have disjoint first
-                        // sets. We'll be approximate and
-                        // supply the same Token::EOF to
-                        // both, though in fact the actual
-                        // lookahead may be helpful here.
-                        let (shift_first, _) =
-                            self.first_sets.first(self.grammar, &[shift_sym],
-                                                  Token::EOF);
-                        let (reduce_first, _) =
-                            self.first_sets.first(self.grammar, &[reduce_sym],
-                                                  Token::EOF);
+                        // different symbols: for this to work, must
+                        // have disjoint first sets. Note that we
+                        // consider a suffix matching epsilon to be
+                        // potentially overlapping, though we could
+                        // supply the actual lookahead for more precision.
+                        let shift_first =
+                            self.first_sets.first0(self.grammar, &[shift_sym]);
+                        let reduce_first =
+                            self.first_sets.first0(self.grammar, &[reduce_sym]);
                         if shift_first.is_disjoint(reduce_first) {
                             Some(true)
                         } else {

--- a/lalrpop/src/lr1/error/test.rs
+++ b/lalrpop/src/lr1/error/test.rs
@@ -23,9 +23,9 @@ pub Ty: () = {
 };
 "#);
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
-    let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
-    let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let conflicts = super::token_conflicts(&states);
+    let err = build_states(&grammar, nt("Ty")).unwrap_err();
+    let mut cx = ErrorReportingCx::new(&grammar, &err.states, &err.conflicts);
+    let conflicts = super::token_conflicts(&err.conflicts);
     let conflict = &conflicts[0];
 
     println!("conflict={:?}", conflict);
@@ -61,9 +61,9 @@ pub Expr: () = {
 };
 "#);
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
-    let states = build_states(&grammar, nt("Expr")).unwrap_err().states;
-    let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let conflicts = super::token_conflicts(&states);
+    let err = build_states(&grammar, nt("Expr")).unwrap_err();
+    let mut cx = ErrorReportingCx::new(&grammar, &err.states, &err.conflicts);
+    let conflicts = super::token_conflicts(&err.conflicts);
     let conflict = &conflicts[0];
 
     println!("conflict={:?}", conflict);
@@ -91,10 +91,9 @@ fn suggest_question_conflict() {
         };
 "#);
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
-    let states = build_states(&grammar, nt("E")).unwrap_err().states;
-
-    let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let conflicts = super::token_conflicts(&states);
+    let err = build_states(&grammar, nt("E")).unwrap_err();
+    let mut cx = ErrorReportingCx::new(&grammar, &err.states, &err.conflicts);
+    let conflicts = super::token_conflicts(&err.conflicts);
     let conflict = &conflicts[0];
 
     println!("conflict={:?}", conflict);
@@ -131,9 +130,9 @@ Path: () = {
 Ident = r#"[a-zA-Z][a-zA-Z0-9]*"#;
 "##);
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
-    let states = build_states(&grammar, nt("ImportDecl")).unwrap_err().states;
-    let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let conflicts = super::token_conflicts(&states);
+    let err = build_states(&grammar, nt("ImportDecl")).unwrap_err();
+    let mut cx = ErrorReportingCx::new(&grammar, &err.states, &err.conflicts);
+    let conflicts = super::token_conflicts(&err.conflicts);
     let conflict = &conflicts[0];
 
     println!("conflict={:?}", conflict);

--- a/lalrpop/src/lr1/error/test.rs
+++ b/lalrpop/src/lr1/error/test.rs
@@ -23,20 +23,15 @@ pub Ty: () = {
 "#);
     let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
     let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let (&lookahead, conflict) =
+    let conflict =
         states.iter()
-              .flat_map(|state| {
-                  state.conflicts.iter().flat_map(move |(l, cs)| {
-                      cs.iter().map(move |c| (l, c))
-                  })
-              })
+              .flat_map(|state| &state.conflicts)
               .next()
               .unwrap();
 
-    println!("lookahead={:?} conflict={:?}",
-             lookahead, conflict);
+    println!("conflict={:?}", conflict);
 
-    match cx.classify(lookahead, conflict) {
+    match cx.classify(conflict) {
         ConflictClassification::Precedence {
             shift,
             reduce,
@@ -68,20 +63,15 @@ pub Expr: () = {
 "#);
     let states = build_states(&grammar, nt("Expr")).unwrap_err().states;
     let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let (&lookahead, conflict) =
+    let conflict =
         states.iter()
-              .flat_map(|state| {
-                  state.conflicts.iter().flat_map(move |(l, cs)| {
-                      cs.iter().map(move |c| (l, c))
-                  })
-              })
+              .flat_map(|state| &state.conflicts)
               .next()
               .unwrap();
 
-    println!("lookahead={:?} conflict={:?}",
-             lookahead, conflict);
+    println!("conflict={:?}", conflict);
 
-    match cx.classify(lookahead, conflict) {
+    match cx.classify(conflict) {
         ConflictClassification::InsufficientLookahead { .. } => { }
         r => panic!("wrong classification {:#?}", r)
     }
@@ -106,20 +96,15 @@ fn suggest_question_conflict() {
     let states = build_states(&grammar, nt("E")).unwrap_err().states;
 
     let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let (&lookahead, conflict) =
+    let conflict =
         states.iter()
-              .flat_map(|state| {
-                  state.conflicts.iter().flat_map(move |(l, cs)| {
-                      cs.iter().map(move |c| (l, c))
-                  })
-              })
+              .flat_map(|state| &state.conflicts)
               .next()
               .unwrap();
 
-    println!("lookahead={:?} conflict={:?}",
-             lookahead, conflict);
+    println!("conflict={:?}", conflict);
 
-    match cx.classify(lookahead, conflict) {
+    match cx.classify(conflict) {
         ConflictClassification::SuggestQuestion {
             shift: _,
             reduce: _,
@@ -153,20 +138,15 @@ Ident = r#"[a-zA-Z][a-zA-Z0-9]*"#;
     let states = build_states(&grammar, nt("ImportDecl")).unwrap_err().states;
 
     let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let (&lookahead, conflict) =
+    let conflict =
         states.iter()
-              .flat_map(|state| {
-                  state.conflicts.iter().flat_map(move |(l, cs)| {
-                      cs.iter().map(move |c| (l, c))
-                  })
-              })
+              .flat_map(|state| &state.conflicts)
               .next()
               .unwrap();
 
-    println!("lookahead={:?} conflict={:?}",
-             lookahead, conflict);
+    println!("conflict={:?}", conflict);
 
-    match cx.classify(lookahead, conflict) {
+    match cx.classify(conflict) {
         ConflictClassification::SuggestInline {
             shift: _,
             reduce: _,

--- a/lalrpop/src/lr1/error/test.rs
+++ b/lalrpop/src/lr1/error/test.rs
@@ -25,11 +25,8 @@ pub Ty: () = {
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
     let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let conflict =
-        states.iter()
-              .flat_map(|state| &state.conflicts)
-              .next()
-              .unwrap();
+    let conflicts = super::token_conflicts(&states);
+    let conflict = &conflicts[0];
 
     println!("conflict={:?}", conflict);
 
@@ -66,11 +63,8 @@ pub Expr: () = {
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let states = build_states(&grammar, nt("Expr")).unwrap_err().states;
     let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let conflict =
-        states.iter()
-              .flat_map(|state| &state.conflicts)
-              .next()
-              .unwrap();
+    let conflicts = super::token_conflicts(&states);
+    let conflict = &conflicts[0];
 
     println!("conflict={:?}", conflict);
 
@@ -100,11 +94,8 @@ fn suggest_question_conflict() {
     let states = build_states(&grammar, nt("E")).unwrap_err().states;
 
     let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let conflict =
-        states.iter()
-              .flat_map(|state| &state.conflicts)
-              .next()
-              .unwrap();
+    let conflicts = super::token_conflicts(&states);
+    let conflict = &conflicts[0];
 
     println!("conflict={:?}", conflict);
 
@@ -141,13 +132,9 @@ Ident = r#"[a-zA-Z][a-zA-Z0-9]*"#;
 "##);
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let states = build_states(&grammar, nt("ImportDecl")).unwrap_err().states;
-
     let mut cx = ErrorReportingCx::new(&grammar, &states);
-    let conflict =
-        states.iter()
-              .flat_map(|state| &state.conflicts)
-              .next()
-              .unwrap();
+    let conflicts = super::token_conflicts(&states);
+    let conflict = &conflicts[0];
 
     println!("conflict={:?}", conflict);
 

--- a/lalrpop/src/lr1/error/test.rs
+++ b/lalrpop/src/lr1/error/test.rs
@@ -1,6 +1,7 @@
 use intern::intern;
 use grammar::repr::*;
 use lr1::build_states;
+use lr1::tls::Lr1Tls;
 use test_util::normalized_grammar;
 use tls::Tls;
 
@@ -21,6 +22,7 @@ pub Ty: () = {
     <t1:Ty> "->" <t2:Ty> => (),
 };
 "#);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
     let mut cx = ErrorReportingCx::new(&grammar, &states);
     let conflict =
@@ -61,6 +63,7 @@ pub Expr: () = {
     "if" Expr "{" "}" => (),
 };
 "#);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let states = build_states(&grammar, nt("Expr")).unwrap_err().states;
     let mut cx = ErrorReportingCx::new(&grammar, &states);
     let conflict =
@@ -93,6 +96,7 @@ fn suggest_question_conflict() {
             "L"
         };
 "#);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let states = build_states(&grammar, nt("E")).unwrap_err().states;
 
     let mut cx = ErrorReportingCx::new(&grammar, &states);
@@ -135,6 +139,7 @@ Path: () = {
 
 Ident = r#"[a-zA-Z][a-zA-Z0-9]*"#;
 "##);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let states = build_states(&grammar, nt("ImportDecl")).unwrap_err().states;
 
     let mut cx = ErrorReportingCx::new(&grammar, &states);

--- a/lalrpop/src/lr1/example/mod.rs
+++ b/lalrpop/src/lr1/example/mod.rs
@@ -3,7 +3,7 @@
 use ascii_canvas::{AsciiView};
 use message::Content;
 use message::builder::InlineBuilder;
-use grammar::repr::{NonterminalString, Symbol};
+use grammar::repr::*;
 use std::fmt::{Debug, Formatter, Error};
 use style::Style;
 use tls::Tls;

--- a/lalrpop/src/lr1/first/mod.rs
+++ b/lalrpop/src/lr1/first/mod.rs
@@ -2,13 +2,13 @@
 
 use collections::{Map, map};
 use grammar::repr::*;
-use lr1::lookahead::{Lookahead, LookaheadSet};
+use lr1::lookahead::{Token, TokenSet};
 
 #[cfg(test)]
 mod test;
 
 pub struct FirstSets {
-    map: Map<NonterminalString, LookaheadSet>
+    map: Map<NonterminalString, TokenSet>
 }
 
 impl FirstSets {
@@ -21,23 +21,23 @@ impl FirstSets {
                                                   .flat_map(|p| &p.productions) {
                 let nt = production.nonterminal;
                 let (lookahead, _) =
-                    this.first(grammar, &production.symbols, Lookahead::EOF);
+                    this.first(grammar, &production.symbols, Token::EOF);
                 let first_set =
-                    this.map.entry(nt).or_insert_with(|| LookaheadSet::new(grammar));
+                    this.map.entry(nt).or_insert_with(|| TokenSet::new(grammar));
                 changed |= first_set.insert_set(&lookahead);
             }
         }
         this
     }
 
-    pub fn first(&self, grammar: &Grammar, symbols: &[Symbol], lookahead: Lookahead)
-                 -> (LookaheadSet, bool) {
-        let mut result = LookaheadSet::new(grammar);
+    pub fn first(&self, grammar: &Grammar, symbols: &[Symbol], lookahead: Token)
+                 -> (TokenSet, bool) {
+        let mut result = TokenSet::new(grammar);
 
         for symbol in symbols {
             match *symbol {
                 Symbol::Terminal(t) => {
-                    result.insert(grammar, Lookahead::Terminal(t));
+                    result.insert(grammar, Token::Terminal(t));
                     return (result, false);
                 }
 
@@ -56,10 +56,10 @@ impl FirstSets {
                         Some(set) => {
                             for lookahead in set.iter(grammar) {
                                 match lookahead {
-                                    Lookahead::EOF => {
+                                    Token::EOF => {
                                         empty_prod = true;
                                     }
-                                    Lookahead::Terminal(_) => {
+                                    Token::Terminal(_) => {
                                         result.insert(grammar, lookahead);
                                     }
                                 }

--- a/lalrpop/src/lr1/first/mod.rs
+++ b/lalrpop/src/lr1/first/mod.rs
@@ -24,7 +24,7 @@ impl FirstSets {
                 let lookahead = this.first0(&production.symbols);
                 let first_set =
                     this.map.entry(nt).or_insert_with(|| TokenSet::new());
-                changed |= first_set.insert_set(&lookahead);
+                changed |= first_set.union_with(&lookahead);
             }
         }
         this
@@ -83,7 +83,7 @@ impl FirstSets {
         result
     }
 
-    pub fn first1(&self, symbols: &[Symbol], lookahead: Token)
+    pub fn first1(&self, symbols: &[Symbol], lookahead: TokenSet)
                   -> TokenSet
     {
         let mut set = self.first0(symbols);
@@ -92,7 +92,7 @@ impl FirstSets {
         let epsilon = set.take_eof();
 
         if epsilon {
-            set.insert(lookahead);
+            set.union_with(&lookahead);
         }
 
         set

--- a/lalrpop/src/lr1/first/mod.rs
+++ b/lalrpop/src/lr1/first/mod.rs
@@ -20,8 +20,7 @@ impl FirstSets {
             for production in grammar.nonterminals.values()
                                                   .flat_map(|p| &p.productions) {
                 let nt = production.nonterminal;
-                let (lookahead, _) =
-                    this.first(grammar, &production.symbols, Token::EOF);
+                let lookahead = this.first0(grammar, &production.symbols);
                 let first_set =
                     this.map.entry(nt).or_insert_with(|| TokenSet::new(grammar));
                 changed |= first_set.insert_set(&lookahead);
@@ -75,6 +74,8 @@ impl FirstSets {
             }
         }
 
+        // control only reaches here if either symbols is empty, or it
+        // consists of nonterminals all of which may match epsilon
         result.insert(grammar, Token::EOF);
         result
     }

--- a/lalrpop/src/lr1/first/mod.rs
+++ b/lalrpop/src/lr1/first/mod.rs
@@ -7,6 +7,7 @@ use lr1::lookahead::{Token, TokenSet};
 #[cfg(test)]
 mod test;
 
+#[derive(Clone)]
 pub struct FirstSets {
     map: Map<NonterminalString, TokenSet>
 }
@@ -29,10 +30,12 @@ impl FirstSets {
         this
     }
 
-    /// Returns `FIRST(...symbols)`. If `...symbols` may match
+    /// Returns `FIRST(...symbols)`. If `...symbols` may derive
     /// epsilon, then this returned set will include EOF. (This is
     /// kind of repurposing EOF to serve as a binary flag of sorts.)
-    pub fn first0(&self, grammar: &Grammar, symbols: &[Symbol]) -> TokenSet {
+    pub fn first0<'s,I>(&self, grammar: &Grammar, symbols: I) -> TokenSet
+        where I: IntoIterator<Item=&'s Symbol>
+    {
         let mut result = TokenSet::new(grammar);
 
         for symbol in symbols {
@@ -75,7 +78,7 @@ impl FirstSets {
         }
 
         // control only reaches here if either symbols is empty, or it
-        // consists of nonterminals all of which may match epsilon
+        // consists of nonterminals all of which may derive epsilon
         result.insert(grammar, Token::EOF);
         result
     }
@@ -85,7 +88,7 @@ impl FirstSets {
     {
         let mut set = self.first0(grammar, symbols);
 
-        // we use EOF as the signal that `symbols` matches epsilon:
+        // we use EOF as the signal that `symbols` derives epsilon:
         let epsilon = set.take_eof(grammar);
 
         if epsilon {

--- a/lalrpop/src/lr1/first/test.rs
+++ b/lalrpop/src/lr1/first/test.rs
@@ -2,6 +2,7 @@ use intern::intern;
 use grammar::repr::*;
 use lr1::lookahead::Token;
 use lr1::lookahead::Token::EOF;
+use lr1::tls::Lr1Tls;
 use test_util::{normalized_grammar};
 use super::FirstSets;
 
@@ -17,23 +18,21 @@ fn la(t: &str) -> Token {
     Token::Terminal(TerminalString::quoted(intern(t)))
 }
 
-fn first0(grammar: &Grammar,
-          first: &FirstSets,
+fn first0(first: &FirstSets,
           symbols: &[Symbol])
           -> Vec<Token>
 {
-    let v = first.first0(grammar, symbols);
-    v.iter(grammar).collect()
+    let v = first.first0(symbols);
+    v.iter().collect()
 }
 
-fn first1(grammar: &Grammar,
-          first: &FirstSets,
+fn first1(first: &FirstSets,
           symbols: &[Symbol],
           lookahead: Token)
           -> Vec<Token>
 {
-    let v = first.first1(grammar, symbols, lookahead);
-    v.iter(grammar).collect()
+    let v = first.first1(symbols, lookahead);
+    v.iter().collect()
 }
 
 #[test]
@@ -47,22 +46,23 @@ fn basic_first1() {
     };
     X = "E"; // intentionally unreachable
 "#);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
 
     assert_eq!(
-        first1(&grammar, &first_sets, &[nt("A")], EOF),
+        first1(&first_sets, &[nt("A")], EOF),
         vec![la("C"), la("D")]);
 
     assert_eq!(
-        first1(&grammar, &first_sets, &[nt("B")], EOF),
+        first1(&first_sets, &[nt("B")], EOF),
         vec![la("D"), EOF]);
 
     assert_eq!(
-        first1(&grammar, &first_sets, &[nt("B"), term("E")], EOF),
+        first1(&first_sets, &[nt("B"), term("E")], EOF),
         vec![la("D"), la("E")]);
 
     assert_eq!(
-        first1(&grammar, &first_sets, &[nt("B"), nt("X")], EOF),
+        first1(&first_sets, &[nt("B"), nt("X")], EOF),
         vec![la("D"), la("E")]);
 }
 
@@ -77,25 +77,26 @@ fn basic_first0() {
     };
     X = "E"; // intentionally unreachable
 "#);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
 
     assert_eq!(
-        first0(&grammar, &first_sets, &[nt("A")]),
+        first0(&first_sets, &[nt("A")]),
         vec![la("C"), la("D")]);
 
     assert_eq!(
-        first0(&grammar, &first_sets, &[nt("B")]),
+        first0(&first_sets, &[nt("B")]),
         vec![la("D"), EOF]);
 
     assert_eq!(
-        first0(&grammar, &first_sets, &[nt("B"), term("E")]),
+        first0(&first_sets, &[nt("B"), term("E")]),
         vec![la("D"), la("E")]);
 
     assert_eq!(
-        first0(&grammar, &first_sets, &[nt("B"), nt("X")]),
+        first0(&first_sets, &[nt("B"), nt("X")]),
         vec![la("D"), la("E")]);
 
     assert_eq!(
-        first0(&grammar, &first_sets, &[nt("X")]),
+        first0(&first_sets, &[nt("X")]),
         vec![la("E")]);
 }

--- a/lalrpop/src/lr1/first/test.rs
+++ b/lalrpop/src/lr1/first/test.rs
@@ -1,7 +1,7 @@
 use intern::intern;
 use grammar::repr::*;
-use lr1::lookahead::Lookahead;
-use lr1::lookahead::Lookahead::EOF;
+use lr1::lookahead::Token;
+use lr1::lookahead::Token::EOF;
 use test_util::{normalized_grammar};
 use super::FirstSets;
 
@@ -13,15 +13,15 @@ pub fn term(t: &str) -> Symbol {
     Symbol::Terminal(TerminalString::quoted(intern(t)))
 }
 
-fn la(t: &str) -> Lookahead {
-    Lookahead::Terminal(TerminalString::quoted(intern(t)))
+fn la(t: &str) -> Token {
+    Token::Terminal(TerminalString::quoted(intern(t)))
 }
 
 fn first(grammar: &Grammar,
          first: &FirstSets,
          symbols: &[Symbol],
-         lookahead: Lookahead)
-         -> Vec<Lookahead>
+         lookahead: Token)
+         -> Vec<Token>
 {
     let (v, _) = first.first(grammar, symbols, lookahead);
     v.iter(grammar).collect()

--- a/lalrpop/src/lr1/first/test.rs
+++ b/lalrpop/src/lr1/first/test.rs
@@ -1,6 +1,6 @@
 use intern::intern;
 use grammar::repr::*;
-use lr1::lookahead::Token;
+use lr1::lookahead::{Token, TokenSet};
 use lr1::lookahead::Token::EOF;
 use lr1::tls::Lr1Tls;
 use test_util::{normalized_grammar};
@@ -31,7 +31,7 @@ fn first1(first: &FirstSets,
           lookahead: Token)
           -> Vec<Token>
 {
-    let v = first.first1(symbols, lookahead);
+    let v = first.first1(symbols, TokenSet::from(lookahead));
     v.iter().collect()
 }
 

--- a/lalrpop/src/lr1/first/test.rs
+++ b/lalrpop/src/lr1/first/test.rs
@@ -17,18 +17,27 @@ fn la(t: &str) -> Token {
     Token::Terminal(TerminalString::quoted(intern(t)))
 }
 
-fn first(grammar: &Grammar,
-         first: &FirstSets,
-         symbols: &[Symbol],
-         lookahead: Token)
-         -> Vec<Token>
+fn first0(grammar: &Grammar,
+          first: &FirstSets,
+          symbols: &[Symbol])
+          -> Vec<Token>
 {
-    let (v, _) = first.first(grammar, symbols, lookahead);
+    let v = first.first0(grammar, symbols);
+    v.iter(grammar).collect()
+}
+
+fn first1(grammar: &Grammar,
+          first: &FirstSets,
+          symbols: &[Symbol],
+          lookahead: Token)
+          -> Vec<Token>
+{
+    let v = first.first1(grammar, symbols, lookahead);
     v.iter(grammar).collect()
 }
 
 #[test]
-fn basic() {
+fn basic_first1() {
     let grammar = normalized_grammar(r#"
     grammar;
     A = B "C";
@@ -41,18 +50,52 @@ fn basic() {
     let first_sets = FirstSets::new(&grammar);
 
     assert_eq!(
-        first(&grammar, &first_sets, &[nt("A")], EOF),
+        first1(&grammar, &first_sets, &[nt("A")], EOF),
         vec![la("C"), la("D")]);
 
     assert_eq!(
-        first(&grammar, &first_sets, &[nt("B")], EOF),
+        first1(&grammar, &first_sets, &[nt("B")], EOF),
         vec![la("D"), EOF]);
 
     assert_eq!(
-        first(&grammar, &first_sets, &[nt("B"), term("E")], EOF),
+        first1(&grammar, &first_sets, &[nt("B"), term("E")], EOF),
         vec![la("D"), la("E")]);
 
     assert_eq!(
-        first(&grammar, &first_sets, &[nt("B"), nt("X")], EOF),
+        first1(&grammar, &first_sets, &[nt("B"), nt("X")], EOF),
         vec![la("D"), la("E")]);
+}
+
+#[test]
+fn basic_first0() {
+    let grammar = normalized_grammar(r#"
+    grammar;
+    A = B "C";
+    B: Option<u32> = {
+        "D" => Some(1),
+        => None
+    };
+    X = "E"; // intentionally unreachable
+"#);
+    let first_sets = FirstSets::new(&grammar);
+
+    assert_eq!(
+        first0(&grammar, &first_sets, &[nt("A")]),
+        vec![la("C"), la("D")]);
+
+    assert_eq!(
+        first0(&grammar, &first_sets, &[nt("B")]),
+        vec![la("D"), EOF]);
+
+    assert_eq!(
+        first0(&grammar, &first_sets, &[nt("B"), term("E")]),
+        vec![la("D"), la("E")]);
+
+    assert_eq!(
+        first0(&grammar, &first_sets, &[nt("B"), nt("X")]),
+        vec![la("D"), la("E")]);
+
+    assert_eq!(
+        first0(&grammar, &first_sets, &[nt("X")]),
+        vec![la("E")]);
 }

--- a/lalrpop/src/lr1/interpret.rs
+++ b/lalrpop/src/lr1/interpret.rs
@@ -8,10 +8,10 @@ use std::iter::IntoIterator;
 use std::fmt::{Debug, Display, Formatter, Error};
 use util::Sep;
 
-pub type InterpretError<'grammar> = (&'grammar State<'grammar>, Lookahead);
+pub type InterpretError<'grammar> = (&'grammar LR1State<'grammar>, Lookahead);
 
 /// Feed in the given tokens and then EOF, returning the final parse tree that is reduced.
-pub fn interpret<'grammar,TOKENS>(states: &'grammar [State<'grammar>], tokens: TOKENS)
+pub fn interpret<'grammar,TOKENS>(states: &'grammar [LR1State<'grammar>], tokens: TOKENS)
                          -> Result<ParseTree, InterpretError<'grammar>>
     where TOKENS: IntoIterator<Item=TerminalString>
 {
@@ -20,8 +20,10 @@ pub fn interpret<'grammar,TOKENS>(states: &'grammar [State<'grammar>], tokens: T
 }
 
 /// Feed in the given tokens and returns the states on the stack.
-pub fn interpret_partial<'grammar,TOKENS>(states: &'grammar [State<'grammar>], tokens: TOKENS)
-                                          -> Result<Vec<StateIndex>, InterpretError<'grammar>>
+pub fn interpret_partial<'grammar,TOKENS>(states: &'grammar [LR1State<'grammar>],
+                                          tokens: TOKENS)
+                                          -> Result<Vec<StateIndex>,
+                                                    InterpretError<'grammar>>
     where TOKENS: IntoIterator<Item=TerminalString>
 {
     let mut m = Machine::new(states);
@@ -30,19 +32,19 @@ pub fn interpret_partial<'grammar,TOKENS>(states: &'grammar [State<'grammar>], t
 }
 
 struct Machine<'grammar> {
-    states: &'grammar [State<'grammar>],
+    states: &'grammar [LR1State<'grammar>],
     state_stack: Vec<StateIndex>,
     data_stack: Vec<ParseTree>,
 }
 
 impl<'grammar> Machine<'grammar> {
-    fn new(states: &'grammar [State<'grammar>]) -> Machine<'grammar> {
+    fn new(states: &'grammar [LR1State<'grammar>]) -> Machine<'grammar> {
         Machine { states: states,
                   state_stack: vec![],
                   data_stack: vec![] }
     }
 
-    fn top_state(&self) -> &'grammar State<'grammar> {
+    fn top_state(&self) -> &'grammar LR1State<'grammar> {
         let index = self.state_stack.last().unwrap();
         &self.states[index.0]
     }

--- a/lalrpop/src/lr1/interpret.rs
+++ b/lalrpop/src/lr1/interpret.rs
@@ -164,16 +164,23 @@ pub trait LookaheadInterpret: Lookahead {
 
 impl LookaheadInterpret for Nil {
     fn reduction<'grammar>(state: &State<'grammar, Self>,
-                           token: Token)
-                           -> Option<&'grammar Production> {
-        state.reductions.values().next().cloned()
+                           _token: Token)
+                           -> Option<&'grammar Production>
+    {
+        state.reductions.iter()
+                        .map(|&(_, production)| production)
+                        .next()
     }
 }
 
 impl LookaheadInterpret for Token {
     fn reduction<'grammar>(state: &State<'grammar, Self>,
                            token: Token)
-                           -> Option<&'grammar Production> {
-        state.reductions.get(&token).cloned()
+                           -> Option<&'grammar Production>
+    {
+        state.reductions.iter()
+                        .filter(|&&(token1, _)| token == token1)
+                        .map(|&(_, production)| production)
+                        .next()
     }
 }

--- a/lalrpop/src/lr1/interpret.rs
+++ b/lalrpop/src/lr1/interpret.rs
@@ -1,57 +1,65 @@
 //! LR(1) interpeter. Just builds up parse trees. Intended for testing.
 
 use lr1::core::*;
-use lr1::lookahead::Token;
+use lr1::lookahead::*;
 use generate::ParseTree;
 use grammar::repr::*;
 use std::iter::IntoIterator;
 use std::fmt::{Debug, Display, Formatter, Error};
 use util::Sep;
 
-pub type InterpretError<'grammar> = (&'grammar LR1State<'grammar>, Token);
+pub type InterpretError<'grammar, L> = (&'grammar State<'grammar, L>, Token);
 
 /// Feed in the given tokens and then EOF, returning the final parse tree that is reduced.
-pub fn interpret<'grammar,TOKENS>(states: &'grammar [LR1State<'grammar>], tokens: TOKENS)
-                         -> Result<ParseTree, InterpretError<'grammar>>
-    where TOKENS: IntoIterator<Item=TerminalString>
+pub fn interpret<'grammar, TOKENS, L>(states: &'grammar [State<'grammar, L>],
+                                      tokens: TOKENS)
+                                      -> Result<ParseTree, InterpretError<'grammar, L>>
+    where TOKENS: IntoIterator<Item = TerminalString>,
+          L: LookaheadInterpret
 {
     let mut m = Machine::new(states);
     m.execute(tokens.into_iter())
 }
 
 /// Feed in the given tokens and returns the states on the stack.
-pub fn interpret_partial<'grammar,TOKENS>(states: &'grammar [LR1State<'grammar>],
-                                          tokens: TOKENS)
-                                          -> Result<Vec<StateIndex>,
-                                                    InterpretError<'grammar>>
-    where TOKENS: IntoIterator<Item=TerminalString>
+pub fn interpret_partial<'grammar, TOKENS, L>
+    (states: &'grammar [State<'grammar, L>],
+     tokens: TOKENS)
+     -> Result<Vec<StateIndex>, InterpretError<'grammar, L>>
+    where TOKENS: IntoIterator<Item = TerminalString>,
+          L: LookaheadInterpret
 {
     let mut m = Machine::new(states);
     try!(m.execute_partial(tokens.into_iter()));
     Ok(m.state_stack)
 }
 
-struct Machine<'grammar> {
-    states: &'grammar [LR1State<'grammar>],
+struct Machine<'grammar, L: LookaheadInterpret + 'grammar> {
+    states: &'grammar [State<'grammar, L>],
     state_stack: Vec<StateIndex>,
     data_stack: Vec<ParseTree>,
 }
 
-impl<'grammar> Machine<'grammar> {
-    fn new(states: &'grammar [LR1State<'grammar>]) -> Machine<'grammar> {
-        Machine { states: states,
-                  state_stack: vec![],
-                  data_stack: vec![] }
+impl<'grammar, L> Machine<'grammar, L>
+    where L: LookaheadInterpret
+{
+    fn new(states: &'grammar [State<'grammar, L>]) -> Machine<'grammar, L> {
+        Machine {
+            states: states,
+            state_stack: vec![],
+            data_stack: vec![],
+        }
     }
 
-    fn top_state(&self) -> &'grammar LR1State<'grammar> {
+    fn top_state(&self) -> &'grammar State<'grammar, L> {
         let index = self.state_stack.last().unwrap();
         &self.states[index.0]
     }
 
-    fn execute_partial<TOKENS>(&mut self, mut tokens: TOKENS)
-                               -> Result<(), InterpretError<'grammar>>
-        where TOKENS: Iterator<Item=TerminalString>
+    fn execute_partial<TOKENS>(&mut self,
+                               mut tokens: TOKENS)
+                               -> Result<(), InterpretError<'grammar, L>>
+        where TOKENS: Iterator<Item = TerminalString>
     {
         assert!(self.state_stack.is_empty());
         assert!(self.data_stack.is_empty());
@@ -67,7 +75,7 @@ impl<'grammar> Machine<'grammar> {
                 self.data_stack.push(ParseTree::Terminal(terminal));
                 self.state_stack.push(next_index);
                 token = tokens.next();
-            } else if let Some(&production) = state.reductions.get(&Token::Terminal(terminal)) {
+            } else if let Some(production) = L::reduction(state, Token::Terminal(terminal)) {
                 let more = self.reduce(production);
                 assert!(more);
             } else {
@@ -78,18 +86,19 @@ impl<'grammar> Machine<'grammar> {
         Ok(())
     }
 
-    fn execute<TOKENS>(&mut self, tokens: TOKENS)
-                           -> Result<ParseTree, InterpretError<'grammar>>
-        where TOKENS: Iterator<Item=TerminalString>
+    fn execute<TOKENS>(&mut self, tokens: TOKENS) -> Result<ParseTree, InterpretError<'grammar, L>>
+        where TOKENS: Iterator<Item = TerminalString>
     {
         try!(self.execute_partial(tokens));
 
         // drain now for EOF
         loop {
             let state = self.top_state();
-            match state.reductions.get(&Token::EOF) {
-                None => { return Err((state, Token::EOF)); }
-                Some(&production) => {
+            match L::reduction(state, Token::EOF) {
+                None => {
+                    return Err((state, Token::EOF));
+                }
+                Some(production) => {
                     if !self.reduce(production) {
                         assert_eq!(self.data_stack.len(), 1);
                         return Ok(self.data_stack.pop().unwrap());
@@ -104,13 +113,13 @@ impl<'grammar> Machine<'grammar> {
 
         // remove the top N items from the data stack
         let mut popped = vec![];
-        for _ in 0 .. args {
+        for _ in 0..args {
             popped.push(self.data_stack.pop().unwrap());
         }
         popped.reverse();
 
         // remove the top N states
-        for _ in 0 .. args {
+        for _ in 0..args {
             self.state_stack.pop().unwrap();
         }
 
@@ -144,5 +153,27 @@ impl Display for ParseTree {
             ParseTree::Nonterminal(id, ref trees) => write!(fmt, "[{}: {}]", id, Sep(", ", trees)),
             ParseTree::Terminal(id) => write!(fmt, "{}", id),
         }
+    }
+}
+
+pub trait LookaheadInterpret: Lookahead {
+    fn reduction<'grammar>(state: &State<'grammar, Self>,
+                           token: Token)
+                           -> Option<&'grammar Production>;
+}
+
+impl LookaheadInterpret for Nil {
+    fn reduction<'grammar>(state: &State<'grammar, Self>,
+                           token: Token)
+                           -> Option<&'grammar Production> {
+        state.reductions.values().next().cloned()
+    }
+}
+
+impl LookaheadInterpret for Token {
+    fn reduction<'grammar>(state: &State<'grammar, Self>,
+                           token: Token)
+                           -> Option<&'grammar Production> {
+        state.reductions.get(&token).cloned()
     }
 }

--- a/lalrpop/src/lr1/interpret.rs
+++ b/lalrpop/src/lr1/interpret.rs
@@ -43,7 +43,8 @@ struct Machine<'grammar, L: LookaheadInterpret + 'grammar> {
 impl<'grammar, L> Machine<'grammar, L>
     where L: LookaheadInterpret
 {
-    fn new(states: &'grammar [State<'grammar, L>]) -> Machine<'grammar, L> {
+    fn new(states: &'grammar [State<'grammar, L>])
+           -> Machine<'grammar, L> {
         Machine {
             states: states,
             state_stack: vec![],
@@ -69,6 +70,9 @@ impl<'grammar, L> Machine<'grammar, L>
         let mut token = tokens.next();
         while let Some(terminal) = token {
             let state = self.top_state();
+
+            println!("state={:?}", state);
+            println!("terminal={:?}", terminal);
 
             // check whether we can shift this token
             if let Some(&next_index) = state.shifts.get(&terminal) {
@@ -109,6 +113,8 @@ impl<'grammar, L> Machine<'grammar, L>
     }
 
     fn reduce(&mut self, production: &Production) -> bool {
+        println!("reduce={:?}", production);
+
         let args = production.symbols.len();
 
         // remove the top N items from the data stack
@@ -173,13 +179,13 @@ impl LookaheadInterpret for Nil {
     }
 }
 
-impl LookaheadInterpret for Token {
+impl LookaheadInterpret for TokenSet {
     fn reduction<'grammar>(state: &State<'grammar, Self>,
                            token: Token)
                            -> Option<&'grammar Production>
     {
         state.reductions.iter()
-                        .filter(|&&(token1, _)| token == token1)
+                        .filter(|&&(ref tokens, _)| tokens.contains(token))
                         .map(|&(_, production)| production)
                         .next()
     }

--- a/lalrpop/src/lr1/interpret.rs
+++ b/lalrpop/src/lr1/interpret.rs
@@ -1,14 +1,14 @@
 //! LR(1) interpeter. Just builds up parse trees. Intended for testing.
 
 use lr1::core::*;
-use lr1::lookahead::Lookahead;
+use lr1::lookahead::Token;
 use generate::ParseTree;
 use grammar::repr::*;
 use std::iter::IntoIterator;
 use std::fmt::{Debug, Display, Formatter, Error};
 use util::Sep;
 
-pub type InterpretError<'grammar> = (&'grammar LR1State<'grammar>, Lookahead);
+pub type InterpretError<'grammar> = (&'grammar LR1State<'grammar>, Token);
 
 /// Feed in the given tokens and then EOF, returning the final parse tree that is reduced.
 pub fn interpret<'grammar,TOKENS>(states: &'grammar [LR1State<'grammar>], tokens: TOKENS)
@@ -63,8 +63,8 @@ impl<'grammar> Machine<'grammar> {
             let state = self.top_state();
 
             // check whether we can shift this token
-            match state.tokens.get(&Lookahead::Terminal(terminal)) {
-                None => { return Err((state, Lookahead::Terminal(terminal))); }
+            match state.tokens.get(&Token::Terminal(terminal)) {
+                None => { return Err((state, Token::Terminal(terminal))); }
 
                 Some(&Action::Shift(next_index)) => {
                     self.data_stack.push(ParseTree::Terminal(terminal));
@@ -91,8 +91,8 @@ impl<'grammar> Machine<'grammar> {
         // drain now for EOF
         loop {
             let state = self.top_state();
-            match state.tokens.get(&Lookahead::EOF) {
-                None => { return Err((state, Lookahead::EOF)); }
+            match state.tokens.get(&Token::EOF) {
+                None => { return Err((state, Token::EOF)); }
                 Some(&Action::Shift(_)) => { unreachable!("cannot shift EOF") }
                 Some(&Action::Reduce(production)) => {
                     if !self.reduce(production) {

--- a/lalrpop/src/lr1/lane_table/lane/mod.rs
+++ b/lalrpop/src/lr1/lane_table/lane/mod.rs
@@ -90,7 +90,7 @@ impl<'trace, 'grammar> LaneTracer<'trace, 'grammar> {
             let unshifted_item = Item { index: item.index - 1, ..item };
             let predecessors = self.state_graph.predecessors(state, shifted_symbol);
             for predecessor in predecessors {
-                self.table.add_successor(state, predecessor);
+                self.table.add_successor(predecessor, state);
                 self.continue_trace(predecessor, conflict, unshifted_item, visited);
             }
             return;

--- a/lalrpop/src/lr1/lane_table/lane/mod.rs
+++ b/lalrpop/src/lr1/lane_table/lane/mod.rs
@@ -47,8 +47,8 @@ impl<'trace, 'grammar> LaneTracer<'trace, 'grammar> {
         // around shifting terminal, so it must be a terminal)
         match item.shift_symbol() {
             Some((Symbol::Terminal(term), _)) => {
-                let mut token_set = TokenSet::new(self.grammar);
-                token_set.insert(self.grammar, Token::Terminal(term));
+                let mut token_set = TokenSet::new();
+                token_set.insert(Token::Terminal(term));
                 self.table.add_lookahead(state, conflict, &token_set);
             }
 
@@ -119,8 +119,8 @@ impl<'trace, 'grammar> LaneTracer<'trace, 'grammar> {
         for &pred_item in state_items.iter()
                                      .filter(|i| i.can_shift_nonterminal(nonterminal)) {
             let symbol_sets = pred_item.symbol_sets();
-            let mut first = self.first_sets.first0(self.grammar, symbol_sets.suffix);
-            let derives_epsilon = first.take_eof(self.grammar);
+            let mut first = self.first_sets.first0(symbol_sets.suffix);
+            let derives_epsilon = first.take_eof();
             self.table.add_lookahead(state, conflict, &first);
             if derives_epsilon {
                 self.continue_trace(state, conflict, pred_item, visited);

--- a/lalrpop/src/lr1/lane_table/lane/mod.rs
+++ b/lalrpop/src/lr1/lane_table/lane/mod.rs
@@ -1,0 +1,102 @@
+//! Code to trace out a single lane, collecting information into the
+//! lane table as we go.
+
+use collections::Set;
+
+pub struct LaneTracer<'trace, 'grammar: 'trace> {
+    grammar: &'trace Grammar,
+    states: &'trace [LR0State<'grammar>],
+    first_sets: FirstSets,
+    state_graph: StateGraph,
+    table: LaneTable,
+}
+
+impl<'trace, 'grammar> LaneTracer<'trace, 'grammar> {
+    pub fn new(grammar: &'grammar Grammar,
+               first_sets: &'trace FirstSets,
+               states: &'trace [LR0State<'grammar>],
+               state_graph: &'trace StateGraph)
+               -> Self {
+        LaneTracer {
+            grammar: grammar,
+            states: states,
+            first_sets: FirstSets::new(grammar),
+            state_graph: StateGraph::new(states),
+            table: LaneTable::new(),
+        }
+    }
+
+    pub fn start_trace(&mut self,
+                       state: StateIndex,
+                       conflict: ConflictIndex,
+                       item: LR0Item<'grammar>) {
+        let mut visited_set = Set::default();
+        self.continue_trace(state, item, &mut visited_set);
+    }
+
+    pub fn continue_trace(&mut self,
+                          state: StateIndex,
+                          conflict: ConflictIndex,
+                          item: LR0Item<'grammar>,
+                          visited: &mut Set<(StateIndex, LR0Item<'grammar>)>) {
+        if !visited.insert((state, item)) {
+            return;
+        }
+
+        if item.index > 0 {
+            // This item was reached by shifting some symbol.  We need
+            // to unshift that symbol, which means we walk backwards
+            // to predecessors of `state` in the state graph.
+            //
+            // Example:
+            //
+            //     X = ...p T (*) ...s
+            //
+            // Here we would be "unshifting" T, which means we will
+            // walk to predecessors of the current state that were
+            // reached by shifting T. Those predecessors will contain
+            // an item like `X = ...p (*) T ...s`, which we will then
+            // process in turn.
+            let shifted_symbol = item.production.symbols[item.index - 1];
+            let unshifted_item = Item { index: item.index - 1, ..item };
+            let predecessors = self.state_graph.predecessors(state, shifted_symbol);
+            for predecessor in predecessors {
+                self.add_successor(state, predecessor);
+                self.continue_trace(predecessor, unshifted_item, visited);
+            }
+            return;
+        }
+
+        // Either: we are in the start state, or this item was
+        // reached by an epsilon transition. We have to
+        // "unepsilon", which means that we search elsewhere in
+        // the state for where the epsilon transition could have
+        // come from.
+        //
+        // Example:
+        //
+        //     X = (*) ...
+        //
+        // We will search for other items in the same state like:
+        //
+        //     Y = ...p (*) X ...s
+        //
+        // We can then insert `FIRST(...s)` as lookahead for
+        // `conflict`. If `...s` may derive epsilon, though, we
+        // have to recurse and search with the previous item.
+
+        let state_items = self.states[state.0].items.vec;
+        for &pred_item in state_items.iter()
+                                     .filter(|i| i.can_shift_nonterminal(nonterminal)) {
+            let symbol_sets = pred_item.symbol_sets();
+            let mut first = self.first_sets.first0(self.grammar, symbol_sets.suffix);
+            let derives_epsilon = first.take_eof(self.grammar);
+            self.table.add_lookahead(state, conflict, &first);
+            if derives_epsilon {
+                self.continue_trace(state, conflict, pred_item, visited);
+            }
+        }
+
+        // need some logic for start state and eof
+    }
+}

--- a/lalrpop/src/lr1/lane_table/lane/mod.rs
+++ b/lalrpop/src/lr1/lane_table/lane/mod.rs
@@ -11,7 +11,6 @@ use lr1::state_graph::StateGraph;
 use super::table::{ConflictIndex, LaneTable};
 
 pub struct LaneTracer<'trace, 'grammar: 'trace> {
-    grammar: &'grammar Grammar,
     states: &'trace [LR0State<'grammar>],
     first_sets: FirstSets,
     state_graph: StateGraph,
@@ -24,7 +23,6 @@ impl<'trace, 'grammar> LaneTracer<'trace, 'grammar> {
                conflicts: usize)
                -> Self {
         LaneTracer {
-            grammar: grammar,
             states: states,
             first_sets: FirstSets::new(grammar),
             state_graph: StateGraph::new(states),

--- a/lalrpop/src/lr1/lane_table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)] // still working on this stuff!
+
 use collections::Set;
 use lr1::build;
 use lr1::core::*;
@@ -10,48 +12,45 @@ mod table;
 #[cfg(test)]
 mod test;
 
-pub fn build_lane_table_states<'grammar>
-    (grammar: &'grammar Grammar,
-     start: NonterminalString)
-     -> Result<Vec<LR1State<'grammar>>, LR1TableConstructionError<'grammar>> {
-    // Just plain assume that there will be some inconsistent states.
-    let lr0_states = match build::build_lr0_states(grammar, start) {
-        Ok(s) => s,
-        Err(e) => e.states,
+pub fn build_lane_table_states<'grammar>(grammar: &'grammar Grammar,
+                                         start: NonterminalString)
+                                         -> LR1Result<'grammar> {
+    let (lr0_states, lr0_conflicts) = match build::build_lr0_states(grammar, start) {
+        Ok(s) => (s, vec![]),
+        Err(e) => (e.states, e.conflicts),
     };
 
     unimplemented!()
 }
 
-fn conflicting_items<'grammar>(state: &LR0State<'grammar>)
-                               -> Set<LR0Item<'grammar>>
-{
+fn conflicting_items<'grammar>(state: &LR0State<'grammar>) -> Set<LR0Item<'grammar>> {
     let conflicts = Nil::conflicts(state);
 
-    let reductions1 =
-        conflicts.iter()
-                 .map(|c| Item::lr0(c.production, c.production.symbols.len()));
+    let reductions1 = conflicts.iter()
+                               .map(|c| Item::lr0(c.production, c.production.symbols.len()));
 
-    let reductions2 =
-        conflicts.iter()
-                 .filter_map(|c| match c.action {
-                     Action::Reduce(p) => Some(Item::lr0(p, p.symbols.len())),
-                     Action::Shift(..) => None,
-                 });
+    let reductions2 = conflicts.iter()
+                               .filter_map(|c| {
+                                   match c.action {
+                                       Action::Reduce(p) => Some(Item::lr0(p, p.symbols.len())),
+                                       Action::Shift(..) => None,
+                                   }
+                               });
 
-    let shifts =
-        conflicts.iter()
-                 .filter_map(|c| match c.action {
-                     Action::Shift(term, _) => Some(term),
-                     Action::Reduce(..) => None,
-                 })
-                 .flat_map(|term| {
-                     state.items
-                          .vec
-                          .iter()
-                          .filter(move |item| item.can_shift_terminal(term))
-                          .cloned()
-                 });
+    let shifts = conflicts.iter()
+                          .filter_map(|c| {
+                              match c.action {
+                                  Action::Shift(term, _) => Some(term),
+                                  Action::Reduce(..) => None,
+                              }
+                          })
+                          .flat_map(|term| {
+                              state.items
+                                   .vec
+                                   .iter()
+                                   .filter(move |item| item.can_shift_terminal(term))
+                                   .cloned()
+                          });
 
     reductions1.chain(reductions2).chain(shifts).collect()
 }

--- a/lalrpop/src/lr1/lane_table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/mod.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] // still working on this stuff!
+#![allow(dead_code)] // still building this
 
 use collections::Set;
 use lr1::build;
@@ -15,7 +15,7 @@ mod test;
 pub fn build_lane_table_states<'grammar>(grammar: &'grammar Grammar,
                                          start: NonterminalString)
                                          -> LR1Result<'grammar> {
-    let (lr0_states, lr0_conflicts) = match build::build_lr0_states(grammar, start) {
+    let (_lr0_states, _lr0_conflicts) = match build::build_lr0_states(grammar, start) {
         Ok(s) => (s, vec![]),
         Err(e) => (e.states, e.conflicts),
     };

--- a/lalrpop/src/lr1/lane_table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/mod.rs
@@ -1,0 +1,24 @@
+use collections::{map, Map};
+use itertools::Itertools;
+use lr1::build;
+use lr1::core::*;
+use lr1::lookahead::*;
+use grammar::repr::*;
+use std::rc::Rc;
+use tls::Tls;
+use util::map::Entry;
+
+mod table;
+
+pub fn build_lane_table_states<'grammar>
+    (grammar: &'grammar Grammar,
+     start: NonterminalString)
+     -> Result<Vec<LR1State<'grammar>>, LR1TableConstructionError<'grammar>> {
+    // Just plain assume that there will be some inconsistent states.
+    let lr0_states = match build::build_lr0_states(grammar, start) {
+        Ok(s) => s,
+        Err(e) => e.states,
+    };
+
+    unimplemented!()
+}

--- a/lalrpop/src/lr1/lane_table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // still building this
-
 use collections::Set;
 use lr1::build;
 use lr1::core::*;
@@ -12,13 +10,31 @@ mod table;
 #[cfg(test)]
 mod test;
 
+use self::lane::*;
+use self::table::*;
+
 pub fn build_lane_table_states<'grammar>(grammar: &'grammar Grammar,
                                          start: NonterminalString)
                                          -> LR1Result<'grammar> {
-    let (_lr0_states, _lr0_conflicts) = match build::build_lr0_states(grammar, start) {
+    let (lr0_states, lr0_conflicts) = match build::build_lr0_states(grammar, start) {
         Ok(s) => (s, vec![]),
         Err(e) => (e.states, e.conflicts),
     };
+
+    // this is mostly just dummy code to ensure that things get used
+    // and avoid dead-code warnings
+    for conflict in lr0_conflicts {
+        let inconsistent_state = &lr0_states[conflict.state.0];
+        let conflicting_items = conflicting_items(inconsistent_state);
+        println!("conflicting_items={:#?}", conflicting_items);
+        let mut tracer = LaneTracer::new(&grammar, &lr0_states, conflicting_items.len());
+        for (i, &conflicting_item) in conflicting_items.iter().enumerate() {
+            tracer.start_trace(inconsistent_state.index,
+                               ConflictIndex::new(i),
+                               conflicting_item);
+        }
+        let _ = tracer.into_table();
+    }
 
     unimplemented!()
 }

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -53,10 +53,9 @@ impl<'grammar> LaneTable<'grammar> {
                          state: StateIndex,
                          conflict: ConflictIndex,
                          tokens: &TokenSet) {
-        let grammar = self.grammar;
         self.lookaheads
             .entry((state, conflict))
-            .or_insert_with(|| TokenSet::new(grammar))
+            .or_insert_with(|| TokenSet::new())
             .insert_set(&tokens);
     }
 
@@ -85,7 +84,7 @@ impl<'grammar> Debug for LaneTable<'grammar> {
                 .chain((0..self.conflicts).map(|i| {
                     self.lookaheads
                         .get(&(index, ConflictIndex::new(i)))
-                        .map(|token_set| format!("{:?}", token_set.debug(self.grammar)))
+                        .map(|token_set| format!("{:?}", token_set))
                         .unwrap_or(String::new())
                 }))
                 .chain(Some(self.successors

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -56,7 +56,7 @@ impl<'grammar> LaneTable<'grammar> {
         self.lookaheads
             .entry((state, conflict))
             .or_insert_with(|| TokenSet::new())
-            .insert_set(&tokens);
+            .union_with(&tokens);
     }
 
     pub fn add_successor(&mut self, state: StateIndex, succ: StateIndex) {

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -18,21 +18,29 @@ use grammar::repr::*;
 use lr1::core::*;
 use lr1::lookahead::*;
 use std::default::Default;
+use std::fmt::{Debug, Error, Formatter};
+use std::iter;
 
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub struct ConflictIndex {
-    index: u32
+    index: usize,
+}
+
+impl ConflictIndex {
+    pub fn new(index: usize) -> ConflictIndex {
+        ConflictIndex { index: index }
+    }
 }
 
 pub struct LaneTable<'grammar> {
     grammar: &'grammar Grammar,
-    conflicts: u32,
+    conflicts: usize,
     lookaheads: Map<(StateIndex, ConflictIndex), TokenSet>,
     successors: Multimap<StateIndex, Set<StateIndex>>,
 }
 
 impl<'grammar> LaneTable<'grammar> {
-    fn new(grammar: &'grammar Grammar, conflicts: u32) -> LaneTable {
+    pub fn new(grammar: &'grammar Grammar, conflicts: usize) -> LaneTable {
         LaneTable {
             grammar: grammar,
             conflicts: conflicts,
@@ -41,21 +49,77 @@ impl<'grammar> LaneTable<'grammar> {
         }
     }
 
-    fn add_lookahead(&mut self,
-                     state: StateIndex,
-                     conflict: ConflictIndex,
-                     tokens: &TokenSet)
-    {
+    pub fn add_lookahead(&mut self,
+                         state: StateIndex,
+                         conflict: ConflictIndex,
+                         tokens: &TokenSet) {
         let grammar = self.grammar;
-        self.lookaheads.entry((state, conflict))
-                       .or_insert_with(|| TokenSet::new(grammar))
-                       .insert_set(&tokens);
+        self.lookaheads
+            .entry((state, conflict))
+            .or_insert_with(|| TokenSet::new(grammar))
+            .insert_set(&tokens);
     }
 
-    fn add_successor(&mut self,
-                     state: StateIndex,
-                     succ: StateIndex)
-    {
+    pub fn add_successor(&mut self, state: StateIndex, succ: StateIndex) {
         self.successors.push(state, succ);
+    }
+}
+
+impl<'grammar> Debug for LaneTable<'grammar> {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        let indices: Set<StateIndex> = self.lookaheads
+                                           .keys()
+                                           .map(|&(state, _)| state)
+                                           .chain(self.successors
+                                                      .iter()
+                                                      .map(|(key, _)| key.clone()))
+                                           .collect();
+
+        let header = iter::once(format!("State"))
+                         .chain((0..self.conflicts).map(|i| format!("C{}", i)))
+                         .chain(Some(format!("Successors")))
+                         .collect();
+
+        let rows = indices.iter().map(|&index| {
+            iter::once(format!("{:?}", index))
+                .chain((0..self.conflicts).map(|i| {
+                    self.lookaheads
+                        .get(&(index, ConflictIndex::new(i)))
+                        .map(|token_set| format!("{:?}", token_set.debug(self.grammar)))
+                        .unwrap_or(String::new())
+                }))
+                .chain(Some(self.successors
+                                .get(&index)
+                                .map(|c| format!("{:?}", c))
+                                .unwrap_or(String::new())))
+                .collect()
+        });
+
+        let table: Vec<Vec<_>> = iter::once(header).chain(rows).collect();
+
+        let columns = 2 + self.conflicts;
+
+        let widths: Vec<_> = (0..columns)
+                                 .map(|c| {
+                                     // find the max width of any row at this column
+                                     table.iter()
+                                          .map(|r| r[c].len())
+                                          .max()
+                                          .unwrap()
+                                 })
+                                 .collect();
+
+        for row in &table {
+            try!(write!(fmt, "| "));
+            for (i, column) in row.iter().enumerate() {
+                if i > 0 {
+                    try!(write!(fmt, " | "));
+                }
+                try!(write!(fmt, "{0:1$}", column, widths[i]));
+            }
+            try!(write!(fmt, " |\n"));
+        }
+
+        Ok(())
     }
 }

--- a/lalrpop/src/lr1/lane_table/table/mod.rs
+++ b/lalrpop/src/lr1/lane_table/table/mod.rs
@@ -1,0 +1,61 @@
+//! The "Lane Table". In the paper, this is depicted like so:
+//!
+//! ```
+//! +-------+----+-----+----+------------+
+//! + State | C1 | ... | Cn | Successors |
+//! +-------+----+-----+----+------------+
+//! ```
+//!
+//! where each row summarizes some state that potentially contributes
+//! lookahead to the conflict. The columns `Ci` represent each of the
+//! conflicts we are trying to disentangle; their values are each
+//! `TokenSet` indicating the lookahead contributing by this state.
+//! The Successors is a vector of further successors. For simplicity
+//! though we store this using maps, at least for now.
+
+use collections::{Map, Multimap, Set};
+use grammar::repr::*;
+use lr1::core::*;
+use lr1::lookahead::*;
+use std::default::Default;
+
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
+pub struct ConflictIndex {
+    index: u32
+}
+
+pub struct LaneTable<'grammar> {
+    grammar: &'grammar Grammar,
+    conflicts: u32,
+    lookaheads: Map<(StateIndex, ConflictIndex), TokenSet>,
+    successors: Multimap<StateIndex, Set<StateIndex>>,
+}
+
+impl<'grammar> LaneTable<'grammar> {
+    fn new(grammar: &'grammar Grammar, conflicts: u32) -> LaneTable {
+        LaneTable {
+            grammar: grammar,
+            conflicts: conflicts,
+            lookaheads: Map::default(),
+            successors: Multimap::default(),
+        }
+    }
+
+    fn add_lookahead(&mut self,
+                     state: StateIndex,
+                     conflict: ConflictIndex,
+                     tokens: &TokenSet)
+    {
+        let grammar = self.grammar;
+        self.lookaheads.entry((state, conflict))
+                       .or_insert_with(|| TokenSet::new(grammar))
+                       .insert_set(&tokens);
+    }
+
+    fn add_successor(&mut self,
+                     state: StateIndex,
+                     succ: StateIndex)
+    {
+        self.successors.push(state, succ);
+    }
+}

--- a/lalrpop/src/lr1/lane_table/test.rs
+++ b/lalrpop/src/lr1/lane_table/test.rs
@@ -89,8 +89,8 @@ fn small_conflict_1() {
     expect_debug(&table,
                  r#"
 | State | C0    | C1    | C2    | C3    | C4    | C5    | Successors |
-| S0    | ["c"] | ["c"] | ["c"] | ["d"] | ["d"] | ["d"] |            |
-| S3    | []    | []    | []    | []    | []    | []    | {S0, S3}   |
+| S0    |       | ["c"] |       |       | ["d"] |       | {S3}       |
+| S3    | ["e"] | []    | ["e"] | ["e"] | []    | ["e"] | {S3}       |
 "#
                      .trim_left());
 }

--- a/lalrpop/src/lr1/lane_table/test.rs
+++ b/lalrpop/src/lr1/lane_table/test.rs
@@ -4,6 +4,7 @@ use test_util::{compare, expect_debug, normalized_grammar};
 use lr1::build;
 use lr1::core::*;
 use lr1::interpret;
+use lr1::tls::Lr1Tls;
 use tls::Tls;
 
 use super::lane::*;
@@ -84,6 +85,7 @@ fn build_table<'grammar>(grammar: &'grammar Grammar,
 fn small_conflict_1() {
     let _tls = Tls::test();
     let grammar = paper_example_small();
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let table = build_table(&grammar, "G", &["e"]);
     println!("{:#?}", table);
     expect_debug(&table,
@@ -155,6 +157,7 @@ P: () = {
 fn large_conflict_1() {
     let _tls = Tls::test();
     let grammar = paper_example_large();
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let table = build_table(&grammar, "G", &["x", "s", "k", "t"]);
     println!("{:#?}", table);
     expect_debug(&table,

--- a/lalrpop/src/lr1/lane_table/test.rs
+++ b/lalrpop/src/lr1/lane_table/test.rs
@@ -1,0 +1,133 @@
+use intern::intern;
+use grammar::repr::*;
+use test_util::{compare, expect_debug, normalized_grammar};
+use lr1::build;
+use lr1::core::*;
+use tls::Tls;
+
+use super::lane::LaneTracer;
+use super::table::ConflictIndex;
+
+fn sym(t: &str) -> Symbol {
+    if t.chars().next().unwrap().is_uppercase() {
+        Symbol::Nonterminal(nt(t))
+    } else {
+        Symbol::Terminal(term(t))
+    }
+}
+
+fn term(t: &str) -> TerminalString {
+    TerminalString::Literal(TerminalLiteral::Quoted(intern(t)))
+}
+
+fn nt(t: &str) -> NonterminalString {
+    NonterminalString(intern(t))
+}
+
+/// A simplified version of the paper's initial grammar; this version
+/// only has one inconsistent state (the same state they talk about in
+/// the paper).
+pub fn paper_example_small() -> Grammar {
+    normalized_grammar(r#"
+grammar;
+
+pub G: () = {
+    X "c",
+    Y "d",
+};
+
+X: () = {
+    "e" X,
+    "e",
+};
+
+Y: () = {
+    "e" Y,
+    "e"
+};
+"#)
+}
+
+#[test]
+fn small_conflict_1() {
+    let _tls = Tls::test();
+    let grammar = paper_example_small();
+    let lr0_states = build::build_lr0_states(&grammar, nt("G")).unwrap_err().states;
+    assert_eq!(lr0_states.iter().filter(|s| !s.conflicts.is_empty()).count(), 1);
+    let inconsistent_state = lr0_states.iter()
+                                       .filter(|s| !s.conflicts.is_empty())
+                                       .next()
+                                       .unwrap();
+    let conflicting_items = super::conflicting_items(inconsistent_state);
+    println!("{:#?}", conflicting_items);
+    let mut tracer = LaneTracer::new(&grammar, &lr0_states, conflicting_items.len());
+    for (i, &conflicting_item) in conflicting_items.iter().enumerate() {
+        tracer.start_trace(inconsistent_state.index,
+                           ConflictIndex::new(i),
+                           conflicting_item);
+    }
+    let table = tracer.into_table();
+    println!("{:#?}", table);
+    expect_debug(&table, r#"
+| State | C0    | C1    | C2    | C3    | C4    | C5    | Successors |
+| S0    | ["c"] | ["c"] | ["c"] | ["d"] | ["d"] | ["d"] |            |
+| S3    | []    | []    | []    | []    | []    | []    | {S0, S3}   |
+"#.trim_left());
+}
+
+pub fn paper_example_large() -> Grammar {
+    normalized_grammar(r#"
+grammar;
+
+pub G: () = {
+    "x" W "a",
+    "x" V "t",
+    "y" W "b",
+    "y" V "t",
+    "z" W "r",
+    "z" V "b",
+    "u" U X "a",
+    "u" U Y "r",
+};
+
+W: () = {
+    U X C
+};
+
+V: () = {
+    U Y "d"
+};
+
+X: () = {
+    "k" "t" U X P,
+    "k" "t"
+};
+
+Y: () = {
+    "k" "t" U Y "u",
+    "k" "t"
+};
+
+U: () = {
+    U "k" "t",
+    "s"
+};
+
+E: () = {
+    "a",
+    "b",
+    "c",
+    "v",
+};
+
+C: () = {
+    "c",
+    "w"
+};
+
+P: () = {
+    "z"
+};
+"#)
+}
+

--- a/lalrpop/src/lr1/lane_table/test.rs
+++ b/lalrpop/src/lr1/lane_table/test.rs
@@ -1,6 +1,6 @@
 use intern::intern;
 use grammar::repr::*;
-use test_util::{compare, expect_debug, normalized_grammar};
+use test_util::{expect_debug, normalized_grammar};
 use lr1::build;
 use lr1::core::*;
 use lr1::interpret;

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -48,18 +48,18 @@ pub struct TokenSet {
 impl TokenSet {
     pub fn new(grammar: &Grammar) -> Self {
         TokenSet {
-            bit_set: BitSet::with_capacity(grammar.all_terminals.len() + 1)
+            bit_set: BitSet::with_capacity(grammar.terminals.all.len() + 1)
         }
     }
 
     fn eof_bit(&self, grammar: &Grammar) -> usize {
-        grammar.all_terminals.len()
+        grammar.terminals.all.len()
     }
 
     fn bit(&self, grammar: &Grammar, lookahead: Token) -> usize {
         match lookahead {
             Token::EOF => self.eof_bit(grammar),
-            Token::Terminal(t) => grammar.terminal_bits[&t],
+            Token::Terminal(t) => grammar.terminals.bits[&t],
         }
     }
 
@@ -133,10 +133,10 @@ impl<'iter> Iterator for TokenSetIter<'iter> {
     fn next(&mut self) -> Option<Token> {
         self.bit_set.next()
                     .map(|bit| {
-                        if bit == self.grammar.all_terminals.len() {
+                        if bit == self.grammar.terminals.all.len() {
                             Token::EOF
                         } else {
-                            Token::Terminal(self.grammar.all_terminals[bit])
+                            Token::Terminal(self.grammar.terminals.all[bit])
                         }
                     })
     }

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -52,9 +52,13 @@ impl TokenSet {
         }
     }
 
+    fn eof_bit(&self, grammar: &Grammar) -> usize {
+        grammar.all_terminals.len()
+    }
+
     fn bit(&self, grammar: &Grammar, lookahead: Token) -> usize {
         match lookahead {
-            Token::EOF => grammar.all_terminals.len(),
+            Token::EOF => self.eof_bit(grammar),
             Token::Terminal(t) => grammar.terminal_bits[&t],
         }
     }
@@ -76,6 +80,15 @@ impl TokenSet {
 
     pub fn contains(&self, grammar: &Grammar, lookahead: Token) -> bool {
         self.bit_set.contains(self.bit(grammar, lookahead))
+    }
+
+    /// If this set contains EOF, removes it from the set and returns
+    /// true. Otherwise, returns false.
+    pub fn take_eof(&mut self, grammar: &Grammar) -> bool {
+        let eof_bit = self.eof_bit(grammar);
+        let contains_eof = self.bit_set.contains(eof_bit);
+        self.bit_set.remove(eof_bit);
+        contains_eof
     }
 
     pub fn is_disjoint(&self, other: TokenSet) -> bool {

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -78,6 +78,10 @@ impl TokenSet {
         self.len() != len
     }
 
+    pub fn contains(&self, grammar: &Grammar, token: Token) -> bool {
+        self.bit_set.contains(self.bit(grammar, token))
+    }
+
     pub fn contains_eof(&self, grammar: &Grammar) -> bool {
         self.bit_set.contains(self.eof_bit(grammar))
     }

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -1,8 +1,9 @@
 use bit_set::{self, BitSet};
 use std::fmt::{Debug, Formatter, Error};
+use std::hash::Hash;
 use grammar::repr::*;
 
-pub trait Lookahead: Clone + Debug + PartialEq + Eq + PartialOrd + Ord {
+pub trait Lookahead: Copy + Debug + Eq + Ord + Hash {
     fn fmt_as_item_suffix(&self, fmt: &mut Formatter) -> Result<(), Error>;
 }
 
@@ -15,9 +16,9 @@ impl Lookahead for Nil {
     }
 }
 
-/// I have semi-arbitrarily decided to say that a "token" is either
-/// one of the terminals of our language, or else the pseudo-symbol
-/// EOF that represents "end of input".
+/// I have semi-arbitrarily decided to use the term "token" to mean
+/// either one of the terminals of our language, or else the
+/// pseudo-symbol EOF that represents "end of input".
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Token {
     EOF,

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -78,8 +78,8 @@ impl TokenSet {
         self.len() != len
     }
 
-    pub fn contains(&self, grammar: &Grammar, lookahead: Token) -> bool {
-        self.bit_set.contains(self.bit(grammar, lookahead))
+    pub fn contains_eof(&self, grammar: &Grammar) -> bool {
+        self.bit_set.contains(self.eof_bit(grammar))
     }
 
     /// If this set contains EOF, removes it from the set and returns

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -2,6 +2,19 @@ use bit_set::{self, BitSet};
 use std::fmt::{Debug, Formatter, Error};
 use grammar::repr::*;
 
+pub trait Lookahead: Clone + Debug + PartialEq + Eq + PartialOrd + Ord {
+    fn fmt_as_item_suffix(&self, fmt: &mut Formatter) -> Result<(), Error>;
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Nil;
+
+impl Lookahead for Nil {
+    fn fmt_as_item_suffix(&self, _fmt: &mut Formatter) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
 /// I have semi-arbitrarily decided to say that a "token" is either
 /// one of the terminals of our language, or else the pseudo-symbol
 /// EOF that represents "end of input".
@@ -9,6 +22,12 @@ use grammar::repr::*;
 pub enum Token {
     EOF,
     Terminal(TerminalString),
+}
+
+impl Lookahead for Token {
+    fn fmt_as_item_suffix(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        write!(fmt, " [{}]", self)
+    }
 }
 
 impl Token {

--- a/lalrpop/src/lr1/lookahead.rs
+++ b/lalrpop/src/lr1/lookahead.rs
@@ -72,6 +72,11 @@ impl TokenSet {
         self.bit_set.insert(bit)
     }
 
+    pub fn insert_eof(&mut self, grammar: &Grammar) -> bool {
+        let bit = self.eof_bit(grammar);
+        self.bit_set.insert(bit)
+    }
+
     pub fn insert_set(&mut self, set: &TokenSet) -> bool {
         let len = self.len();
         self.bit_set.union_with(&set.bit_set);

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -10,6 +10,7 @@ mod core;
 mod error;
 mod example;
 mod first;
+mod lane_table;
 mod lookahead;
 mod trace;
 mod state_graph;

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -16,14 +16,14 @@ mod state_graph;
 
 #[cfg(test)] mod interpret;
 
-use self::core::{State};
+use self::core::LR1State;
 
 pub use self::core::TableConstructionError;
 pub use self::error::report_error;
 
 pub fn build_states<'grammar>(grammar: &'grammar Grammar,
                               start: NonterminalString)
-                              -> Result<Vec<State<'grammar>>,
+                              -> Result<Vec<LR1State<'grammar>>,
                                         TableConstructionError<'grammar>>
 {
     match grammar.algorithm {

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -21,14 +21,12 @@ mod trace;
 
 use self::core::LR1State;
 
-pub use self::core::LR1TableConstructionError;
+pub use self::core::{LR1Result, LR1TableConstructionError};
 pub use self::error::report_error;
 
 pub fn build_states<'grammar>(grammar: &'grammar Grammar,
                               start: NonterminalString)
-                              -> Result<Vec<LR1State<'grammar>>,
-                                        LR1TableConstructionError<'grammar>>
-{
+                              -> LR1Result<'grammar> {
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
 
     match grammar.algorithm {

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -1,6 +1,7 @@
 //! Naive LR(1) generation algorithm.
 
 use grammar::repr::*;
+use self::tls::Lr1Tls;
 
 pub mod ascent;
 
@@ -12,8 +13,9 @@ mod example;
 mod first;
 mod lane_table;
 mod lookahead;
-mod trace;
 mod state_graph;
+mod tls;
+mod trace;
 
 #[cfg(test)] mod interpret;
 
@@ -27,6 +29,8 @@ pub fn build_states<'grammar>(grammar: &'grammar Grammar,
                               -> Result<Vec<LR1State<'grammar>>,
                                         LR1TableConstructionError<'grammar>>
 {
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
+
     match grammar.algorithm {
         Algorithm::LR1 => build::build_lr1_states(grammar, start),
         Algorithm::LALR1 => build_lalr::build_lalr_states(grammar, start),

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -19,8 +19,6 @@ mod trace;
 
 #[cfg(test)] mod interpret;
 
-use self::core::LR1State;
-
 pub use self::core::{LR1Result, LR1TableConstructionError};
 pub use self::error::report_error;
 

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -18,13 +18,13 @@ mod state_graph;
 
 use self::core::LR1State;
 
-pub use self::core::TableConstructionError;
+pub use self::core::LR1TableConstructionError;
 pub use self::error::report_error;
 
 pub fn build_states<'grammar>(grammar: &'grammar Grammar,
                               start: NonterminalString)
                               -> Result<Vec<LR1State<'grammar>>,
-                                        TableConstructionError<'grammar>>
+                                        LR1TableConstructionError<'grammar>>
 {
     match grammar.algorithm {
         Algorithm::LR1 => build::build_lr1_states(grammar, start),

--- a/lalrpop/src/lr1/state_graph.rs
+++ b/lalrpop/src/lr1/state_graph.rs
@@ -10,7 +10,7 @@ pub struct StateGraph {
 }
 
 impl StateGraph {
-    pub fn new<'grammar>(states: &[State<'grammar>]) -> StateGraph {
+    pub fn new<'grammar>(states: &[LR1State<'grammar>]) -> StateGraph {
         let mut graph = Graph::new();
 
         // First, create the nodes.

--- a/lalrpop/src/lr1/state_graph.rs
+++ b/lalrpop/src/lr1/state_graph.rs
@@ -1,5 +1,6 @@
 use grammar::repr::*;
 use lr1::core::*;
+use lr1::lookahead::Lookahead;
 use petgraph::{EdgeDirection, Graph};
 use petgraph::graph::NodeIndex;
 
@@ -10,7 +11,9 @@ pub struct StateGraph {
 }
 
 impl StateGraph {
-    pub fn new<'grammar>(states: &[LR1State<'grammar>]) -> StateGraph {
+    pub fn new<'grammar, L>(states: &[State<'grammar, L>]) -> StateGraph
+        where L: Lookahead
+    {
         let mut graph = Graph::new();
 
         // First, create the nodes.

--- a/lalrpop/src/lr1/state_graph.rs
+++ b/lalrpop/src/lr1/state_graph.rs
@@ -85,4 +85,15 @@ impl StateGraph {
                   .map(|(succ, _)| StateIndex(succ.index()))
                   .collect()
     }
+
+    pub fn predecessors(&self,
+                        state_index: StateIndex,
+                        symbol: Symbol)
+                        -> Vec<StateIndex> {
+        self.graph.edges_directed(NodeIndex::new(state_index.0),
+                                  EdgeDirection::Incoming)
+                  .filter(|&(_, s)| *s == symbol)
+                  .map(|(pred, _)| StateIndex(pred.index()))
+                  .collect()
+    }
 }

--- a/lalrpop/src/lr1/state_graph.rs
+++ b/lalrpop/src/lr1/state_graph.rs
@@ -25,20 +25,11 @@ impl StateGraph {
             // - shifts (found in the `conflicts` and `tokens` maps)
             // - gotos (found in the `gotos` map)
             graph.extend_with_edges(
-                state.conflicts
+                state.shifts
                      .iter()
-                     .filter_map(|conflict| {
-                         match conflict.action {
-                             Action::Shift(state) => {
-                                 Some((conflict.lookahead.unwrap_terminal(), state))
-                             }
-                             Action::Reduce(_) => None,
-                         }
+                     .map(|(&terminal, &state)| {
+                         (Symbol::Terminal(terminal), state)
                      })
-                     .chain(
-                         state.shifts.iter()
-                                     .map(|(&terminal, &state)| (terminal, state)))
-                     .map(|(terminal, state)| (Symbol::Terminal(terminal), state))
                      .chain(
                          state.gotos
                               .iter()

--- a/lalrpop/src/lr1/state_graph.rs
+++ b/lalrpop/src/lr1/state_graph.rs
@@ -27,17 +27,18 @@ impl StateGraph {
             graph.extend_with_edges(
                 state.conflicts
                      .iter()
-                     .flat_map(|(lookahead, conflicts)| {
-                         conflicts.iter()
-                                  .map(move |conflict| (lookahead, &conflict.action))
-                     })
-                     .chain(state.tokens.iter())
-                     .filter_map(|(l, action)| match *action {
-                         Action::Reduce(_) => None,
-                         Action::Shift(target) => {
-                             Some((Symbol::Terminal(l.unwrap_terminal()), target))
+                     .filter_map(|conflict| {
+                         match conflict.action {
+                             Action::Shift(state) => {
+                                 Some((conflict.lookahead.unwrap_terminal(), state))
+                             }
+                             Action::Reduce(_) => None,
                          }
                      })
+                     .chain(
+                         state.shifts.iter()
+                                     .map(|(&terminal, &state)| (terminal, state)))
+                     .map(|(terminal, state)| (Symbol::Terminal(terminal), state))
                      .chain(
                          state.gotos
                               .iter()

--- a/lalrpop/src/lr1/tls.rs
+++ b/lalrpop/src/lr1/tls.rs
@@ -26,6 +26,14 @@ impl Lr1Tls {
     pub fn terminals() -> Arc<TerminalSet> {
         TERMINALS.with(|s| s.borrow().clone().expect("LR1 TLS not installed"))
     }
+
+    pub fn with<OP,RET>(op: OP) -> RET
+        where OP: FnOnce(&TerminalSet) -> RET
+    {
+        TERMINALS.with(|s| {
+            op(s.borrow().as_ref().expect("LR1 TLS not installed"))
+        })
+    }
 }
 
 impl Drop for Lr1Tls {

--- a/lalrpop/src/lr1/tls.rs
+++ b/lalrpop/src/lr1/tls.rs
@@ -1,0 +1,36 @@
+//! Thread-local data specific to LR(1) processing.
+
+use grammar::repr::TerminalSet;
+use std::cell::RefCell;
+use std::mem;
+use std::sync::Arc;
+
+thread_local! {
+    static TERMINALS: RefCell<Option<Arc<TerminalSet>>> = RefCell::new(None)
+}
+
+pub struct Lr1Tls {
+    old_value: Option<Arc<TerminalSet>>
+}
+
+impl Lr1Tls {
+    pub fn install(terminals: TerminalSet) -> Lr1Tls {
+        let old_value = TERMINALS.with(|s| {
+            let mut s = s.borrow_mut();
+            mem::replace(&mut *s, Some(Arc::new(terminals)))
+        });
+
+        Lr1Tls { old_value: old_value }
+    }
+
+    pub fn terminals() -> Arc<TerminalSet> {
+        TERMINALS.with(|s| s.borrow().clone().expect("LR1 TLS not installed"))
+    }
+}
+
+impl Drop for Lr1Tls {
+    fn drop(&mut self) {
+        TERMINALS.with(|s| *s.borrow_mut() = self.old_value.take());
+    }
+}
+

--- a/lalrpop/src/lr1/tls.rs
+++ b/lalrpop/src/lr1/tls.rs
@@ -23,10 +23,6 @@ impl Lr1Tls {
         Lr1Tls { old_value: old_value }
     }
 
-    pub fn terminals() -> Arc<TerminalSet> {
-        TERMINALS.with(|s| s.borrow().clone().expect("LR1 TLS not installed"))
-    }
-
     pub fn with<OP,RET>(op: OP) -> RET
         where OP: FnOnce(&TerminalSet) -> RET
     {

--- a/lalrpop/src/lr1/trace/mod.rs
+++ b/lalrpop/src/lr1/trace/mod.rs
@@ -9,7 +9,6 @@ mod shift;
 mod trace_graph;
 
 pub struct Tracer<'trace, 'grammar: 'trace> {
-    grammar: &'trace Grammar,
     states: &'trace [LR1State<'grammar>],
     first_sets: &'trace FirstSets,
     state_graph: StateGraph,
@@ -18,12 +17,10 @@ pub struct Tracer<'trace, 'grammar: 'trace> {
 }
 
 impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
-    pub fn new(grammar: &'grammar Grammar,
-               first_sets: &'trace FirstSets,
+    pub fn new(first_sets: &'trace FirstSets,
                states: &'trace [LR1State<'grammar>])
                -> Self {
         Tracer {
-            grammar: grammar,
             states: states,
             first_sets: first_sets,
             state_graph: StateGraph::new(states),

--- a/lalrpop/src/lr1/trace/mod.rs
+++ b/lalrpop/src/lr1/trace/mod.rs
@@ -10,7 +10,7 @@ mod trace_graph;
 
 pub struct Tracer<'trace, 'grammar: 'trace> {
     grammar: &'trace Grammar,
-    states: &'trace [State<'grammar>],
+    states: &'trace [LR1State<'grammar>],
     first_sets: FirstSets,
     state_graph: StateGraph,
     trace_graph: TraceGraph<'grammar>,
@@ -19,7 +19,7 @@ pub struct Tracer<'trace, 'grammar: 'trace> {
 
 impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
     pub fn new(grammar: &'grammar Grammar,
-               states: &'trace [State<'grammar>])
+               states: &'trace [LR1State<'grammar>])
                -> Self {
         Tracer {
             grammar: grammar,

--- a/lalrpop/src/lr1/trace/mod.rs
+++ b/lalrpop/src/lr1/trace/mod.rs
@@ -11,7 +11,7 @@ mod trace_graph;
 pub struct Tracer<'trace, 'grammar: 'trace> {
     grammar: &'trace Grammar,
     states: &'trace [LR1State<'grammar>],
-    first_sets: FirstSets,
+    first_sets: &'trace FirstSets,
     state_graph: StateGraph,
     trace_graph: TraceGraph<'grammar>,
     visited_set: Set<(StateIndex, NonterminalString)>,
@@ -19,12 +19,13 @@ pub struct Tracer<'trace, 'grammar: 'trace> {
 
 impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
     pub fn new(grammar: &'grammar Grammar,
+               first_sets: &'trace FirstSets,
                states: &'trace [LR1State<'grammar>])
                -> Self {
         Tracer {
             grammar: grammar,
             states: states,
-            first_sets: FirstSets::new(grammar),
+            first_sets: first_sets,
             state_graph: StateGraph::new(states),
             trace_graph: TraceGraph::new(),
             visited_set: set(),

--- a/lalrpop/src/lr1/trace/reduce/mod.rs
+++ b/lalrpop/src/lr1/trace/reduce/mod.rs
@@ -66,11 +66,11 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
         if !self.visited_set.insert((item_state, nonterminal)) {
             return;
         }
-        for &pred_item in self.states[item_state.0]
-                              .items
-                              .vec
-                              .iter()
-                              .filter(|i| i.can_shift_nonterminal(nonterminal)) {
+        for pred_item in self.states[item_state.0]
+                             .items
+                             .vec
+                             .iter()
+                             .filter(|i| i.can_shift_nonterminal(nonterminal)) {
             // Found a state:
             //
             //     Z = ...p (*) Y ...s
@@ -90,7 +90,7 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
                 //    [Z = ...p (*) Y ...s] -(...p,Y,...s)-> [Y]
                 //
                 // and stop.
-                self.trace_graph.add_edge(pred_item, nonterminal, symbol_sets);
+                self.trace_graph.add_edge(pred_item.to_lr0(), nonterminal, symbol_sets);
             } else {
                 // Add an edge
                 //

--- a/lalrpop/src/lr1/trace/reduce/mod.rs
+++ b/lalrpop/src/lr1/trace/reduce/mod.rs
@@ -81,8 +81,8 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
 
             let symbol_sets = pred_item.symbol_sets();
 
-            let first_suffix = self.first_sets.first0(self.grammar, symbol_sets.suffix);
-            let continue_tracing = first_suffix.contains_eof(self.grammar);
+            let first_suffix = self.first_sets.first0(symbol_sets.suffix);
+            let continue_tracing = first_suffix.contains_eof();
 
             if !continue_tracing {
                 // Add an edge

--- a/lalrpop/src/lr1/trace/reduce/mod.rs
+++ b/lalrpop/src/lr1/trace/reduce/mod.rs
@@ -1,5 +1,5 @@
 use lr1::core::*;
-use lr1::lookahead::Lookahead;
+use lr1::lookahead::Token;
 use grammar::repr::*;
 
 use super::Tracer;
@@ -64,7 +64,7 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
     fn trace_reduce_from_state(&mut self,
                                item_state: StateIndex,
                                nonterminal: NonterminalString, // "Y"
-                               lookahead: Lookahead) // "L"
+                               lookahead: Token) // "L"
     {
         if !self.visited_set.insert((item_state, nonterminal)) {
             return;
@@ -119,7 +119,7 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
     fn can_shift_with_lookahead(&self,
                                 item: LR1Item<'grammar>,
                                 nonterminal: NonterminalString,
-                                lookahead: Lookahead)
+                                lookahead: Token)
                                 -> CanShiftResult
     {
         if let Some((shifted, remainder)) = item.shift_symbol() {

--- a/lalrpop/src/lr1/trace/reduce/mod.rs
+++ b/lalrpop/src/lr1/trace/reduce/mod.rs
@@ -1,18 +1,15 @@
 use lr1::core::*;
-use lr1::lookahead::Token;
 use grammar::repr::*;
 
 use super::Tracer;
 use super::trace_graph::*;
-
-use self::CanShiftResult::*;
 
 #[cfg(test)] mod test;
 
 impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
     pub fn backtrace_reduce(mut self,
                             item_state: StateIndex,
-                            item: LR1Item<'grammar>)
+                            item: LR0Item<'grammar>)
                             -> TraceGraph<'grammar>
     {
         self.trace_reduce_item(item_state, item);
@@ -21,17 +18,17 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
 
     fn trace_reduce_item(&mut self,
                          item_state: StateIndex,
-                         item: LR1Item<'grammar>)
+                         item: LR0Item<'grammar>)
     {
         // We start out with an item
         //
-        //     X = ...p (*) ...s [L]
+        //     X = ...p (*) ...s
         //
-        // which we can (eventually) reduce when we see [L], though we
-        // may have to do some epsilon reductions first if ...s is
-        // non-empty.
+        // which we can (eventually) reduce, though we may have to do
+        // some epsilon reductions first if ...s is non-empty. We want
+        // to trace back until we have (at least) one element of
+        // context for the reduction.
         let nonterminal = item.production.nonterminal; // X
-        let lookahead = item.lookahead; // L
 
         // Add an edge
         //
@@ -48,103 +45,66 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
 
         // Add in edges from [X] to all the places [X] can be consumed.
         for pred_state in pred_states {
-            self.trace_reduce_from_state(pred_state, nonterminal, lookahead);
+            self.trace_reduce_from_state(pred_state, nonterminal);
         }
     }
 
-    // We know that we can reduce the nonterminal Y with lookahead
-    // L. We want to find out who will consume that reduced value. So
-    // search for those items that can shift an `X`:
+    // We know that we can reduce the nonterminal `Y`. We want to find
+    // at least one element of context, so we search back to find out
+    // who will consume that reduced value. So search for those items
+    // that can shift a `Y`:
     //
-    //     Z = ... (*) Y ...s [L1]
+    //     Z = ... (*) Y ...s
     //
-    // where L is in FIRST(...s, L1).
-    //
-    // (Note that `lookahead` remains constant for the entire reduce backtrace.)
+    // If we find that `...s` is potentially empty, then we haven't
+    // actually found any context, and so we may have to keep
+    // searching.
     fn trace_reduce_from_state(&mut self,
                                item_state: StateIndex,
-                               nonterminal: NonterminalString, // "Y"
-                               lookahead: Token) // "L"
+                               nonterminal: NonterminalString) // "Y"
     {
         if !self.visited_set.insert((item_state, nonterminal)) {
             return;
         }
-        for &pred_item in self.states[item_state.0].items.vec.iter() {
-            match self.can_shift_with_lookahead(pred_item, nonterminal, lookahead) {
-                CannotShift => { }
-                CanShift(maybe_empty) => {
-                    // Found a state:
-                    //
-                    //     Z = ...p (*) Y ...s [L1]
-                    //
-                    // where L is in FIRST(...s, L1). We need to
-                    // continue tracing back so long as the lookahead
-                    // may still have come from the surrounding
-                    // context. This can occur if `...x` may be empty
-                    // *and* the lookahead matches (if the lookahead
-                    // doesn't match, then the only source for L is
-                    // `...x`).
+        for &pred_item in self.states[item_state.0]
+                              .items
+                              .vec
+                              .iter()
+                              .filter(|i| i.can_shift_nonterminal(nonterminal)) {
+            // Found a state:
+            //
+            //     Z = ...p (*) Y ...s
+            //
+            // If `...s` does not match `\epsilon`, then we are done,
+            // because `FIRST(...s)` will provide a token of context.
+            // But otherwise we have to keep searching backwards.
 
-                    if !maybe_empty {
-                        // Add an edge
-                        //
-                        //    [Z = ...p (*) Y ...s] -(...p,Y,...s)-> [Y]
-                        //
-                        // and stop.
-                        self.trace_graph.add_edge(pred_item,
-                                                  nonterminal,
-                                                  pred_item.symbol_sets());
-                    } else {
-                        // Add an edge
-                        //
-                        //    [Z] -{..p}-> [Y]
-                        //
-                        // because we can reduce by consuming `...p`
-                        // tokens, and continue tracing.
-                        self.trace_graph.add_edge(
-                            pred_item.production.nonterminal,
-                            nonterminal,
-                            pred_item.symbol_sets());
+            let symbol_sets = pred_item.symbol_sets();
 
-                        self.trace_reduce_item(item_state, pred_item);
-                    }
-                }
+            let first_suffix = self.first_sets.first0(self.grammar, symbol_sets.suffix);
+            let continue_tracing = first_suffix.contains_eof(self.grammar);
+
+            if !continue_tracing {
+                // Add an edge
+                //
+                //    [Z = ...p (*) Y ...s] -(...p,Y,...s)-> [Y]
+                //
+                // and stop.
+                self.trace_graph.add_edge(pred_item, nonterminal, symbol_sets);
+            } else {
+                // Add an edge
+                //
+                //    [Z] -{..p}-> [Y]
+                //
+                // because we can reduce by consuming `...p`
+                // tokens, and continue tracing.
+                self.trace_graph.add_edge(pred_item.production.nonterminal,
+                                          nonterminal,
+                                          symbol_sets);
+
+                self.trace_reduce_item(item_state, pred_item.to_lr0());
             }
         }
     }
-
-    fn can_shift_with_lookahead(&self,
-                                item: LR1Item<'grammar>,
-                                nonterminal: NonterminalString,
-                                lookahead: Token)
-                                -> CanShiftResult
-    {
-        if let Some((shifted, remainder)) = item.shift_symbol() {
-            if shifted == Symbol::Nonterminal(nonterminal) {
-                let mut first = self.first_sets.first0(self.grammar, remainder);
-
-                // if the result contains EOF, then the suffix may
-                // match nothing; in that case, check the lookahead on
-                // the item itself
-                let epsilon = first.take_eof(self.grammar);
-                if epsilon {
-                    if item.lookahead == lookahead {
-                        return CanShift(true);
-                    }
-                }
-
-                // otherwise, the suffix always matches something; see
-                // if our intended lookahead is within
-                if first.contains(self.grammar, lookahead) {
-                    return CanShift(false);
-                }
-            }
-        }
-        CannotShift
-    }
 }
 
-enum CanShiftResult {
-    CannotShift,
-    CanShift(bool) // if true, remainder is maybe empty
-}

--- a/lalrpop/src/lr1/trace/reduce/mod.rs
+++ b/lalrpop/src/lr1/trace/reduce/mod.rs
@@ -12,7 +12,7 @@ use self::CanShiftResult::*;
 impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
     pub fn backtrace_reduce(mut self,
                             item_state: StateIndex,
-                            item: Item<'grammar>)
+                            item: LR1Item<'grammar>)
                             -> TraceGraph<'grammar>
     {
         self.trace_reduce_item(item_state, item);
@@ -21,7 +21,7 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
 
     fn trace_reduce_item(&mut self,
                          item_state: StateIndex,
-                         item: Item<'grammar>)
+                         item: LR1Item<'grammar>)
     {
         // We start out with an item
         //
@@ -117,7 +117,7 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
     }
 
     fn can_shift_with_lookahead(&self,
-                                item: Item<'grammar>,
+                                item: LR1Item<'grammar>,
                                 nonterminal: NonterminalString,
                                 lookahead: Lookahead)
                                 -> CanShiftResult

--- a/lalrpop/src/lr1/trace/reduce/test.rs
+++ b/lalrpop/src/lr1/trace/reduce/test.rs
@@ -133,16 +133,15 @@ pub Ty: () = {
 "#);
     let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
     let tracer = Tracer::new(&grammar, &states);
-    let (&lookahead, conflict) =
+    let conflict =
         states.iter()
-              .flat_map(|s| &s.conflicts)
-              .flat_map(|(l, cs)| cs.iter().map(move |c| (l, c)))
+              .flat_map(|state| &state.conflicts)
               .next()
               .unwrap();
     println!("conflict={:?}", conflict);
     let item = Item { production: conflict.production,
                       index: conflict.production.symbols.len(),
-                      lookahead: lookahead };
+                      lookahead: conflict.lookahead };
     println!("item={:?}", item);
     let backtrace = tracer.backtrace_reduce(conflict.state, item);
     println!("{:#?}", backtrace);
@@ -185,16 +184,15 @@ pub Ty: () = {
 };
 "#);
     let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
-    let (&lookahead, conflict) =
+    let conflict =
         states.iter()
-              .flat_map(|s| &s.conflicts)
-              .flat_map(|(l, cs)| cs.iter().map(move |c| (l, c)))
+              .flat_map(|state| &state.conflicts)
               .next()
               .unwrap();
     println!("conflict={:?}", conflict);
     let item = Item { production: conflict.production,
                       index: conflict.production.symbols.len(),
-                      lookahead: lookahead };
+                      lookahead: conflict.lookahead };
     println!("item={:?}", item);
     let tracer = Tracer::new(&grammar, &states);
     let graph = tracer.backtrace_reduce(conflict.state, item);

--- a/lalrpop/src/lr1/trace/reduce/test.rs
+++ b/lalrpop/src/lr1/trace/reduce/test.rs
@@ -55,7 +55,7 @@ fn backtrace1() {
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
     let states = build_states(&grammar, nt("Start")).unwrap();
-    let tracer = Tracer::new(&grammar, &first_sets, &states);
+    let tracer = Tracer::new(&first_sets, &states);
     let state_stack = interpret_partial(&states, terms!["Int"]).unwrap();
     let top_state = *state_stack.last().unwrap();
 
@@ -133,7 +133,7 @@ pub Ty: () = {
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
     let err = build_states(&grammar, nt("Ty")).unwrap_err();
-    let tracer = Tracer::new(&grammar, &first_sets, &err.states);
+    let tracer = Tracer::new(&first_sets, &err.states);
     let conflict = err.conflicts[0].clone();
     println!("conflict={:?}", conflict);
     let item = Item { production: conflict.production,
@@ -153,7 +153,7 @@ pub Ty: () = {
 
     // Check that we can successfully enumerate and paint the examples
     // here.
-    let pictures: Vec<_> = backtrace.lr1_examples(&grammar, &first_sets, &item)
+    let pictures: Vec<_> = backtrace.lr1_examples(&first_sets, &item)
                                     .map(|e| e.paint_unstyled())
                                     .collect();
     expect_debug(&pictures, r#"
@@ -189,7 +189,7 @@ pub Ty: () = {
                       index: conflict.production.symbols.len(),
                       lookahead: conflict.lookahead.clone() };
     println!("item={:?}", item);
-    let tracer = Tracer::new(&grammar, &first_sets, &err.states);
+    let tracer = Tracer::new(&first_sets, &err.states);
     let graph = tracer.backtrace_reduce(conflict.state, item.to_lr0());
     expect_debug(&graph, r#"
 [
@@ -201,7 +201,7 @@ pub Ty: () = {
 "#.trim());
 
     let list: Vec<_> =
-        graph.lr1_examples(&grammar, &first_sets, &item)
+        graph.lr1_examples(&first_sets, &item)
              .map(|example| example.paint_unstyled())
              .collect();
     expect_debug(&list, r#"
@@ -248,7 +248,7 @@ fn backtrace_filter() {
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let states = build_states(&grammar, nt("Start")).unwrap();
     let first_sets = FirstSets::new(&grammar);
-    let tracer = Tracer::new(&grammar, &first_sets, &states);
+    let tracer = Tracer::new(&first_sets, &states);
     let state_stack = interpret_partial(&states, terms!["Int"]).unwrap();
     let top_state = *state_stack.last().unwrap();
 
@@ -308,7 +308,7 @@ fn backtrace_filter() {
     // Select those with `;` as lookahead
     let semi_item = lr1_item.with_lookahead(TokenSet::from(semi));
     let pictures: Vec<_> =
-        backtrace.lr1_examples(&grammar, &first_sets, &semi_item)
+        backtrace.lr1_examples(&first_sets, &semi_item)
                  .map(|e| e.paint_unstyled())
                  .collect();
     expect_debug(&pictures, r#"

--- a/lalrpop/src/lr1/trace/reduce/test.rs
+++ b/lalrpop/src/lr1/trace/reduce/test.rs
@@ -3,7 +3,7 @@ use grammar::repr::*;
 use lr1::build_states;
 use lr1::core::Item;
 use lr1::interpret::interpret_partial;
-use lr1::lookahead::Lookahead;
+use lr1::lookahead::Token;
 use test_util::{expect_debug, normalized_grammar};
 use tls::Tls;
 
@@ -63,7 +63,7 @@ fn backtrace1() {
     // Expr = "Int" (*) [";"]
     //
     // Select the last one.
-    let semi = Lookahead::Terminal(term(";"));
+    let semi = Token::Terminal(term(";"));
     let semi_item = states[top_state.0].items.vec.iter()
                                                  .filter(|item| item.lookahead == semi)
                                                  .next()
@@ -101,7 +101,7 @@ fn backtrace2() {
     // Expr = "Int" (*) [";"]
     //
     // Select the last one.
-    let plus = Lookahead::Terminal(term("+"));
+    let plus = Token::Terminal(term("+"));
     let plus_item = states[top_state.0].items.vec.iter()
                                                  .filter(|item| item.lookahead == plus)
                                                  .next()

--- a/lalrpop/src/lr1/trace/reduce/test.rs
+++ b/lalrpop/src/lr1/trace/reduce/test.rs
@@ -5,6 +5,7 @@ use lr1::core::Item;
 use lr1::first::FirstSets;
 use lr1::interpret::interpret_partial;
 use lr1::lookahead::Token;
+use lr1::tls::Lr1Tls;
 use test_util::{expect_debug, normalized_grammar};
 use tls::Tls;
 
@@ -51,6 +52,7 @@ fn test_grammar1() -> Grammar {
 fn backtrace1() {
     let _tls = Tls::test();
     let grammar = test_grammar1();
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
     let states = build_states(&grammar, nt("Start")).unwrap();
     let tracer = Tracer::new(&grammar, &first_sets, &states);
@@ -126,6 +128,7 @@ pub Ty: () = {
     <t1:Ty> "->" <t2:Ty> => (),
 };
 "#);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
     let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
     let tracer = Tracer::new(&grammar, &first_sets, &states);
@@ -179,6 +182,7 @@ pub Ty: () = {
     <t1:Ty> "->" <t2:Ty> => (),
 };
 "#);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
     let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
     let conflict =
@@ -247,6 +251,7 @@ fn backtrace_filter() {
         "Int",
     };
 "#);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let states = build_states(&grammar, nt("Start")).unwrap();
     let first_sets = FirstSets::new(&grammar);
     let tracer = Tracer::new(&grammar, &first_sets, &states);

--- a/lalrpop/src/lr1/trace/reduce/test.rs
+++ b/lalrpop/src/lr1/trace/reduce/test.rs
@@ -132,13 +132,9 @@ pub Ty: () = {
 "#);
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
-    let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
-    let tracer = Tracer::new(&grammar, &first_sets, &states);
-    let conflict =
-        states.iter()
-              .flat_map(|state| &state.conflicts)
-              .next()
-              .unwrap();
+    let err = build_states(&grammar, nt("Ty")).unwrap_err();
+    let tracer = Tracer::new(&grammar, &first_sets, &err.states);
+    let conflict = err.conflicts[0].clone();
     println!("conflict={:?}", conflict);
     let item = Item { production: conflict.production,
                       index: conflict.production.symbols.len(),
@@ -186,18 +182,14 @@ pub Ty: () = {
 "#);
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
-    let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
-    let conflict =
-        states.iter()
-              .flat_map(|state| &state.conflicts)
-              .next()
-              .unwrap();
+    let err = build_states(&grammar, nt("Ty")).unwrap_err();
+    let conflict = err.conflicts[0].clone();
     println!("conflict={:?}", conflict);
     let item = Item { production: conflict.production,
                       index: conflict.production.symbols.len(),
                       lookahead: conflict.lookahead.clone() };
     println!("item={:?}", item);
-    let tracer = Tracer::new(&grammar, &first_sets, &states);
+    let tracer = Tracer::new(&grammar, &first_sets, &err.states);
     let graph = tracer.backtrace_reduce(conflict.state, item.to_lr0());
     expect_debug(&graph, r#"
 [

--- a/lalrpop/src/lr1/trace/shift/mod.rs
+++ b/lalrpop/src/lr1/trace/shift/mod.rs
@@ -95,7 +95,7 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
     }
 
     fn can_shift(&self,
-                 item: Item<'grammar>,
+                 item: LR1Item<'grammar>,
                  nonterminal: NonterminalString)
                  -> bool
     {

--- a/lalrpop/src/lr1/trace/shift/mod.rs
+++ b/lalrpop/src/lr1/trace/shift/mod.rs
@@ -72,7 +72,7 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
                            nonterminal: NonterminalString) // "Y"
     {
         if self.visited_set.insert((item_state, nonterminal)) {
-            for &pred_item in self.states[item_state.0].items.vec.iter() {
+            for pred_item in self.states[item_state.0].items.vec.iter() {
                 if pred_item.can_shift_nonterminal(nonterminal) {
                     if pred_item.index > 0 {
                         // Add an edge:

--- a/lalrpop/src/lr1/trace/shift/mod.rs
+++ b/lalrpop/src/lr1/trace/shift/mod.rs
@@ -73,7 +73,7 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
     {
         if self.visited_set.insert((item_state, nonterminal)) {
             for &pred_item in self.states[item_state.0].items.vec.iter() {
-                if self.can_shift(pred_item, nonterminal) {
+                if pred_item.can_shift_nonterminal(nonterminal) {
                     if pred_item.index > 0 {
                         // Add an edge:
                         //
@@ -91,17 +91,6 @@ impl<'trace, 'grammar> Tracer<'trace, 'grammar> {
                     }
                 }
             }
-        }
-    }
-
-    fn can_shift(&self,
-                 item: LR1Item<'grammar>,
-                 nonterminal: NonterminalString)
-                 -> bool
-    {
-        match item.shift_symbol() {
-            Some((Symbol::Nonterminal(shifted), _)) => shifted == nonterminal,
-            _ => false,
         }
     }
 }

--- a/lalrpop/src/lr1/trace/shift/test.rs
+++ b/lalrpop/src/lr1/trace/shift/test.rs
@@ -43,7 +43,7 @@ pub Ty: () = {
     //     Ty = Ty -> Ty (*) (reduce)
 
     assert!(conflict.production.symbols.len() == 3);
-    let item = Item { production: conflict.production, index: 1, lookahead: () };
+    let item = Item::lr0(conflict.production, 1);
     println!("item={:?}", item);
     let tracer = Tracer::new(&grammar, &states);
     let graph = tracer.backtrace_shift(conflict.state, item);

--- a/lalrpop/src/lr1/trace/shift/test.rs
+++ b/lalrpop/src/lr1/trace/shift/test.rs
@@ -29,12 +29,8 @@ pub Ty: () = {
 "#);
     let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
-    let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
-    let conflict =
-        states.iter()
-              .flat_map(|s| &s.conflicts)
-              .next()
-              .unwrap();
+    let err = build_states(&grammar, nt("Ty")).unwrap_err();
+    let conflict = err.conflicts[0].clone();
     println!("conflict={:?}", conflict);
 
     // Gin up the LR0 item involved in the shift/reduce conflict:
@@ -48,7 +44,7 @@ pub Ty: () = {
     assert!(conflict.production.symbols.len() == 3);
     let item = Item::lr0(conflict.production, 1);
     println!("item={:?}", item);
-    let tracer = Tracer::new(&grammar, &first_sets, &states);
+    let tracer = Tracer::new(&grammar, &first_sets, &err.states);
     let graph = tracer.backtrace_shift(conflict.state, item);
     expect_debug(&graph, r#"
 [

--- a/lalrpop/src/lr1/trace/shift/test.rs
+++ b/lalrpop/src/lr1/trace/shift/test.rs
@@ -44,7 +44,7 @@ pub Ty: () = {
     assert!(conflict.production.symbols.len() == 3);
     let item = Item::lr0(conflict.production, 1);
     println!("item={:?}", item);
-    let tracer = Tracer::new(&grammar, &first_sets, &err.states);
+    let tracer = Tracer::new(&first_sets, &err.states);
     let graph = tracer.backtrace_shift(conflict.state, item);
     expect_debug(&graph, r#"
 [

--- a/lalrpop/src/lr1/trace/shift/test.rs
+++ b/lalrpop/src/lr1/trace/shift/test.rs
@@ -3,6 +3,7 @@ use grammar::repr::*;
 use lr1::build_states;
 use lr1::core::*;
 use lr1::first::FirstSets;
+use lr1::tls::Lr1Tls;
 use test_util::{expect_debug, normalized_grammar};
 use tls::Tls;
 
@@ -26,6 +27,7 @@ pub Ty: () = {
     <t1:Ty> "->" <t2:Ty> => (),
 };
 "#);
+    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let first_sets = FirstSets::new(&grammar);
     let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
     let conflict =

--- a/lalrpop/src/lr1/trace/shift/test.rs
+++ b/lalrpop/src/lr1/trace/shift/test.rs
@@ -43,7 +43,7 @@ pub Ty: () = {
     //     Ty = Ty -> Ty (*) (reduce)
 
     assert!(conflict.production.symbols.len() == 3);
-    let item = LR0Item { production: conflict.production, index: 1 };
+    let item = Item { production: conflict.production, index: 1, lookahead: () };
     println!("item={:?}", item);
     let tracer = Tracer::new(&grammar, &states);
     let graph = tracer.backtrace_shift(conflict.state, item);

--- a/lalrpop/src/lr1/trace/shift/test.rs
+++ b/lalrpop/src/lr1/trace/shift/test.rs
@@ -28,8 +28,7 @@ pub Ty: () = {
     let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
     let conflict =
         states.iter()
-              .flat_map(|s| s.conflicts.values())
-              .flat_map(|cs| cs.iter())
+              .flat_map(|s| &s.conflicts)
               .next()
               .unwrap();
     println!("conflict={:?}", conflict);

--- a/lalrpop/src/lr1/trace/shift/test.rs
+++ b/lalrpop/src/lr1/trace/shift/test.rs
@@ -2,6 +2,7 @@ use intern::intern;
 use grammar::repr::*;
 use lr1::build_states;
 use lr1::core::*;
+use lr1::first::FirstSets;
 use test_util::{expect_debug, normalized_grammar};
 use tls::Tls;
 
@@ -25,6 +26,7 @@ pub Ty: () = {
     <t1:Ty> "->" <t2:Ty> => (),
 };
 "#);
+    let first_sets = FirstSets::new(&grammar);
     let states = build_states(&grammar, nt("Ty")).unwrap_err().states;
     let conflict =
         states.iter()
@@ -44,7 +46,7 @@ pub Ty: () = {
     assert!(conflict.production.symbols.len() == 3);
     let item = Item::lr0(conflict.production, 1);
     println!("item={:?}", item);
-    let tracer = Tracer::new(&grammar, &states);
+    let tracer = Tracer::new(&grammar, &first_sets, &states);
     let graph = tracer.backtrace_shift(conflict.state, item);
     expect_debug(&graph, r#"
 [
@@ -55,7 +57,7 @@ pub Ty: () = {
 "#.trim());
 
     let list: Vec<_> =
-        graph.examples(item)
+        graph.lr0_examples(item)
              .map(|example| example.paint_unstyled())
              .collect();
     expect_debug(&list, r#"

--- a/lalrpop/src/lr1/trace/trace_graph/mod.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/mod.rs
@@ -151,11 +151,6 @@ impl<'grammar> Debug for TraceGraph<'grammar> {
 pub struct PathEnumerator<'graph, 'grammar: 'graph> {
     graph: &'graph TraceGraph<'grammar>,
     stack: Vec<EnumeratorState<'graph, 'grammar>>,
-
-    // The list of symbols for the current item.
-    symbols: Vec<Symbol>,
-
-    cursor: usize,
 }
 
 struct EnumeratorState<'graph, 'grammar: 'graph> {
@@ -172,8 +167,6 @@ impl<'graph, 'grammar> PathEnumerator<'graph, 'grammar> {
         let mut enumerator = PathEnumerator {
             graph: graph,
             stack: vec![],
-            symbols: vec![],
-            cursor: 0,
         };
         let edges = enumerator.incoming_edges(start_state);
         enumerator.stack.push(EnumeratorState {
@@ -299,25 +292,7 @@ impl<'graph, 'grammar> PathEnumerator<'graph, 'grammar> {
         }
     }
 
-    // Assemble the `symbols` vector and `cursor`
-    fn found_trace(&mut self)
-                   -> bool {
-        self.symbols.truncate(0);
-
-        self.symbols.extend(
-            self.stack.iter()
-                      .rev()
-                      .flat_map(|s| s.symbol_sets.prefix));
-
-        self.cursor = self.symbols.len();
-
-        self.symbols.extend(
-            self.stack[1].symbol_sets.cursor);
-
-        self.symbols.extend(
-            self.stack.iter()
-                      .flat_map(|s| s.symbol_sets.suffix));
-
+    fn found_trace(&mut self) -> bool {
         true
     }
 

--- a/lalrpop/src/lr1/trace/trace_graph/mod.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/mod.rs
@@ -1,5 +1,6 @@
 use collections::{Map, map};
 use lr1::core::*;
+use lr1::lookahead::*;
 use lr1::example::*;
 use grammar::repr::*;
 use petgraph::{EdgeDirection, Graph};
@@ -102,7 +103,7 @@ impl<'grammar> Into<TraceGraphNode<'grammar>> for NonterminalString {
     }
 }
 
-impl<'grammar, L: Clone> Into<TraceGraphNode<'grammar>> for Item<'grammar, L> {
+impl<'grammar, L: Lookahead> Into<TraceGraphNode<'grammar>> for Item<'grammar, L> {
     fn into(self) -> TraceGraphNode<'grammar> {
         TraceGraphNode::Item(self.to_lr0())
     }

--- a/lalrpop/src/lr1/trace/trace_graph/mod.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/mod.rs
@@ -316,7 +316,6 @@ impl<'graph, 'grammar> PathEnumerator<'graph, 'grammar> {
     pub fn first0(&self, grammar: &Grammar, first_sets: &FirstSets) -> TokenSet {
         assert!(self.found_trace());
         first_sets.first0(
-            grammar,
             self.stack[1].symbol_sets
                          .cursor
                          .into_iter()
@@ -433,7 +432,7 @@ impl<'graph, 'grammar> Iterator for FilteredPathEnumerator<'graph, 'grammar> {
     fn next(&mut self) -> Option<Example> {
         while self.base.found_trace() {
             let firsts = self.base.first0(self.grammar, self.first_sets);
-            if firsts.contains(self.grammar, self.lookahead) {
+            if firsts.contains(self.lookahead) {
                 let example = self.base.example();
                 self.base.advance();
                 return Some(example);

--- a/lalrpop/src/lr1/trace/trace_graph/mod.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/mod.rs
@@ -99,13 +99,11 @@ impl<'grammar> TraceGraph<'grammar> {
     }
 
     pub fn lr1_examples<'trace>(&'trace self,
-                                grammar: &'grammar Grammar,
                                 first_sets: &'trace FirstSets,
                                 item: &LR1Item<'grammar>)
                                 -> FilteredPathEnumerator<'trace, 'grammar>
     {
-        FilteredPathEnumerator::new(grammar,
-                                    first_sets,
+        FilteredPathEnumerator::new(first_sets,
                                     self,
                                     item.to_lr0(),
                                     item.lookahead.clone())
@@ -322,7 +320,7 @@ impl<'graph, 'grammar> PathEnumerator<'graph, 'grammar> {
     /// the terminal that was to be shifted; if derived from a reduce
     /// item, this constitutes the set of lookaheads that will trigger
     /// a reduce.
-    pub fn first0(&self, grammar: &Grammar, first_sets: &FirstSets) -> TokenSet {
+    pub fn first0(&self, first_sets: &FirstSets) -> TokenSet {
         assert!(self.found_trace());
         first_sets.first0(
             self.stack[1].symbol_sets
@@ -414,21 +412,18 @@ impl<'graph, 'grammar> Iterator for PathEnumerator<'graph, 'grammar> {
 
 pub struct FilteredPathEnumerator<'graph, 'grammar: 'graph> {
     base: PathEnumerator<'graph, 'grammar>,
-    grammar: &'grammar Grammar,
     first_sets: &'graph FirstSets,
     lookahead: TokenSet,
 }
 
 impl<'graph, 'grammar> FilteredPathEnumerator<'graph, 'grammar> {
-    fn new(grammar: &'grammar Grammar,
-           first_sets: &'graph FirstSets,
+    fn new(first_sets: &'graph FirstSets,
            graph: &'graph TraceGraph<'grammar>,
            lr0_item: LR0Item<'grammar>,
            lookahead: TokenSet)
            -> Self {
         FilteredPathEnumerator {
             base: PathEnumerator::new(graph, lr0_item),
-            grammar: grammar,
             first_sets: first_sets,
             lookahead: lookahead,
         }
@@ -440,7 +435,7 @@ impl<'graph, 'grammar> Iterator for FilteredPathEnumerator<'graph, 'grammar> {
 
     fn next(&mut self) -> Option<Example> {
         while self.base.found_trace() {
-            let firsts = self.base.first0(self.grammar, self.first_sets);
+            let firsts = self.base.first0(self.first_sets);
             if firsts.is_intersecting(&self.lookahead) {
                 let example = self.base.example();
                 self.base.advance();

--- a/lalrpop/src/lr1/trace/trace_graph/mod.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/mod.rs
@@ -102,13 +102,7 @@ impl<'grammar> Into<TraceGraphNode<'grammar>> for NonterminalString {
     }
 }
 
-impl<'grammar> Into<TraceGraphNode<'grammar>> for LR0Item<'grammar> {
-    fn into(self) -> TraceGraphNode<'grammar> {
-        TraceGraphNode::Item(self)
-    }
-}
-
-impl<'grammar> Into<TraceGraphNode<'grammar>> for Item<'grammar> {
+impl<'grammar, L: Clone> Into<TraceGraphNode<'grammar>> for Item<'grammar, L> {
     fn into(self) -> TraceGraphNode<'grammar> {
         TraceGraphNode::Item(self.to_lr0())
     }

--- a/lalrpop/src/lr1/trace/trace_graph/test.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/test.rs
@@ -57,22 +57,19 @@ fn enumerator() {
 
     let mut graph = TraceGraph::new();
 
-    let item0 = LR0Item { production: &productions[0], index: 1 }; // X = X0 (*) X1
+    let item0 = Item::lr0(&productions[0], 1); // X = X0 (*) X1
     graph.add_edge(
         nt!(X),
         item0,
         item0.symbol_sets());
 
-    let item1 = LR0Item { production: &productions[1], index: 1 }; // Y = Y0 (*) X Y1
+    let item1 = Item::lr0(&productions[1], 1); // Y = Y0 (*) X Y1
     graph.add_edge(item1, nt!(X), item1.symbol_sets());
 
-    let item2 = LR0Item { production: &productions[2], index: 1 }; // Z = Z0 (*) X Z1
+    let item2 = Item::lr0(&productions[2], 1); // Z = Z0 (*) X Z1
     graph.add_edge(item2, nt!(X), item2.symbol_sets());
 
-    let enumerator = graph.examples(LR0Item {
-        production: &productions[0],
-        index: 1
-    });
+    let enumerator = graph.examples(Item::lr0(&productions[0], 1));
     let list: Vec<_> =
         enumerator.map(|example| example.paint_unstyled())
                   .collect();
@@ -124,7 +121,7 @@ fn enumerator1() {
 
     let mut graph = TraceGraph::new();
 
-    let item0 = LR0Item { production: &productions[0], index: 2 }; // W = W0 W1 (*)
+    let item0 = Item::lr0(&productions[0], 2); // W = W0 W1 (*)
     graph.add_edge(nt!(W), item0, item0.symbol_sets());
 
     graph.add_edge(nt!(X), nt!(W), SymbolSets {
@@ -133,16 +130,13 @@ fn enumerator1() {
         suffix: &productions[1].symbols[2..]
     });
 
-    let item1 = LR0Item { production: &productions[2], index: 1 };
+    let item1 = Item::lr0(&productions[2], 1);
     graph.add_edge(item1, nt!(X), item1.symbol_sets());
 
-    let item2 = LR0Item { production: &productions[3], index: 1 };
+    let item2 = Item::lr0(&productions[3], 1);
     graph.add_edge(item2, nt!(X), item2.symbol_sets());
 
-    let enumerator = graph.examples(LR0Item {
-        production: &productions[0],
-        index: 2,
-    });
+    let enumerator = graph.examples(Item::lr0(&productions[0], 2));
     let list: Vec<_> =
         enumerator.map(|example| example.paint_unstyled())
                   .collect();

--- a/lalrpop/src/lr1/trace/trace_graph/test.rs
+++ b/lalrpop/src/lr1/trace/trace_graph/test.rs
@@ -69,7 +69,7 @@ fn enumerator() {
     let item2 = Item::lr0(&productions[2], 1); // Z = Z0 (*) X Z1
     graph.add_edge(item2, nt!(X), item2.symbol_sets());
 
-    let enumerator = graph.examples(Item::lr0(&productions[0], 1));
+    let enumerator = graph.lr0_examples(Item::lr0(&productions[0], 1));
     let list: Vec<_> =
         enumerator.map(|example| example.paint_unstyled())
                   .collect();
@@ -136,7 +136,7 @@ fn enumerator1() {
     let item2 = Item::lr0(&productions[3], 1);
     graph.add_edge(item2, nt!(X), item2.symbol_sets());
 
-    let enumerator = graph.examples(Item::lr0(&productions[0], 2));
+    let enumerator = graph.lr0_examples(Item::lr0(&productions[0], 2));
     let list: Vec<_> =
         enumerator.map(|example| example.paint_unstyled())
                   .collect();

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -159,8 +159,10 @@ impl LowerState {
             where_clauses: grammar.where_clauses,
             algorithm: algorithm,
             intern_token: self.intern_token,
-            all_terminals: all_terminals,
-            terminal_bits: terminal_bits,
+            terminals: r::TerminalSet {
+                all: all_terminals,
+                bits: terminal_bits,
+            }
         })
     }
 


### PR DESCRIPTION
This is a collection of refactorings aiming at (eventually) implementing the lane-table algorithm. Since these touch a lot of core data-structures, I wanted to get this work landed.

Major refactorings:

- the LR data structures are now generic over the "lookahead" `L`
- the set of tokens is now stored in TLS, allowing us to stop passing it around for TokenSet and the like
- we store shifts/reduces in distinct tables in the LR data structures, allowing them to have cleaner types