### PR TITLE
Don't emit module-level attributes

### DIFF
--- a/lalrpop/src/build/action.rs
+++ b/lalrpop/src/build/action.rs
@@ -63,7 +63,7 @@ pub fn emit_action_code<W: Write>(grammar: &r::Grammar, rust: &mut RustWrite<W>)
 
 fn ret_type_string(grammar: &r::Grammar, defn: &r::ActionFnDefn) -> String {
     if defn.fallible {
-        format!("Result<{},{}ParseError<{},{},{}>>",
+        format!("Result<{},{}lalrpop_util::ParseError<{},{},{}>>",
                 defn.ret_type,
                 grammar.prefix,
                 grammar.types.terminal_loc_type(),

--- a/lalrpop/src/build/action.rs
+++ b/lalrpop/src/build/action.rs
@@ -38,6 +38,13 @@ pub fn emit_action_code<W: Write>(grammar: &r::Grammar, rust: &mut RustWrite<W>)
     for (i, defn) in grammar.action_fn_defns.iter().enumerate() {
         rust!(rust, "");
 
+        // we always thread the parameters through to the action code,
+        // even if they are not used, and hence we need to disable the
+        // unused variables lint, which otherwise gets very excited.
+        if !grammar.parameters.is_empty() {
+            rust!(rust, "#[allow(unused_variables)]");
+        }
+
         match defn.kind {
             r::ActionFnDefnKind::User(ref data) => {
                 try!(emit_user_action_code(grammar, rust, i, defn, data))

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -325,13 +325,6 @@ fn emit_recursive_ascent(session: &Session,
     // often some of the uses are not used here
     rust!(rust, "#![allow(unused_imports)]");
 
-    // we always thread the parameters through to the action code,
-    // even if they are not used, and hence we need to disable the
-    // unused variables lint, which otherwise gets very excited.
-    if !grammar.parameters.is_empty() {
-        rust!(rust, "#![allow(unused_variables)]");
-    }
-
     try!(emit_uses(grammar, &mut rust));
 
     if grammar.start_nonterminals.is_empty() {

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -322,9 +322,6 @@ fn emit_recursive_ascent(session: &Session,
     // includes things like `super::` it will resolve in the natural
     // way.
 
-    // often some of the uses are not used here
-    rust!(rust, "#![allow(unused_imports)]");
-
     try!(emit_uses(grammar, &mut rust));
 
     if grammar.start_nonterminals.is_empty() {

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -50,7 +50,7 @@ pub fn compile<W: Write>(
     rust!(out, "");
     rust!(out, "impl<'input> Iterator for {}Matcher<'input> {{", prefix);
     rust!(out, "type Item = Result<(usize, (usize, &'input str), usize), \
-                {}ParseError<usize,(usize, &'input str),{}>>;",
+                {}lalrpop_util::ParseError<usize,(usize, &'input str),{}>>;",
           prefix, grammar.types.error_type());
     rust!(out, "");
     rust!(out, "fn next(&mut self) -> Option<Self::Item> {{");
@@ -79,7 +79,7 @@ pub fn compile<W: Write>(
           prefix, prefix, prefix, prefix);
     rust!(out, "}}"); // some
     rust!(out, "None => {{");
-    rust!(out, "Some(Err({}ParseError::InvalidToken {{ location: {}start_offset }}))",
+    rust!(out, "Some(Err({}lalrpop_util::ParseError::InvalidToken {{ location: {}start_offset }}))",
           prefix, prefix);
     rust!(out, "}}"); // none
     rust!(out, "}}"); // match
@@ -91,4 +91,3 @@ pub fn compile<W: Write>(
 
     Ok(())
 }
-

--- a/lalrpop/src/lr1/ascent.rs
+++ b/lalrpop/src/lr1/ascent.rs
@@ -299,7 +299,7 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
 
         // extra tokens?
         rust!(self.out, "(Some({}lookahead), _) => {{", self.prefix);
-        rust!(self.out, "Err({}ParseError::ExtraToken {{ token: {}lookahead }})",
+        rust!(self.out, "Err({}lalrpop_util::ParseError::ExtraToken {{ token: {}lookahead }})",
               self.prefix, self.prefix);
         rust!(self.out, "}}");
 
@@ -418,7 +418,7 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
 
         // if we hit this, the next token is not recognized, so generate an error
         rust!(self.out, "_ => {{");
-        rust!(self.out, "return Err({}ParseError::UnrecognizedToken {{", self.prefix);
+        rust!(self.out, "return Err({}lalrpop_util::ParseError::UnrecognizedToken {{", self.prefix);
         rust!(self.out, "token: {}lookahead,", self.prefix);
         rust!(self.out, "expected: vec![],");
         rust!(self.out, "}});");
@@ -906,7 +906,7 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
     }
 
     fn parse_error_type(&self) -> String {
-        format!("{}ParseError<{},{},{}>",
+        format!("{}lalrpop_util::ParseError<{},{},{}>",
                 self.prefix,
                 self.types.terminal_loc_type(),
                 self.types.terminal_token_type(),
@@ -923,7 +923,7 @@ impl<'ascent,'grammar,W:Write> RecursiveAscent<'ascent,'grammar,W> {
             rust!(self.out, "Some(Err(e)) => return Err(e),");
         } else {
             // otherwise, they are user errors
-            rust!(self.out, "Some(Err(e)) => return Err({}ParseError::User {{ error: e }}),",
+            rust!(self.out, "Some(Err(e)) => return Err({}lalrpop_util::ParseError::User {{ error: e }}),",
                   self.prefix);
         }
         rust!(self.out, "}};");

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -156,8 +156,6 @@ impl<W:Write> RustWrite<W> {
         // stuff that we plan to use
         rust!(self, "extern crate lalrpop_util as {}lalrpop_util;",
               prefix);
-        rust!(self, "use self::{}lalrpop_util::ParseError as {}ParseError;",
-              prefix, prefix);
 
         Ok(())
     }


### PR DESCRIPTION
This makes it so that `lalrpop` doesn't emit top-level module-level attributes. It does so by:

  * Moving the `#[allow(unused_variables)]` to each use-site.
  * Using fully qualified paths instead of `#[allow(unused_imports)]`.

This has the additional advantage that the user will get warnings for unused manual imports.

The main purpose of this pull request is however to allow generated parser files to be `include!()`d.