### PR TITLE
Fix panicking bug in add_range().

### DIFF
--- a/lalrpop/src/lexer/dfa/overlap.rs
+++ b/lalrpop/src/lexer/dfa/overlap.rs
@@ -52,6 +52,7 @@ fn add_range(range: Test,
     // Find first overlapping range in `disjoint_ranges`, if any.
     match disjoint_ranges[start_index..].iter().position(|r| r.intersects(range)) {
         Some(index) => {
+            let index = index + start_index;
             let overlapping_range = disjoint_ranges[index];
 
             // If the range we are trying to add already exists, we're all done.


### PR DESCRIPTION
add_range() uses the wrong index into the vector of disjoint ranges, which causes panics for some grammars and might produce faulty parsers for others. Try this:

```
grammar;

A = r"[0-1]";
B = r"[0-2]";
C = r"[0-3]";
```
With the current master I get this panic when trying to generate a parser:

> error: failed to run custom build command for `comatus v0.1.0 (file:///home/ll/src/git/comatus)`
> Process didn't exit successfully: `/home/ll/src/git/comatus/target/debug/build/comatus-b2d8aadff4832138/build-script-build` (exit code: 101)
> --- stdout
> processing file `/home/ll/src/git/comatus/src/aaaa.lalrpop`
> 
> --- stderr
> thread '<main>' panicked at 'assertion failed: low_range.is_disjoint(max_range)', /home/ll/.cargo/git/checkouts/lalrpop-c0dd81ff2de87ac9/4893ddacc6743849a9249b5a7579e92d85d444e2/lalrpop/src/lexer/dfa/overlap.rs:74
> note: Run with `RUST_BACKTRACE=1` for a backtrace.

With this fix I instead get a nice error message:

> error: failed to run custom build command for `comatus v0.1.0 (file:///home/ll/src/git/comatus)`
> Process didn't exit successfully: `/home/ll/src/git/comatus/target/debug/build/comatus-b2d8aadff4832138/build-script-build` (exit code: 1)
> --- stdout
> processing file `/home/ll/src/git/comatus/src/aaaa.lalrpop`
> /home/ll/src/git/comatus/src/aaaa.lalrpop:5:5: 5:12 error: ambiguity detected between the terminal `r#"[0-3]"#` and the terminal `r#"[0-2]"#`
> 
> --- stderr
>   C = r"[0-3]";
>       ~~~~~~~~