### PR TITLE
allow type parameters not constained by arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
         "lalrpop-snap",
         "lalrpop-intern",
         "lalrpop-util",
+        "doc/calculator",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+members = [
+        "lalrpop",
+        "lalrpop-test",
+        "lalrpop-snap",
+        "lalrpop-intern",
+        "lalrpop-util",
+]

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -3,6 +3,7 @@ name = "calculator"
 version = "0.12.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 build = "build.rs" # <-- We added this and everything after!
+workspace = "../.."
 
 [build-dependencies]
 lalrpop = "0.12.0"

--- a/lalrpop-intern/Cargo.toml
+++ b/lalrpop-intern/Cargo.toml
@@ -5,3 +5,4 @@ description = "Simple string interner used by LALRPOP"
 repository = "https://github.com/nikomatsakis/lalrpop"
 license = "Apache-2.0/MIT"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+workspace = ".."

--- a/lalrpop-snap/Cargo.toml
+++ b/lalrpop-snap/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/nikomatsakis/lalrpop"
 license = "Apache-2.0/MIT"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 # build = "build.rs"
+workspace = ".."
 
 [dependencies]
 atty = "0.1.2"

--- a/lalrpop-test/Cargo.toml
+++ b/lalrpop-test/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.12.0" # LALRPOP
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 license = "Apache-2.0/MIT"
 build = "build.rs"
+workspace = ".."
 
 [dependencies]
 diff = "0.1"

--- a/lalrpop-test/src/error.rs
+++ b/lalrpop-test/src/error.rs
@@ -49,7 +49,7 @@ mod __parse__Items {
                     None => None,
                     Some(Err(e)) => return Err(__lalrpop_util::ParseError::User { error: e }),
                 };
-                match try!(__state0(&mut __tokens, __lookahead)) {
+                match try!(__state0(&mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -95,6 +95,7 @@ mod __parse__Items {
             >(
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,Tok,char>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
@@ -104,7 +105,7 @@ mod __parse__Items {
                     None => {
                         let __start: usize = ::std::default::Default::default();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action1(&__start, &__end);
+                        let __nt = super::super::super::__action1::<>(&__start, &__end);
                         let __nt = __Nonterminal::Items((
                             __start,
                             __nt,
@@ -123,7 +124,7 @@ mod __parse__Items {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Items(__sym0) => {
-                            __result = try!(__state1(__tokens, __lookahead, __sym0));
+                            __result = try!(__state1(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -154,24 +155,25 @@ mod __parse__Items {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, Vec<(usize, usize)>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,Tok,char>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state2(__tokens, __sym0, __sym1));
+                        __result = try!(__state2(__tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state3(__tokens, __sym0, __sym1));
+                        __result = try!(__state3(__tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(__sym0);
+                        let __nt = super::super::super::__action0::<>(__sym0);
                         let __nt = __Nonterminal::____Items((
                             __start,
                             __nt,
@@ -207,6 +209,7 @@ mod __parse__Items {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Vec<(usize, usize)>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,Tok,char>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
@@ -221,7 +224,7 @@ mod __parse__Items {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = try!(super::super::super::__action2(__sym0, __sym1));
+                        let __nt = try!(super::super::super::__action2::<>(__sym0, __sym1));
                         let __nt = __Nonterminal::Items((
                             __start,
                             __nt,
@@ -257,6 +260,7 @@ mod __parse__Items {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Vec<(usize, usize)>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,Tok,char>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
@@ -271,7 +275,7 @@ mod __parse__Items {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = try!(super::super::super::__action3(__sym0, __sym1));
+                        let __nt = try!(super::super::super::__action3::<>(__sym0, __sym1));
                         let __nt = __Nonterminal::Items((
                             __start,
                             __nt,
@@ -402,7 +406,7 @@ mod __parse__Items {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -417,7 +421,7 @@ mod __parse__Items {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -434,6 +438,7 @@ mod __parse__Items {
                 __lookahead_start: Option<&usize>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<>,usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<Vec<(usize, usize)>,__lalrpop_util::ParseError<usize,Tok,char>>>
             {
                 let __nonterminal = match -__action {
@@ -441,7 +446,7 @@ mod __parse__Items {
                         // Items =  => ActionFn(1);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action1(&__start, &__end);
+                        let __nt = super::super::super::__action1::<>(&__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::NtItems(__nt), __end));
@@ -453,7 +458,7 @@ mod __parse__Items {
                         let __sym0 = __pop_NtItems(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = match super::super::super::__action2(__sym0, __sym1) {
+                        let __nt = match super::super::super::__action2::<>(__sym0, __sym1) {
                             Ok(v) => v,
                             Err(e) => return Some(Err(e)),
                         };
@@ -468,7 +473,7 @@ mod __parse__Items {
                         let __sym0 = __pop_NtItems(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = match super::super::super::__action3(__sym0, __sym1) {
+                        let __nt = match super::super::super::__action3::<>(__sym0, __sym1) {
                             Ok(v) => v,
                             Err(e) => return Some(Err(e)),
                         };
@@ -482,7 +487,7 @@ mod __parse__Items {
                         let __sym0 = __pop_NtItems(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(__sym0);
+                        let __nt = super::super::super::__action0::<>(__sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/expr.rs
+++ b/lalrpop-test/src/expr.rs
@@ -50,7 +50,7 @@ mod __parse__Expr {
                     None => None,
                     Some(Err(e)) => return Err(__lalrpop_util::ParseError::User { error: e }),
                 };
-                match try!(__state0(scale, &mut __tokens, __lookahead)) {
+                match try!(__state0(scale, &mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -125,17 +125,18 @@ mod __parse__Expr {
                 scale: i32,
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym0 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym0));
+                        __result = try!(__state4(scale, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym0));
+                        __result = try!(__state5(scale, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -148,13 +149,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym0) => {
-                            __result = try!(__state1(scale, __tokens, __lookahead, __sym0));
+                            __result = try!(__state1(scale, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym0) => {
-                            __result = try!(__state2(scale, __tokens, __lookahead, __sym0));
+                            __result = try!(__state2(scale, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym0) => {
-                            __result = try!(__state3(scale, __tokens, __lookahead, __sym0));
+                            __result = try!(__state3(scale, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -186,24 +187,25 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state6(scale, __tokens, __sym0, __sym1));
+                        __result = try!(__state6(scale, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state7(scale, __tokens, __sym0, __sym1));
+                        __result = try!(__state7(scale, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(scale, __sym0);
+                        let __nt = super::super::super::__action0::<>(scale, __sym0);
                         let __nt = __Nonterminal::____Expr((
                             __start,
                             __nt,
@@ -244,18 +246,19 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state8(scale, __tokens, __sym0, __sym1));
+                        __result = try!(__state8(scale, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(scale, __tokens, __sym0, __sym1));
+                        __result = try!(__state9(scale, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::Plus, _)) |
@@ -263,7 +266,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(scale, __sym0);
+                        let __nt = super::super::super::__action3::<>(scale, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -300,6 +303,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -311,7 +315,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(scale, __sym0);
+                        let __nt = super::super::super::__action6::<>(scale, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -385,6 +389,7 @@ mod __parse__Expr {
                 scale: i32,
                 __tokens: &mut __TOKENS,
                 __sym0: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -397,11 +402,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state13(scale, __tokens, __sym1));
+                        __result = try!(__state13(scale, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(scale, __tokens, __sym1));
+                        __result = try!(__state14(scale, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -417,13 +422,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state10(scale, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state10(scale, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state11(scale, __tokens, __lookahead, __sym1));
+                            __result = try!(__state11(scale, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state12(scale, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(scale, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -450,6 +455,7 @@ mod __parse__Expr {
                 scale: i32,
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -466,7 +472,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(scale, __sym0);
+                        let __nt = super::super::super::__action7::<>(scale, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -521,6 +527,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -534,11 +541,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym2));
+                        __result = try!(__state4(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym2));
+                        __result = try!(__state5(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -554,10 +561,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state15(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state15(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(scale, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -603,6 +610,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -616,11 +624,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym2));
+                        __result = try!(__state4(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym2));
+                        __result = try!(__state5(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -636,10 +644,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state16(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state16(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(scale, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -671,6 +679,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -682,11 +691,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym2));
+                        __result = try!(__state4(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym2));
+                        __result = try!(__state5(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -699,7 +708,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state17(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state17(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -732,6 +741,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -743,11 +753,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym2));
+                        __result = try!(__state4(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym2));
+                        __result = try!(__state5(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -760,7 +770,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state18(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state18(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -794,6 +804,7 @@ mod __parse__Expr {
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: &mut Option<((), Tok, ())>,
                 __sym1: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -801,17 +812,17 @@ mod __parse__Expr {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state19(scale, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state19(scale, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state20(scale, __tokens, __sym1, __sym2));
+                        __result = try!(__state20(scale, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state21(scale, __tokens, __sym1, __sym2));
+                        __result = try!(__state21(scale, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -846,18 +857,19 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state22(scale, __tokens, __sym0, __sym1));
+                        __result = try!(__state22(scale, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state23(scale, __tokens, __sym0, __sym1));
+                        __result = try!(__state23(scale, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -865,7 +877,7 @@ mod __parse__Expr {
                     Some((_, Tok::Minus, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(scale, __sym0);
+                        let __nt = super::super::super::__action3::<>(scale, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -902,6 +914,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -913,7 +926,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(scale, __sym0);
+                        let __nt = super::super::super::__action6::<>(scale, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -987,6 +1000,7 @@ mod __parse__Expr {
                 scale: i32,
                 __tokens: &mut __TOKENS,
                 __sym0: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -999,11 +1013,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state13(scale, __tokens, __sym1));
+                        __result = try!(__state13(scale, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(scale, __tokens, __sym1));
+                        __result = try!(__state14(scale, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1019,13 +1033,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state24(scale, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state24(scale, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state11(scale, __tokens, __lookahead, __sym1));
+                            __result = try!(__state11(scale, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state12(scale, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(scale, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1052,6 +1066,7 @@ mod __parse__Expr {
                 scale: i32,
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1068,7 +1083,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(scale, __sym0);
+                        let __nt = super::super::super::__action7::<>(scale, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1111,18 +1126,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<((), i32, ())>,
                 __sym1: &mut Option<((), Tok, ())>,
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state8(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state8(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::Plus, _)) |
@@ -1132,7 +1148,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1175,18 +1191,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<((), i32, ())>,
                 __sym1: &mut Option<((), Tok, ())>,
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state8(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state8(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::Plus, _)) |
@@ -1196,7 +1213,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1235,6 +1252,7 @@ mod __parse__Expr {
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1246,7 +1264,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1285,6 +1303,7 @@ mod __parse__Expr {
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1296,7 +1315,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1334,6 +1353,7 @@ mod __parse__Expr {
                 __sym0: ((), Tok, ()),
                 __sym1: ((), i32, ()),
                 __sym2: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1350,7 +1370,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1405,6 +1425,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1418,11 +1439,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state13(scale, __tokens, __sym2));
+                        __result = try!(__state13(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(scale, __tokens, __sym2));
+                        __result = try!(__state14(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1438,10 +1459,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state25(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state25(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state12(scale, __tokens, __lookahead, __sym2));
+                            __result = try!(__state12(scale, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1487,6 +1508,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1500,11 +1522,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state13(scale, __tokens, __sym2));
+                        __result = try!(__state13(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(scale, __tokens, __sym2));
+                        __result = try!(__state14(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1520,10 +1542,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state26(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state26(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state12(scale, __tokens, __lookahead, __sym2));
+                            __result = try!(__state12(scale, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1555,6 +1577,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1566,11 +1589,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state13(scale, __tokens, __sym2));
+                        __result = try!(__state13(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(scale, __tokens, __sym2));
+                        __result = try!(__state14(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1583,7 +1606,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state27(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state27(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1616,6 +1639,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1627,11 +1651,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state13(scale, __tokens, __sym2));
+                        __result = try!(__state13(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(scale, __tokens, __sym2));
+                        __result = try!(__state14(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1644,7 +1668,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state28(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state28(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1678,6 +1702,7 @@ mod __parse__Expr {
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: &mut Option<((), Tok, ())>,
                 __sym1: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1685,17 +1710,17 @@ mod __parse__Expr {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state29(scale, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state29(scale, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state20(scale, __tokens, __sym1, __sym2));
+                        __result = try!(__state20(scale, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state21(scale, __tokens, __sym1, __sym2));
+                        __result = try!(__state21(scale, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -1732,18 +1757,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<((), i32, ())>,
                 __sym1: &mut Option<((), Tok, ())>,
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state22(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state22(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state23(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state23(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -1753,7 +1779,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1796,18 +1822,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<((), i32, ())>,
                 __sym1: &mut Option<((), Tok, ())>,
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state22(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state22(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state23(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state23(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -1817,7 +1844,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1856,6 +1883,7 @@ mod __parse__Expr {
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1867,7 +1895,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1906,6 +1934,7 @@ mod __parse__Expr {
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1917,7 +1946,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1955,6 +1984,7 @@ mod __parse__Expr {
                 __sym0: ((), Tok, ()),
                 __sym1: ((), i32, ()),
                 __sym2: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1971,7 +2001,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -2729,7 +2759,7 @@ mod __parse__Expr {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(scale, __action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(scale, __action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -2744,7 +2774,7 @@ mod __parse__Expr {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(scale, __action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(scale, __action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -2762,6 +2792,7 @@ mod __parse__Expr {
                 __lookahead_start: Option<&()>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<((),__Symbol<>,())>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<i32,__lalrpop_util::ParseError<(),Tok,()>>>
             {
                 let __nonterminal = match -__action {
@@ -2772,7 +2803,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(scale, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -2785,7 +2816,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(scale, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -2796,7 +2827,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(scale, __sym0);
+                        let __nt = super::super::super::__action3::<>(scale, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -2809,7 +2840,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(scale, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -2822,7 +2853,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(scale, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -2833,7 +2864,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtTerm(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(scale, __sym0);
+                        let __nt = super::super::super::__action6::<>(scale, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -2844,7 +2875,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_TermNum(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(scale, __sym0);
+                        let __nt = super::super::super::__action7::<>(scale, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -2857,7 +2888,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Term_22_28_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(scale, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -2868,7 +2899,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(scale, __sym0);
+                        let __nt = super::super::super::__action0::<>(scale, __sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/expr_arena.rs
+++ b/lalrpop-test/src/expr_arena.rs
@@ -55,7 +55,7 @@ mod __parse__Expr {
                     None => None,
                     Some(Err(e)) => return Err(__lalrpop_util::ParseError::User { error: e }),
                 };
-                match try!(__state0(arena, &mut __tokens, __lookahead)) {
+                match try!(__state0(arena, &mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -142,21 +142,22 @@ mod __parse__Expr {
                 arena: &'ast Arena<'ast>,
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym0 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(arena, __tokens, __sym0));
+                        __result = try!(__state4(arena, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym0 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state5(arena, __tokens, __sym0));
+                        __result = try!(__state5(arena, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(arena, __tokens, __sym0));
+                        __result = try!(__state6(arena, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -169,13 +170,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym0) => {
-                            __result = try!(__state1(arena, __tokens, __lookahead, __sym0));
+                            __result = try!(__state1(arena, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym0) => {
-                            __result = try!(__state2(arena, __tokens, __lookahead, __sym0));
+                            __result = try!(__state2(arena, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym0) => {
-                            __result = try!(__state3(arena, __tokens, __lookahead, __sym0));
+                            __result = try!(__state3(arena, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -208,24 +209,25 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state7(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state7(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state8(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state8(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(arena, __sym0);
+                        let __nt = super::super::super::__action0::<>(arena, __sym0);
                         let __nt = __Nonterminal::____Expr((
                             __start,
                             __nt,
@@ -267,18 +269,19 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state9(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state10(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state10(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::Plus, _)) |
@@ -286,7 +289,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(arena, __sym0);
+                        let __nt = super::super::super::__action3::<>(arena, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -324,6 +327,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -335,7 +339,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(arena, __sym0);
+                        let __nt = super::super::super::__action7::<>(arena, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -416,6 +420,7 @@ mod __parse__Expr {
                 arena: &'ast Arena<'ast>,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -428,15 +433,15 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state14(arena, __tokens, __sym1));
+                        __result = try!(__state14(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state15(arena, __tokens, __sym1));
+                        __result = try!(__state15(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(arena, __tokens, __sym1));
+                        __result = try!(__state16(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -452,13 +457,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state11(arena, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state11(arena, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state12(arena, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(arena, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state13(arena, __tokens, __lookahead, __sym1));
+                            __result = try!(__state13(arena, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -486,6 +491,7 @@ mod __parse__Expr {
                 arena: &'ast Arena<'ast>,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -497,7 +503,7 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state17(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state17(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -528,6 +534,7 @@ mod __parse__Expr {
                 arena: &'ast Arena<'ast>,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -544,7 +551,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action8(arena, __sym0);
+                        let __nt = super::super::super::__action8::<>(arena, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -604,6 +611,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -617,15 +625,15 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(arena, __tokens, __sym2));
+                        __result = try!(__state4(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state5(arena, __tokens, __sym2));
+                        __result = try!(__state5(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(arena, __tokens, __sym2));
+                        __result = try!(__state6(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -641,10 +649,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state18(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state18(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state3(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -695,6 +703,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -708,15 +717,15 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(arena, __tokens, __sym2));
+                        __result = try!(__state4(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state5(arena, __tokens, __sym2));
+                        __result = try!(__state5(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(arena, __tokens, __sym2));
+                        __result = try!(__state6(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -732,10 +741,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state19(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state19(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state3(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -768,6 +777,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -779,11 +789,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(arena, __tokens, __sym2));
+                        __result = try!(__state4(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(arena, __tokens, __sym2));
+                        __result = try!(__state6(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -796,7 +806,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state20(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state20(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -830,6 +840,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -841,11 +852,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(arena, __tokens, __sym2));
+                        __result = try!(__state4(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(arena, __tokens, __sym2));
+                        __result = try!(__state6(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -858,7 +869,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state21(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state21(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -893,6 +904,7 @@ mod __parse__Expr {
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: &mut Option<(usize, Tok, usize)>,
                 __sym1: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -900,17 +912,17 @@ mod __parse__Expr {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state22(arena, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state22(arena, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state23(arena, __tokens, __sym1, __sym2));
+                        __result = try!(__state23(arena, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state24(arena, __tokens, __sym1, __sym2));
+                        __result = try!(__state24(arena, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -946,18 +958,19 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state25(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state25(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state26(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state26(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -965,7 +978,7 @@ mod __parse__Expr {
                     Some((_, Tok::Minus, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(arena, __sym0);
+                        let __nt = super::super::super::__action3::<>(arena, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1003,6 +1016,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1014,7 +1028,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(arena, __sym0);
+                        let __nt = super::super::super::__action7::<>(arena, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1095,6 +1109,7 @@ mod __parse__Expr {
                 arena: &'ast Arena<'ast>,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1107,15 +1122,15 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state14(arena, __tokens, __sym1));
+                        __result = try!(__state14(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state15(arena, __tokens, __sym1));
+                        __result = try!(__state15(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(arena, __tokens, __sym1));
+                        __result = try!(__state16(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1131,13 +1146,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state27(arena, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state27(arena, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state12(arena, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(arena, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state13(arena, __tokens, __lookahead, __sym1));
+                            __result = try!(__state13(arena, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1165,6 +1180,7 @@ mod __parse__Expr {
                 arena: &'ast Arena<'ast>,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1176,7 +1192,7 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state28(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state28(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -1207,6 +1223,7 @@ mod __parse__Expr {
                 arena: &'ast Arena<'ast>,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1223,7 +1240,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action8(arena, __sym0);
+                        let __nt = super::super::super::__action8::<>(arena, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1325,6 +1342,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Tok, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1336,20 +1354,20 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state34(arena, __tokens, __sym2));
+                        __result = try!(__state34(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state35(arena, __tokens, __sym2));
+                        __result = try!(__state35(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state36(arena, __tokens, __sym2));
+                        __result = try!(__state36(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((_, Tok::RParen, _)) => {
                         let __start = __sym1.2.clone();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action23(arena, &__start, &__end);
+                        let __nt = super::super::super::__action23::<>(arena, &__start, &__end);
                         let __nt = __Nonterminal::Comma_3cExpr_3e((
                             __start,
                             __nt,
@@ -1368,20 +1386,20 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b(__sym2) => {
-                            __result = try!(__state29(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state29(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Comma_3cExpr_3e(__sym2) => {
-                            __result = try!(__state30(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state30(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         __Nonterminal::Expr(__sym2) => {
-                            __result = try!(__state31(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state31(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state32(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state32(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state33(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1416,18 +1434,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
                 __sym1: &mut Option<(usize, Tok, usize)>,
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state10(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state10(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::Plus, _)) |
@@ -1437,7 +1456,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1481,18 +1500,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
                 __sym1: &mut Option<(usize, Tok, usize)>,
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state10(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state10(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::Plus, _)) |
@@ -1502,7 +1522,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1542,6 +1562,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1553,7 +1574,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1593,6 +1614,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1604,7 +1626,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1643,6 +1665,7 @@ mod __parse__Expr {
                 __sym0: (usize, Tok, usize),
                 __sym1: (usize, &'ast Node<'ast>, usize),
                 __sym2: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1659,7 +1682,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action9(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action9::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1719,6 +1742,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1732,15 +1756,15 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state14(arena, __tokens, __sym2));
+                        __result = try!(__state14(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state15(arena, __tokens, __sym2));
+                        __result = try!(__state15(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(arena, __tokens, __sym2));
+                        __result = try!(__state16(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1756,10 +1780,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state37(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state37(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state13(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state13(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1810,6 +1834,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1823,15 +1848,15 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state14(arena, __tokens, __sym2));
+                        __result = try!(__state14(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state15(arena, __tokens, __sym2));
+                        __result = try!(__state15(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(arena, __tokens, __sym2));
+                        __result = try!(__state16(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1847,10 +1872,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state38(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state38(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state13(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state13(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1883,6 +1908,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1894,11 +1920,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state14(arena, __tokens, __sym2));
+                        __result = try!(__state14(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(arena, __tokens, __sym2));
+                        __result = try!(__state16(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1911,7 +1937,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state39(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state39(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1945,6 +1971,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -1956,11 +1983,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state14(arena, __tokens, __sym2));
+                        __result = try!(__state14(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(arena, __tokens, __sym2));
+                        __result = try!(__state16(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1973,7 +2000,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state40(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state40(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -2008,6 +2035,7 @@ mod __parse__Expr {
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: &mut Option<(usize, Tok, usize)>,
                 __sym1: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2015,17 +2043,17 @@ mod __parse__Expr {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state41(arena, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state41(arena, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state23(arena, __tokens, __sym1, __sym2));
+                        __result = try!(__state23(arena, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state24(arena, __tokens, __sym1, __sym2));
+                        __result = try!(__state24(arena, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -2121,6 +2149,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Tok, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2132,20 +2161,20 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state34(arena, __tokens, __sym2));
+                        __result = try!(__state34(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state35(arena, __tokens, __sym2));
+                        __result = try!(__state35(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state36(arena, __tokens, __sym2));
+                        __result = try!(__state36(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((_, Tok::RParen, _)) => {
                         let __start = __sym1.2.clone();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action23(arena, &__start, &__end);
+                        let __nt = super::super::super::__action23::<>(arena, &__start, &__end);
                         let __nt = __Nonterminal::Comma_3cExpr_3e((
                             __start,
                             __nt,
@@ -2164,20 +2193,20 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b(__sym2) => {
-                            __result = try!(__state29(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state29(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Comma_3cExpr_3e(__sym2) => {
-                            __result = try!(__state42(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state42(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         __Nonterminal::Expr(__sym2) => {
-                            __result = try!(__state31(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state31(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state32(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state32(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state33(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -2262,6 +2291,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, ::std::vec::Vec<&'ast Node<'ast>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2269,21 +2299,21 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state34(arena, __tokens, __sym1));
+                        __result = try!(__state34(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state35(arena, __tokens, __sym1));
+                        __result = try!(__state35(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state36(arena, __tokens, __sym1));
+                        __result = try!(__state36(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((_, Tok::RParen, _)) => {
                         let __sym0 = __sym0.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action25(arena, __sym0);
+                        let __nt = super::super::super::__action25::<>(arena, __sym0);
                         let __nt = __Nonterminal::Comma_3cExpr_3e((
                             __start,
                             __nt,
@@ -2306,13 +2336,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state43(arena, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state43(arena, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state32(arena, __tokens, __lookahead, __sym1));
+                            __result = try!(__state32(arena, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state33(arena, __tokens, __lookahead, __sym1));
+                            __result = try!(__state33(arena, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -2343,13 +2373,14 @@ mod __parse__Expr {
                 __sym0: (usize, Tok, usize),
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state44(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                        __result = try!(__state44(arena, __tokens, __sym0, __sym1, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -2387,29 +2418,30 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state45(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state45(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Comma, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state46(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state46(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state47(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state47(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action22(arena, __sym0);
+                        let __nt = super::super::super::__action22::<>(arena, __sym0);
                         let __nt = __Nonterminal::Comma_3cExpr_3e((
                             __start,
                             __nt,
@@ -2451,18 +2483,19 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state48(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state48(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state49(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state49(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -2471,7 +2504,7 @@ mod __parse__Expr {
                     Some((_, Tok::Minus, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(arena, __sym0);
+                        let __nt = super::super::super::__action3::<>(arena, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -2509,6 +2542,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2521,7 +2555,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(arena, __sym0);
+                        let __nt = super::super::super::__action7::<>(arena, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -2602,6 +2636,7 @@ mod __parse__Expr {
                 arena: &'ast Arena<'ast>,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2614,15 +2649,15 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state14(arena, __tokens, __sym1));
+                        __result = try!(__state14(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state15(arena, __tokens, __sym1));
+                        __result = try!(__state15(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(arena, __tokens, __sym1));
+                        __result = try!(__state16(arena, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -2638,13 +2673,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state50(arena, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state50(arena, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state12(arena, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(arena, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state13(arena, __tokens, __lookahead, __sym1));
+                            __result = try!(__state13(arena, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -2672,6 +2707,7 @@ mod __parse__Expr {
                 arena: &'ast Arena<'ast>,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2683,7 +2719,7 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state51(arena, __tokens, __sym0, __sym1));
+                        __result = try!(__state51(arena, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -2714,6 +2750,7 @@ mod __parse__Expr {
                 arena: &'ast Arena<'ast>,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2731,7 +2768,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action8(arena, __sym0);
+                        let __nt = super::super::super::__action8::<>(arena, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -2775,18 +2812,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
                 __sym1: &mut Option<(usize, Tok, usize)>,
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state25(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state25(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state26(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state26(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -2796,7 +2834,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -2840,18 +2878,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
                 __sym1: &mut Option<(usize, Tok, usize)>,
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state25(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state25(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state26(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state26(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -2861,7 +2900,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -2901,6 +2940,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2912,7 +2952,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -2952,6 +2992,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -2963,7 +3004,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -3002,6 +3043,7 @@ mod __parse__Expr {
                 __sym0: (usize, Tok, usize),
                 __sym1: (usize, &'ast Node<'ast>, usize),
                 __sym2: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3018,7 +3060,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action9(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action9::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -3058,13 +3100,14 @@ mod __parse__Expr {
                 __sym0: (usize, Tok, usize),
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state52(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                        __result = try!(__state52(arena, __tokens, __sym0, __sym1, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -3103,31 +3146,32 @@ mod __parse__Expr {
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: &mut Option<(usize, ::std::vec::Vec<&'ast Node<'ast>>, usize)>,
                 __sym1: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state45(arena, __tokens, __sym1, __sym2));
+                        __result = try!(__state45(arena, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Comma, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state53(arena, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state53(arena, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state47(arena, __tokens, __sym1, __sym2));
+                        __result = try!(__state47(arena, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) => {
                         let __sym0 = __sym0.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action24(arena, __sym0, __sym1);
+                        let __nt = super::super::super::__action24::<>(arena, __sym0, __sym1);
                         let __nt = __Nonterminal::Comma_3cExpr_3e((
                             __start,
                             __nt,
@@ -3167,6 +3211,7 @@ mod __parse__Expr {
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
                 __sym3: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3183,7 +3228,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym3.2.clone();
-                        let __nt = super::super::super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
+                        let __nt = super::super::super::__action6::<>(arena, __sym0, __sym1, __sym2, __sym3);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -3243,6 +3288,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3256,15 +3302,15 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state34(arena, __tokens, __sym2));
+                        __result = try!(__state34(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state35(arena, __tokens, __sym2));
+                        __result = try!(__state35(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state36(arena, __tokens, __sym2));
+                        __result = try!(__state36(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -3280,10 +3326,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state54(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state54(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state33(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -3312,6 +3358,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3327,7 +3374,7 @@ mod __parse__Expr {
                     Some((_, Tok::Num(_), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action18(arena, __sym0, __sym1);
+                        let __nt = super::super::super::__action18::<>(arena, __sym0, __sym1);
                         let __nt = __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b((
                             __start,
                             __nt,
@@ -3387,6 +3434,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3400,15 +3448,15 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state34(arena, __tokens, __sym2));
+                        __result = try!(__state34(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state35(arena, __tokens, __sym2));
+                        __result = try!(__state35(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state36(arena, __tokens, __sym2));
+                        __result = try!(__state36(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -3424,10 +3472,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state55(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state55(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state33(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -3460,6 +3508,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3471,11 +3520,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state34(arena, __tokens, __sym2));
+                        __result = try!(__state34(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state36(arena, __tokens, __sym2));
+                        __result = try!(__state36(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -3488,7 +3537,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state56(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state56(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -3522,6 +3571,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3533,11 +3583,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state34(arena, __tokens, __sym2));
+                        __result = try!(__state34(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state36(arena, __tokens, __sym2));
+                        __result = try!(__state36(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -3550,7 +3600,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state57(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state57(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -3585,6 +3635,7 @@ mod __parse__Expr {
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: &mut Option<(usize, Tok, usize)>,
                 __sym1: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3592,17 +3643,17 @@ mod __parse__Expr {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state58(arena, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state58(arena, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state23(arena, __tokens, __sym1, __sym2));
+                        __result = try!(__state23(arena, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state24(arena, __tokens, __sym1, __sym2));
+                        __result = try!(__state24(arena, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -3698,6 +3749,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Tok, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3709,20 +3761,20 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state34(arena, __tokens, __sym2));
+                        __result = try!(__state34(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state35(arena, __tokens, __sym2));
+                        __result = try!(__state35(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state36(arena, __tokens, __sym2));
+                        __result = try!(__state36(arena, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((_, Tok::RParen, _)) => {
                         let __start = __sym1.2.clone();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action23(arena, &__start, &__end);
+                        let __nt = super::super::super::__action23::<>(arena, &__start, &__end);
                         let __nt = __Nonterminal::Comma_3cExpr_3e((
                             __start,
                             __nt,
@@ -3741,20 +3793,20 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b(__sym2) => {
-                            __result = try!(__state29(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state29(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Comma_3cExpr_3e(__sym2) => {
-                            __result = try!(__state59(arena, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state59(arena, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         __Nonterminal::Expr(__sym2) => {
-                            __result = try!(__state31(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state31(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state32(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state32(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state33(arena, __tokens, __lookahead, __sym2));
+                            __result = try!(__state33(arena, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -3785,6 +3837,7 @@ mod __parse__Expr {
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
                 __sym3: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3801,7 +3854,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym3.2.clone();
-                        let __nt = super::super::super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
+                        let __nt = super::super::super::__action6::<>(arena, __sym0, __sym1, __sym2, __sym3);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -3840,6 +3893,7 @@ mod __parse__Expr {
                 __sym0: (usize, ::std::vec::Vec<&'ast Node<'ast>>, usize),
                 __sym1: (usize, &'ast Node<'ast>, usize),
                 __sym2: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -3855,7 +3909,7 @@ mod __parse__Expr {
                     Some((_, Tok::Num(_), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action19(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action19::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::_28_3cExpr_3e_20_22_2c_22_29_2b((
                             __start,
                             __nt,
@@ -3899,18 +3953,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
                 __sym1: &mut Option<(usize, Tok, usize)>,
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state48(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state48(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state49(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state49(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -3921,7 +3976,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -3965,18 +4020,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, &'ast Node<'ast>, usize)>,
                 __sym1: &mut Option<(usize, Tok, usize)>,
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state48(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state48(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state49(arena, __tokens, __sym2, __sym3));
+                        __result = try!(__state49(arena, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -3987,7 +4043,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -4027,6 +4083,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -4039,7 +4096,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -4079,6 +4136,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'ast Node<'ast>, usize),
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, &'ast Node<'ast>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -4091,7 +4149,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -4130,6 +4188,7 @@ mod __parse__Expr {
                 __sym0: (usize, Tok, usize),
                 __sym1: (usize, &'ast Node<'ast>, usize),
                 __sym2: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -4147,7 +4206,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action9(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action9::<>(arena, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -4187,13 +4246,14 @@ mod __parse__Expr {
                 __sym0: (usize, Tok, usize),
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state60(arena, __tokens, __sym0, __sym1, __sym2, __sym3));
+                        __result = try!(__state60(arena, __tokens, __sym0, __sym1, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -4227,6 +4287,7 @@ mod __parse__Expr {
                 __sym1: (usize, Tok, usize),
                 __sym2: (usize, Vec<&'ast Node<'ast>>, usize),
                 __sym3: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<'ast>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<'ast>);
@@ -4244,7 +4305,7 @@ mod __parse__Expr {
                     Some((_, Tok::Div, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym3.2.clone();
-                        let __nt = super::super::super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
+                        let __nt = super::super::super::__action6::<>(arena, __sym0, __sym1, __sym2, __sym3);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -6184,7 +6245,7 @@ mod __parse__Expr {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(arena, __action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(arena, __action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -6199,7 +6260,7 @@ mod __parse__Expr {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(arena, __action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(arena, __action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -6218,6 +6279,7 @@ mod __parse__Expr {
                 __lookahead_start: Option<&usize>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'ast>,usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<&'ast Node<'ast>,__lalrpop_util::ParseError<usize,Tok,()>>>
             {
                 let __nonterminal = match -__action {
@@ -6227,7 +6289,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action15(arena, __sym0, __sym1);
+                        let __nt = super::super::super::__action15::<>(arena, __sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::Nt_28_3cExpr_3e_20_22_2c_22_29(__nt), __end));
@@ -6237,7 +6299,7 @@ mod __parse__Expr {
                         // (<Expr> ",")* =  => ActionFn(13);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action13(arena, &__start, &__end);
+                        let __nt = super::super::super::__action13::<>(arena, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::Nt_28_3cExpr_3e_20_22_2c_22_29_2a(__nt), __end));
@@ -6248,7 +6310,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Nt_28_3cExpr_3e_20_22_2c_22_29_2b(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action14(arena, __sym0);
+                        let __nt = super::super::super::__action14::<>(arena, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::Nt_28_3cExpr_3e_20_22_2c_22_29_2a(__nt), __end));
@@ -6260,7 +6322,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action18(arena, __sym0, __sym1);
+                        let __nt = super::super::super::__action18::<>(arena, __sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::Nt_28_3cExpr_3e_20_22_2c_22_29_2b(__nt), __end));
@@ -6273,7 +6335,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Nt_28_3cExpr_3e_20_22_2c_22_29_2b(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action19(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action19::<>(arena, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::Nt_28_3cExpr_3e_20_22_2c_22_29_2b(__nt), __end));
@@ -6284,7 +6346,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action22(arena, __sym0);
+                        let __nt = super::super::super::__action22::<>(arena, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtComma_3cExpr_3e(__nt), __end));
@@ -6294,7 +6356,7 @@ mod __parse__Expr {
                         // Comma<Expr> =  => ActionFn(23);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action23(arena, &__start, &__end);
+                        let __nt = super::super::super::__action23::<>(arena, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::NtComma_3cExpr_3e(__nt), __end));
@@ -6306,7 +6368,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Nt_28_3cExpr_3e_20_22_2c_22_29_2b(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action24(arena, __sym0, __sym1);
+                        let __nt = super::super::super::__action24::<>(arena, __sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::NtComma_3cExpr_3e(__nt), __end));
@@ -6317,7 +6379,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Nt_28_3cExpr_3e_20_22_2c_22_29_2b(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action25(arena, __sym0);
+                        let __nt = super::super::super::__action25::<>(arena, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtComma_3cExpr_3e(__nt), __end));
@@ -6330,7 +6392,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(arena, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -6343,7 +6405,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(arena, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -6354,7 +6416,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(arena, __sym0);
+                        let __nt = super::super::super::__action3::<>(arena, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -6365,7 +6427,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action11(arena, __sym0);
+                        let __nt = super::super::super::__action11::<>(arena, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpr_3f(__nt), __end));
@@ -6375,7 +6437,7 @@ mod __parse__Expr {
                         // Expr? =  => ActionFn(12);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action12(arena, &__start, &__end);
+                        let __nt = super::super::super::__action12::<>(arena, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::NtExpr_3f(__nt), __end));
@@ -6388,7 +6450,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(arena, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -6401,7 +6463,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(arena, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -6415,7 +6477,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Term_22_2a_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym3.2.clone();
-                        let __nt = super::super::super::__action6(arena, __sym0, __sym1, __sym2, __sym3);
+                        let __nt = super::super::super::__action6::<>(arena, __sym0, __sym1, __sym2, __sym3);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 4);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -6426,7 +6488,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtTerm(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(arena, __sym0);
+                        let __nt = super::super::super::__action7::<>(arena, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -6437,7 +6499,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_TermNum(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action8(arena, __sym0);
+                        let __nt = super::super::super::__action8::<>(arena, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -6450,7 +6512,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Term_22_28_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action9(arena, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action9::<>(arena, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -6461,7 +6523,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(arena, __sym0);
+                        let __nt = super::super::super::__action0::<>(arena, __sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/expr_generic.lalrpop
+++ b/lalrpop-test/src/expr_generic.lalrpop
@@ -5,8 +5,6 @@ use std::str::FromStr;
 grammar<F>
 where F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq;
 
-use util::tok::Tok;
-
 pub Expr = {
     <l:Expr> "-" <r:Factor> => l - r,
     <l:Expr> "+" <r:Factor> => l + r,

--- a/lalrpop-test/src/expr_generic.rs
+++ b/lalrpop-test/src/expr_generic.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Sub};
 use std::str::FromStr;
-use util::tok::Tok;
 extern crate lalrpop_util as __lalrpop_util;
 
 mod __parse__Expr {
@@ -10,7 +9,6 @@ mod __parse__Expr {
     use std::fmt::Debug;
     use std::ops::{Add, Div, Mul, Sub};
     use std::str::FromStr;
-    use util::tok::Tok;
     extern crate lalrpop_util as __lalrpop_util;
     pub fn parse_Expr<
         'input,
@@ -20,10 +18,10 @@ mod __parse__Expr {
     ) -> Result<F, __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
       F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
     {
-        let __ascent = __ascent::parse_Expr(
+        let __ascent = __ascent::parse_Expr::<F>(
             input,
         );
-        let __parse_table = __parse_table::parse_Expr(
+        let __parse_table = __parse_table::parse_Expr::<F>(
             input,
         );
         assert_eq!(__ascent, __parse_table);
@@ -37,7 +35,6 @@ mod __parse__Expr {
             use std::fmt::Debug;
             use std::ops::{Add, Div, Mul, Sub};
             use std::str::FromStr;
-            use util::tok::Tok;
             extern crate lalrpop_util as __lalrpop_util;
             pub fn parse_Expr<
                 'input,
@@ -53,7 +50,7 @@ mod __parse__Expr {
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
-                match try!(__state0(input, &mut __tokens, __lookahead)) {
+                match try!(__state0(input, &mut __tokens, __lookahead, ::std::marker::PhantomData::<(F)>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -130,6 +127,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -137,11 +135,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym0));
+                        __result = try!(__state4(input, __tokens, __sym0, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym0));
+                        __result = try!(__state5(input, __tokens, __sym0, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -154,13 +152,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym0) => {
-                            __result = try!(__state1(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state1(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<(F)>));
                         }
                         __Nonterminal::Factor(__sym0) => {
-                            __result = try!(__state2(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state2(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<(F)>));
                         }
                         __Nonterminal::Term(__sym0) => {
-                            __result = try!(__state3(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state3(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<(F)>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -194,6 +192,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -201,18 +200,18 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state6(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state7(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state7(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(input, __sym0);
+                        let __nt = super::super::super::__action0::<F>(input, __sym0);
                         let __nt = __Nonterminal::____Expr((
                             __start,
                             __nt,
@@ -255,6 +254,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -262,12 +262,12 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state8(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state8(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state9(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state9(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((_, (3, _), _)) |
@@ -275,7 +275,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(input, __sym0);
+                        let __nt = super::super::super::__action3::<F>(input, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -314,6 +314,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -326,7 +327,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(input, __sym0);
+                        let __nt = super::super::super::__action6::<F>(input, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -402,6 +403,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -415,11 +417,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym1));
+                        __result = try!(__state13(input, __tokens, __sym1, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym1));
+                        __result = try!(__state14(input, __tokens, __sym1, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -435,13 +437,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state10(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state10(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<(F)>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state11(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state11(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<(F)>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state12(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<(F)>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -470,6 +472,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -487,7 +490,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0);
+                        let __nt = super::super::super::__action7::<F>(input, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -544,6 +547,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -558,11 +562,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym2));
+                        __result = try!(__state4(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym2));
+                        __result = try!(__state5(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -578,10 +582,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state15(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state15(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state3(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<(F)>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -629,6 +633,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -643,11 +648,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym2));
+                        __result = try!(__state4(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym2));
+                        __result = try!(__state5(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -663,10 +668,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state16(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state16(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state3(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<(F)>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -700,6 +705,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -712,11 +718,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym2));
+                        __result = try!(__state4(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym2));
+                        __result = try!(__state5(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -729,7 +735,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state17(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state17(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                             return Ok(__result);
                         }
                         _ => {
@@ -764,6 +770,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -776,11 +783,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym2));
+                        __result = try!(__state4(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym2));
+                        __result = try!(__state5(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -793,7 +800,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state18(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state18(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                             return Ok(__result);
                         }
                         _ => {
@@ -829,6 +836,7 @@ mod __parse__Expr {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: &mut Option<(usize, &'input str, usize)>,
                 __sym1: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -837,17 +845,17 @@ mod __parse__Expr {
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state19(input, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state19(input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state20(input, __tokens, __sym1, __sym2));
+                        __result = try!(__state20(input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state21(input, __tokens, __sym1, __sym2));
+                        __result = try!(__state21(input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     _ => {
@@ -884,6 +892,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -891,12 +900,12 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state22(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state22(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state23(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state23(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((_, (1, _), _)) |
@@ -904,7 +913,7 @@ mod __parse__Expr {
                     Some((_, (4, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(input, __sym0);
+                        let __nt = super::super::super::__action3::<F>(input, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -943,6 +952,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -955,7 +965,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(input, __sym0);
+                        let __nt = super::super::super::__action6::<F>(input, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1031,6 +1041,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1044,11 +1055,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym1));
+                        __result = try!(__state13(input, __tokens, __sym1, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym1));
+                        __result = try!(__state14(input, __tokens, __sym1, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1064,13 +1075,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state24(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state24(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<(F)>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state11(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state11(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<(F)>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state12(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<(F)>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1099,6 +1110,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1116,7 +1128,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0);
+                        let __nt = super::super::super::__action7::<F>(input, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1161,6 +1173,7 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, F, usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1168,12 +1181,12 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state8(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state8(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state9(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((_, (3, _), _)) |
@@ -1183,7 +1196,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<F>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1228,6 +1241,7 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, F, usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1235,12 +1249,12 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state8(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state8(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state9(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((_, (3, _), _)) |
@@ -1250,7 +1264,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<F>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1291,6 +1305,7 @@ mod __parse__Expr {
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1303,7 +1318,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<F>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1344,6 +1359,7 @@ mod __parse__Expr {
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1356,7 +1372,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<F>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1396,6 +1412,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, F, usize),
                 __sym2: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1413,7 +1430,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<F>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1470,6 +1487,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1484,11 +1502,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym2));
+                        __result = try!(__state13(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym2));
+                        __result = try!(__state14(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1504,10 +1522,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state25(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state25(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state12(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state12(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<(F)>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1555,6 +1573,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1569,11 +1588,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym2));
+                        __result = try!(__state13(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym2));
+                        __result = try!(__state14(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1589,10 +1608,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state26(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state26(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state12(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state12(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<(F)>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1626,6 +1645,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1638,11 +1658,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym2));
+                        __result = try!(__state13(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym2));
+                        __result = try!(__state14(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1655,7 +1675,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state27(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state27(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1690,6 +1710,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1702,11 +1723,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym2));
+                        __result = try!(__state13(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym2));
+                        __result = try!(__state14(input, __tokens, __sym2, ::std::marker::PhantomData::<(F)>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1719,7 +1740,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1755,6 +1776,7 @@ mod __parse__Expr {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: &mut Option<(usize, &'input str, usize)>,
                 __sym1: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1763,17 +1785,17 @@ mod __parse__Expr {
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state29(input, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state29(input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state20(input, __tokens, __sym1, __sym2));
+                        __result = try!(__state20(input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state21(input, __tokens, __sym1, __sym2));
+                        __result = try!(__state21(input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     _ => {
@@ -1812,6 +1834,7 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, F, usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1819,12 +1842,12 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state22(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state22(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state23(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state23(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((_, (1, _), _)) |
@@ -1834,7 +1857,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<F>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1879,6 +1902,7 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, F, usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1886,12 +1910,12 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state22(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state22(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state23(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state23(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
                     }
                     Some((_, (1, _), _)) |
@@ -1901,7 +1925,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<F>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1942,6 +1966,7 @@ mod __parse__Expr {
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -1954,7 +1979,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<F>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1995,6 +2020,7 @@ mod __parse__Expr {
                 __sym0: (usize, F, usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, F, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -2007,7 +2033,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<F>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -2047,6 +2073,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, F, usize),
                 __sym2: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<F>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -2064,7 +2091,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<F>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -2092,7 +2119,6 @@ mod __parse__Expr {
             use std::fmt::Debug;
             use std::ops::{Add, Div, Mul, Sub};
             use std::str::FromStr;
-            use util::tok::Tok;
             extern crate lalrpop_util as __lalrpop_util;
             #[allow(dead_code)]
             pub enum __Symbol<'input, F> {
@@ -2823,7 +2849,7 @@ mod __parse__Expr {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<(F)>) {
                                 return r;
                             }
                         } else {
@@ -2838,7 +2864,7 @@ mod __parse__Expr {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<(F)>) {
                             return r;
                         }
                     } else {
@@ -2858,6 +2884,7 @@ mod __parse__Expr {
                 __lookahead_start: Option<&usize>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input, F>,usize)>,
+                _: ::std::marker::PhantomData<(F)>,
             ) -> Option<Result<F,__lalrpop_util::ParseError<usize,(usize, &'input str),()>>> where
               F: Debug + FromStr + Sub<Output=F> + Add<Output=F> + Mul<Output=F> + Div<Output=F> + PartialEq + Eq,
             {
@@ -2869,7 +2896,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<F>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -2882,7 +2909,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<F>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -2893,7 +2920,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(input, __sym0);
+                        let __nt = super::super::super::__action3::<F>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -2906,7 +2933,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<F>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -2919,7 +2946,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<F>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -2930,7 +2957,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtTerm(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(input, __sym0);
+                        let __nt = super::super::super::__action6::<F>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -2941,7 +2968,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Termr_23_22_5b0_2d9_5d_2b_22_23(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0);
+                        let __nt = super::super::super::__action7::<F>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -2954,7 +2981,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Term_22_28_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<F>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -2965,7 +2992,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(input, __sym0);
+                        let __nt = super::super::super::__action0::<F>(input, __sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/expr_intern_tok.lalrpop
+++ b/lalrpop-test/src/expr_intern_tok.lalrpop
@@ -1,5 +1,4 @@
 use std::str::FromStr;
-use util::tok::Tok;
 
 grammar(scale: i32);
 

--- a/lalrpop-test/src/expr_intern_tok.rs
+++ b/lalrpop-test/src/expr_intern_tok.rs
@@ -1,12 +1,10 @@
 use std::str::FromStr;
-use util::tok::Tok;
 extern crate lalrpop_util as __lalrpop_util;
 
 mod __parse__Expr {
     #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
 
     use std::str::FromStr;
-    use util::tok::Tok;
     extern crate lalrpop_util as __lalrpop_util;
     pub fn parse_Expr<
         'input,
@@ -32,7 +30,6 @@ mod __parse__Expr {
             #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
 
             use std::str::FromStr;
-            use util::tok::Tok;
             extern crate lalrpop_util as __lalrpop_util;
             pub fn parse_Expr<
                 'input,
@@ -47,7 +44,7 @@ mod __parse__Expr {
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
-                match try!(__state0(scale, input, &mut __tokens, __lookahead)) {
+                match try!(__state0(scale, input, &mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -131,17 +128,18 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, input, __tokens, __sym0));
+                        __result = try!(__state5(scale, input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(scale, input, __tokens, __sym0));
+                        __result = try!(__state6(scale, input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -154,16 +152,16 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym0) => {
-                            __result = try!(__state1(scale, input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state1(scale, input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym0) => {
-                            __result = try!(__state2(scale, input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state2(scale, input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Num(__sym0) => {
-                            __result = try!(__state3(scale, input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state3(scale, input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym0) => {
-                            __result = try!(__state4(scale, input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state4(scale, input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -197,24 +195,25 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state7(scale, input, __tokens, __sym0, __sym1));
+                        __result = try!(__state7(scale, input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state8(scale, input, __tokens, __sym0, __sym1));
+                        __result = try!(__state8(scale, input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(scale, input, __sym0);
+                        let __nt = super::super::super::__action0::<>(scale, input, __sym0);
                         let __nt = __Nonterminal::____Expr((
                             __start,
                             __nt,
@@ -257,18 +256,19 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state9(scale, input, __tokens, __sym0, __sym1));
+                        __result = try!(__state9(scale, input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state10(scale, input, __tokens, __sym0, __sym1));
+                        __result = try!(__state10(scale, input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (3, _), _)) |
@@ -276,7 +276,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(scale, input, __sym0);
+                        let __nt = super::super::super::__action3::<>(scale, input, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -315,6 +315,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -326,7 +327,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(scale, input, __sym0);
+                        let __nt = super::super::super::__action7::<>(scale, input, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -365,6 +366,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -376,7 +378,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(scale, input, __sym0);
+                        let __nt = super::super::super::__action6::<>(scale, input, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -458,6 +460,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -470,11 +473,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state15(scale, input, __tokens, __sym1));
+                        __result = try!(__state15(scale, input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(scale, input, __tokens, __sym1));
+                        __result = try!(__state16(scale, input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -490,16 +493,16 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state11(scale, input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state11(scale, input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state12(scale, input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(scale, input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Num(__sym1) => {
-                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state14(scale, input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state14(scale, input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -528,6 +531,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -544,7 +548,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action9(scale, input, __sym0);
+                        let __nt = super::super::super::__action9::<>(scale, input, __sym0);
                         let __nt = __Nonterminal::Num((
                             __start,
                             __nt,
@@ -605,6 +609,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -618,11 +623,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, input, __tokens, __sym2));
+                        __result = try!(__state5(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(scale, input, __tokens, __sym2));
+                        __result = try!(__state6(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -638,13 +643,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state17(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state17(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Num(__sym2) => {
-                            __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state4(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state4(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -696,6 +701,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -709,11 +715,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, input, __tokens, __sym2));
+                        __result = try!(__state5(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(scale, input, __tokens, __sym2));
+                        __result = try!(__state6(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -729,13 +735,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state18(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state18(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Num(__sym2) => {
-                            __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state4(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state4(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -771,6 +777,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -782,11 +789,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, input, __tokens, __sym2));
+                        __result = try!(__state5(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(scale, input, __tokens, __sym2));
+                        __result = try!(__state6(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -799,10 +806,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Num(__sym2) => {
-                            __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state19(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state19(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -839,6 +846,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -850,11 +858,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, input, __tokens, __sym2));
+                        __result = try!(__state5(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(scale, input, __tokens, __sym2));
+                        __result = try!(__state6(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -867,10 +875,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Num(__sym2) => {
-                            __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state20(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state20(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -906,6 +914,7 @@ mod __parse__Expr {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: &mut Option<(usize, &'input str, usize)>,
                 __sym1: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -913,17 +922,17 @@ mod __parse__Expr {
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state21(scale, input, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state21(scale, input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state22(scale, input, __tokens, __sym1, __sym2));
+                        __result = try!(__state22(scale, input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state23(scale, input, __tokens, __sym1, __sym2));
+                        __result = try!(__state23(scale, input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -960,18 +969,19 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state24(scale, input, __tokens, __sym0, __sym1));
+                        __result = try!(__state24(scale, input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state25(scale, input, __tokens, __sym0, __sym1));
+                        __result = try!(__state25(scale, input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (1, _), _)) |
@@ -979,7 +989,7 @@ mod __parse__Expr {
                     Some((_, (4, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(scale, input, __sym0);
+                        let __nt = super::super::super::__action3::<>(scale, input, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1018,6 +1028,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1029,7 +1040,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(scale, input, __sym0);
+                        let __nt = super::super::super::__action7::<>(scale, input, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1068,6 +1079,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1079,7 +1091,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(scale, input, __sym0);
+                        let __nt = super::super::super::__action6::<>(scale, input, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1161,6 +1173,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1173,11 +1186,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state15(scale, input, __tokens, __sym1));
+                        __result = try!(__state15(scale, input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(scale, input, __tokens, __sym1));
+                        __result = try!(__state16(scale, input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1193,16 +1206,16 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state26(scale, input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state26(scale, input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state12(scale, input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(scale, input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Num(__sym1) => {
-                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state14(scale, input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state14(scale, input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1231,6 +1244,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1247,7 +1261,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action9(scale, input, __sym0);
+                        let __nt = super::super::super::__action9::<>(scale, input, __sym0);
                         let __nt = __Nonterminal::Num((
                             __start,
                             __nt,
@@ -1292,18 +1306,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, i32, usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state9(scale, input, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(scale, input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state10(scale, input, __tokens, __sym2, __sym3));
+                        __result = try!(__state10(scale, input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (3, _), _)) |
@@ -1313,7 +1328,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(scale, input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1358,18 +1373,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, i32, usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state9(scale, input, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(scale, input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state10(scale, input, __tokens, __sym2, __sym3));
+                        __result = try!(__state10(scale, input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (3, _), _)) |
@@ -1379,7 +1395,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(scale, input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1420,6 +1436,7 @@ mod __parse__Expr {
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1431,7 +1448,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(scale, input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1472,6 +1489,7 @@ mod __parse__Expr {
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1483,7 +1501,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(scale, input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1523,6 +1541,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, i32, usize),
                 __sym2: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1539,7 +1558,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(scale, input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1600,6 +1619,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1613,11 +1633,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state15(scale, input, __tokens, __sym2));
+                        __result = try!(__state15(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(scale, input, __tokens, __sym2));
+                        __result = try!(__state16(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1633,13 +1653,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state27(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state27(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Num(__sym2) => {
-                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state14(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state14(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1691,6 +1711,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1704,11 +1725,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state15(scale, input, __tokens, __sym2));
+                        __result = try!(__state15(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(scale, input, __tokens, __sym2));
+                        __result = try!(__state16(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1724,13 +1745,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state28(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state28(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Num(__sym2) => {
-                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state14(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state14(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1766,6 +1787,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1777,11 +1799,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state15(scale, input, __tokens, __sym2));
+                        __result = try!(__state15(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(scale, input, __tokens, __sym2));
+                        __result = try!(__state16(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1794,10 +1816,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Num(__sym2) => {
-                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state29(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state29(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1834,6 +1856,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1845,11 +1868,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state15(scale, input, __tokens, __sym2));
+                        __result = try!(__state15(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(scale, input, __tokens, __sym2));
+                        __result = try!(__state16(scale, input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1862,10 +1885,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Num(__sym2) => {
-                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state13(scale, input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state30(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state30(scale, input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1901,6 +1924,7 @@ mod __parse__Expr {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: &mut Option<(usize, &'input str, usize)>,
                 __sym1: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1908,17 +1932,17 @@ mod __parse__Expr {
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state31(scale, input, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state31(scale, input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state22(scale, input, __tokens, __sym1, __sym2));
+                        __result = try!(__state22(scale, input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state23(scale, input, __tokens, __sym1, __sym2));
+                        __result = try!(__state23(scale, input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -1957,18 +1981,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, i32, usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state24(scale, input, __tokens, __sym2, __sym3));
+                        __result = try!(__state24(scale, input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state25(scale, input, __tokens, __sym2, __sym3));
+                        __result = try!(__state25(scale, input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (1, _), _)) |
@@ -1978,7 +2003,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(scale, input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -2023,18 +2048,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, i32, usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state24(scale, input, __tokens, __sym2, __sym3));
+                        __result = try!(__state24(scale, input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state25(scale, input, __tokens, __sym2, __sym3));
+                        __result = try!(__state25(scale, input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (1, _), _)) |
@@ -2044,7 +2070,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(scale, input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -2085,6 +2111,7 @@ mod __parse__Expr {
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -2096,7 +2123,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(scale, input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -2137,6 +2164,7 @@ mod __parse__Expr {
                 __sym0: (usize, i32, usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, i32, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -2148,7 +2176,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(scale, input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -2188,6 +2216,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, i32, usize),
                 __sym2: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -2204,7 +2233,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(scale, input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -2230,7 +2259,6 @@ mod __parse__Expr {
             #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
 
             use std::str::FromStr;
-            use util::tok::Tok;
             extern crate lalrpop_util as __lalrpop_util;
             #[allow(dead_code)]
             pub enum __Symbol<'input> {
@@ -3054,7 +3082,7 @@ mod __parse__Expr {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(scale, input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(scale, input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -3069,7 +3097,7 @@ mod __parse__Expr {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(scale, input, __action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(scale, input, __action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -3089,6 +3117,7 @@ mod __parse__Expr {
                 __lookahead_start: Option<&usize>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<i32,__lalrpop_util::ParseError<usize,(usize, &'input str),()>>>
             {
                 let __nonterminal = match -__action {
@@ -3099,7 +3128,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(scale, input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -3112,7 +3141,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(scale, input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -3123,7 +3152,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(scale, input, __sym0);
+                        let __nt = super::super::super::__action3::<>(scale, input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -3136,7 +3165,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(scale, input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -3149,7 +3178,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(scale, input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -3160,7 +3189,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtTerm(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(scale, input, __sym0);
+                        let __nt = super::super::super::__action6::<>(scale, input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -3171,7 +3200,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Termr_23_22_5b0_2d9_5d_2b_22_23(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action9(scale, input, __sym0);
+                        let __nt = super::super::super::__action9::<>(scale, input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtNum(__nt), __end));
@@ -3182,7 +3211,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtNum(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(scale, input, __sym0);
+                        let __nt = super::super::super::__action7::<>(scale, input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -3195,7 +3224,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Term_22_28_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(scale, input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(scale, input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -3206,7 +3235,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(scale, input, __sym0);
+                        let __nt = super::super::super::__action0::<>(scale, input, __sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/expr_lalr.rs
+++ b/lalrpop-test/src/expr_lalr.rs
@@ -50,7 +50,7 @@ mod __parse__Expr {
                     None => None,
                     Some(Err(e)) => return Err(__lalrpop_util::ParseError::User { error: e }),
                 };
-                match try!(__state0(scale, &mut __tokens, __lookahead)) {
+                match try!(__state0(scale, &mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -99,17 +99,18 @@ mod __parse__Expr {
                 scale: i32,
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym0 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym0));
+                        __result = try!(__state4(scale, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym0));
+                        __result = try!(__state5(scale, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -122,13 +123,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym0) => {
-                            __result = try!(__state1(scale, __tokens, __lookahead, __sym0));
+                            __result = try!(__state1(scale, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym0) => {
-                            __result = try!(__state2(scale, __tokens, __lookahead, __sym0));
+                            __result = try!(__state2(scale, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym0) => {
-                            __result = try!(__state3(scale, __tokens, __lookahead, __sym0));
+                            __result = try!(__state3(scale, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -160,24 +161,25 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state6(scale, __tokens, __sym0, __sym1));
+                        __result = try!(__state6(scale, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state7(scale, __tokens, __sym0, __sym1));
+                        __result = try!(__state7(scale, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(scale, __sym0);
+                        let __nt = super::super::super::__action0::<>(scale, __sym0);
                         let __nt = __Nonterminal::____Expr((
                             __start,
                             __nt,
@@ -218,18 +220,19 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state8(scale, __tokens, __sym0, __sym1));
+                        __result = try!(__state8(scale, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(scale, __tokens, __sym0, __sym1));
+                        __result = try!(__state9(scale, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -238,7 +241,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(scale, __sym0);
+                        let __nt = super::super::super::__action3::<>(scale, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -275,6 +278,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -287,7 +291,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(scale, __sym0);
+                        let __nt = super::super::super::__action6::<>(scale, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -335,6 +339,7 @@ mod __parse__Expr {
                 scale: i32,
                 __tokens: &mut __TOKENS,
                 __sym0: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -347,11 +352,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym1));
+                        __result = try!(__state4(scale, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym1));
+                        __result = try!(__state5(scale, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -367,13 +372,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state10(scale, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state10(scale, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state2(scale, __tokens, __lookahead, __sym1));
+                            __result = try!(__state2(scale, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state3(scale, __tokens, __lookahead, __sym1));
+                            __result = try!(__state3(scale, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -400,6 +405,7 @@ mod __parse__Expr {
                 scale: i32,
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -417,7 +423,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(scale, __sym0);
+                        let __nt = super::super::super::__action7::<>(scale, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -462,6 +468,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -475,11 +482,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym2));
+                        __result = try!(__state4(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym2));
+                        __result = try!(__state5(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -495,10 +502,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state11(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state11(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(scale, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -534,6 +541,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -547,11 +555,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym2));
+                        __result = try!(__state4(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym2));
+                        __result = try!(__state5(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -567,10 +575,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state12(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state12(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state3(scale, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(scale, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -602,6 +610,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -613,11 +622,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym2));
+                        __result = try!(__state4(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym2));
+                        __result = try!(__state5(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -630,7 +639,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state13(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state13(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -663,6 +672,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -674,11 +684,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(scale, __tokens, __sym2));
+                        __result = try!(__state4(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(scale, __tokens, __sym2));
+                        __result = try!(__state5(scale, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -691,7 +701,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state14(scale, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state14(scale, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -725,6 +735,7 @@ mod __parse__Expr {
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: &mut Option<((), Tok, ())>,
                 __sym1: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -732,17 +743,17 @@ mod __parse__Expr {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state15(scale, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state15(scale, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state6(scale, __tokens, __sym1, __sym2));
+                        __result = try!(__state6(scale, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state7(scale, __tokens, __sym1, __sym2));
+                        __result = try!(__state7(scale, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -779,18 +790,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<((), i32, ())>,
                 __sym1: &mut Option<((), Tok, ())>,
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state8(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state8(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -801,7 +813,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -844,18 +856,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<((), i32, ())>,
                 __sym1: &mut Option<((), Tok, ())>,
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Times, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state8(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state8(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Div, __loc2)) => {
                         let __sym3 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(scale, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(scale, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, Tok::RParen, _)) |
@@ -866,7 +879,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -905,6 +918,7 @@ mod __parse__Expr {
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -917,7 +931,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -956,6 +970,7 @@ mod __parse__Expr {
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -968,7 +983,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1006,6 +1021,7 @@ mod __parse__Expr {
                 __sym0: ((), Tok, ()),
                 __sym1: ((), i32, ()),
                 __sym2: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -1023,7 +1039,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(scale, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1423,7 +1439,7 @@ mod __parse__Expr {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(scale, __action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(scale, __action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -1438,7 +1454,7 @@ mod __parse__Expr {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(scale, __action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(scale, __action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -1456,6 +1472,7 @@ mod __parse__Expr {
                 __lookahead_start: Option<&()>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<((),__Symbol<>,())>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<i32,__lalrpop_util::ParseError<(),Tok,()>>>
             {
                 let __nonterminal = match -__action {
@@ -1466,7 +1483,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(scale, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -1479,7 +1496,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(scale, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -1490,7 +1507,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(scale, __sym0);
+                        let __nt = super::super::super::__action3::<>(scale, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -1503,7 +1520,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(scale, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -1516,7 +1533,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(scale, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -1527,7 +1544,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtTerm(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(scale, __sym0);
+                        let __nt = super::super::super::__action6::<>(scale, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -1538,7 +1555,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_TermNum(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(scale, __sym0);
+                        let __nt = super::super::super::__action7::<>(scale, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -1551,7 +1568,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Term_22_28_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(scale, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(scale, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -1562,7 +1579,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(scale, __sym0);
+                        let __nt = super::super::super::__action0::<>(scale, __sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/generics_issue_104.lalrpop
+++ b/lalrpop-test/src/generics_issue_104.lalrpop
@@ -1,0 +1,10 @@
+use lalrpop_util::ParseError;
+use generics_issue_104_lib::Generator;
+
+grammar<T> where T: Generator;
+
+extern {
+    type Error = String;
+}
+
+pub Schema : String = "grammar" "{" <id:r"[a-zA-Z0-9]*"> "}" => T::schema(id);

--- a/lalrpop-test/src/generics_issue_104.rs
+++ b/lalrpop-test/src/generics_issue_104.rs
@@ -1,0 +1,1036 @@
+use lalrpop_util::ParseError;
+use generics_issue_104_lib::Generator;
+extern crate lalrpop_util as __lalrpop_util;
+
+mod __parse__Schema {
+    #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
+
+    use lalrpop_util::ParseError;
+    use generics_issue_104_lib::Generator;
+    extern crate lalrpop_util as __lalrpop_util;
+    pub fn parse_Schema<
+        'input,
+        T,
+    >(
+        input: &'input str,
+    ) -> Result<String, __lalrpop_util::ParseError<usize,(usize, &'input str),String>> where
+      T: Generator,
+    {
+        let __ascent = __ascent::parse_Schema::<T>(
+            input,
+        );
+        let __parse_table = __parse_table::parse_Schema::<T>(
+            input,
+        );
+        assert_eq!(__ascent, __parse_table);
+        return __ascent;
+    }
+    mod __ascent {
+
+        mod __parse__Schema {
+            #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
+
+            use lalrpop_util::ParseError;
+            use generics_issue_104_lib::Generator;
+            extern crate lalrpop_util as __lalrpop_util;
+            pub fn parse_Schema<
+                'input,
+                T,
+            >(
+                input: &'input str,
+            ) -> Result<String, __lalrpop_util::ParseError<usize,(usize, &'input str),String>> where
+              T: Generator,
+            {
+                let mut __tokens = super::super::super::__intern_token::__Matcher::new(input);
+                let __lookahead = match __tokens.next() {
+                    Some(Ok(v)) => Some(v),
+                    None => None,
+                    Some(Err(e)) => return Err(e),
+                };
+                match try!(__state0(input, &mut __tokens, __lookahead, ::std::marker::PhantomData::<(T)>)) {
+                    (Some(__lookahead), _) => {
+                        Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
+                    }
+                    (None, __Nonterminal::____Schema((_, __nt, _))) => {
+                        Ok(__nt)
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            #[allow(dead_code)]
+            pub enum __Nonterminal<> {
+                Schema((usize, String, usize)),
+                ____Schema((usize, String, usize)),
+            }
+
+            // State 0
+            //     AllInputs = []
+            //     OptionalInputs = []
+            //     FixedInputs = []
+            //     WillPushLen = 0
+            //     WillPush = []
+            //     WillProduce = None
+            //
+            //     Schema = (*) "grammar" "{" r#"[a-zA-Z0-9]*"# "}" [EOF]
+            //     __Schema = (*) Schema [EOF]
+            //
+            //   "grammar" -> S2
+            //
+            //     Schema -> S1
+            pub fn __state0<
+                'input,
+                T,
+                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize,(usize, &'input str),String>>>,
+            >(
+                input: &'input str,
+                __tokens: &mut __TOKENS,
+                __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                _: ::std::marker::PhantomData<(T)>,
+            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),String>> where
+              T: Generator,
+            {
+                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                match __lookahead {
+                    Some((__loc1, (0, __tok0), __loc2)) => {
+                        let __sym0 = (__loc1, (__tok0), __loc2);
+                        __result = try!(__state2(input, __tokens, __sym0, ::std::marker::PhantomData::<(T)>));
+                    }
+                    _ => {
+                        return Err(__lalrpop_util::ParseError::UnrecognizedToken {
+                            token: __lookahead,
+                            expected: vec![],
+                        });
+                    }
+                }
+                loop {
+                    let (__lookahead, __nt) = __result;
+                    match __nt {
+                        __Nonterminal::Schema(__sym0) => {
+                            __result = try!(__state1(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<(T)>));
+                        }
+                        _ => {
+                            return Ok((__lookahead, __nt));
+                        }
+                    }
+                }
+            }
+
+            // State 1
+            //     AllInputs = [Schema]
+            //     OptionalInputs = []
+            //     FixedInputs = [Schema]
+            //     WillPushLen = 0
+            //     WillPush = []
+            //     WillProduce = Some(__Schema)
+            //
+            //     __Schema = Schema (*) [EOF]
+            //
+            //   [EOF] -> __Schema = Schema => ActionFn(0);
+            //
+            pub fn __state1<
+                'input,
+                T,
+                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize,(usize, &'input str),String>>>,
+            >(
+                input: &'input str,
+                __tokens: &mut __TOKENS,
+                __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                __sym0: (usize, String, usize),
+                _: ::std::marker::PhantomData<(T)>,
+            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),String>> where
+              T: Generator,
+            {
+                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                match __lookahead {
+                    None => {
+                        let __start = __sym0.0.clone();
+                        let __end = __sym0.2.clone();
+                        let __nt = super::super::super::__action0::<T>(input, __sym0);
+                        let __nt = __Nonterminal::____Schema((
+                            __start,
+                            __nt,
+                            __end,
+                        ));
+                        __result = (__lookahead, __nt);
+                        return Ok(__result);
+                    }
+                    _ => {
+                        return Err(__lalrpop_util::ParseError::UnrecognizedToken {
+                            token: __lookahead,
+                            expected: vec![],
+                        });
+                    }
+                }
+            }
+
+            // State 2
+            //     AllInputs = ["grammar"]
+            //     OptionalInputs = []
+            //     FixedInputs = ["grammar"]
+            //     WillPushLen = 3
+            //     WillPush = ["{", r#"[a-zA-Z0-9]*"#, "}"]
+            //     WillProduce = Some(Schema)
+            //
+            //     Schema = "grammar" (*) "{" r#"[a-zA-Z0-9]*"# "}" [EOF]
+            //
+            //   "{" -> S3
+            //
+            pub fn __state2<
+                'input,
+                T,
+                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize,(usize, &'input str),String>>>,
+            >(
+                input: &'input str,
+                __tokens: &mut __TOKENS,
+                __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(T)>,
+            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),String>> where
+              T: Generator,
+            {
+                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let __lookahead = match __tokens.next() {
+                    Some(Ok(v)) => Some(v),
+                    None => None,
+                    Some(Err(e)) => return Err(e),
+                };
+                match __lookahead {
+                    Some((__loc1, (1, __tok0), __loc2)) => {
+                        let __sym1 = (__loc1, (__tok0), __loc2);
+                        __result = try!(__state3(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<(T)>));
+                        return Ok(__result);
+                    }
+                    _ => {
+                        return Err(__lalrpop_util::ParseError::UnrecognizedToken {
+                            token: __lookahead,
+                            expected: vec![],
+                        });
+                    }
+                }
+            }
+
+            // State 3
+            //     AllInputs = ["grammar", "{"]
+            //     OptionalInputs = []
+            //     FixedInputs = ["grammar", "{"]
+            //     WillPushLen = 2
+            //     WillPush = [r#"[a-zA-Z0-9]*"#, "}"]
+            //     WillProduce = Some(Schema)
+            //
+            //     Schema = "grammar" "{" (*) r#"[a-zA-Z0-9]*"# "}" [EOF]
+            //
+            //   r#"[a-zA-Z0-9]*"# -> S4
+            //
+            pub fn __state3<
+                'input,
+                T,
+                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize,(usize, &'input str),String>>>,
+            >(
+                input: &'input str,
+                __tokens: &mut __TOKENS,
+                __sym0: (usize, &'input str, usize),
+                __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(T)>,
+            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),String>> where
+              T: Generator,
+            {
+                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let __lookahead = match __tokens.next() {
+                    Some(Ok(v)) => Some(v),
+                    None => None,
+                    Some(Err(e)) => return Err(e),
+                };
+                match __lookahead {
+                    Some((__loc1, (3, __tok0), __loc2)) => {
+                        let __sym2 = (__loc1, (__tok0), __loc2);
+                        __result = try!(__state4(input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(T)>));
+                        return Ok(__result);
+                    }
+                    _ => {
+                        return Err(__lalrpop_util::ParseError::UnrecognizedToken {
+                            token: __lookahead,
+                            expected: vec![],
+                        });
+                    }
+                }
+            }
+
+            // State 4
+            //     AllInputs = ["grammar", "{", r#"[a-zA-Z0-9]*"#]
+            //     OptionalInputs = []
+            //     FixedInputs = ["grammar", "{", r#"[a-zA-Z0-9]*"#]
+            //     WillPushLen = 1
+            //     WillPush = ["}"]
+            //     WillProduce = Some(Schema)
+            //
+            //     Schema = "grammar" "{" r#"[a-zA-Z0-9]*"# (*) "}" [EOF]
+            //
+            //   "}" -> S5
+            //
+            pub fn __state4<
+                'input,
+                T,
+                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize,(usize, &'input str),String>>>,
+            >(
+                input: &'input str,
+                __tokens: &mut __TOKENS,
+                __sym0: (usize, &'input str, usize),
+                __sym1: (usize, &'input str, usize),
+                __sym2: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(T)>,
+            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),String>> where
+              T: Generator,
+            {
+                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let __lookahead = match __tokens.next() {
+                    Some(Ok(v)) => Some(v),
+                    None => None,
+                    Some(Err(e)) => return Err(e),
+                };
+                match __lookahead {
+                    Some((__loc1, (2, __tok0), __loc2)) => {
+                        let __sym3 = (__loc1, (__tok0), __loc2);
+                        __result = try!(__state5(input, __tokens, __sym0, __sym1, __sym2, __sym3, ::std::marker::PhantomData::<(T)>));
+                        return Ok(__result);
+                    }
+                    _ => {
+                        return Err(__lalrpop_util::ParseError::UnrecognizedToken {
+                            token: __lookahead,
+                            expected: vec![],
+                        });
+                    }
+                }
+            }
+
+            // State 5
+            //     AllInputs = ["grammar", "{", r#"[a-zA-Z0-9]*"#, "}"]
+            //     OptionalInputs = []
+            //     FixedInputs = ["grammar", "{", r#"[a-zA-Z0-9]*"#, "}"]
+            //     WillPushLen = 0
+            //     WillPush = []
+            //     WillProduce = Some(Schema)
+            //
+            //     Schema = "grammar" "{" r#"[a-zA-Z0-9]*"# "}" (*) [EOF]
+            //
+            //   [EOF] -> Schema = "grammar", "{", r#"[a-zA-Z0-9]*"#, "}" => ActionFn(1);
+            //
+            pub fn __state5<
+                'input,
+                T,
+                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize,(usize, &'input str),String>>>,
+            >(
+                input: &'input str,
+                __tokens: &mut __TOKENS,
+                __sym0: (usize, &'input str, usize),
+                __sym1: (usize, &'input str, usize),
+                __sym2: (usize, &'input str, usize),
+                __sym3: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<(T)>,
+            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),String>> where
+              T: Generator,
+            {
+                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let __lookahead = match __tokens.next() {
+                    Some(Ok(v)) => Some(v),
+                    None => None,
+                    Some(Err(e)) => return Err(e),
+                };
+                match __lookahead {
+                    None => {
+                        let __start = __sym0.0.clone();
+                        let __end = __sym3.2.clone();
+                        let __nt = super::super::super::__action1::<T>(input, __sym0, __sym1, __sym2, __sym3);
+                        let __nt = __Nonterminal::Schema((
+                            __start,
+                            __nt,
+                            __end,
+                        ));
+                        __result = (__lookahead, __nt);
+                        return Ok(__result);
+                    }
+                    _ => {
+                        return Err(__lalrpop_util::ParseError::UnrecognizedToken {
+                            token: __lookahead,
+                            expected: vec![],
+                        });
+                    }
+                }
+            }
+        }
+        pub use self::__parse__Schema::parse_Schema;
+    }
+    mod __parse_table {
+
+        mod __parse__Schema {
+            #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
+
+            use lalrpop_util::ParseError;
+            use generics_issue_104_lib::Generator;
+            extern crate lalrpop_util as __lalrpop_util;
+            #[allow(dead_code)]
+            pub enum __Symbol<'input> {
+                Term_22grammar_22(&'input str),
+                Term_22_7b_22(&'input str),
+                Term_22_7d_22(&'input str),
+                Termr_23_22_5ba_2dzA_2dZ0_2d9_5d_2a_22_23(&'input str),
+                NtSchema(String),
+                Nt____Schema(String),
+            }
+            const __ACTION: &'static [i32] = &[
+                // State 0
+                //     Schema = (*) "grammar" "{" r#"[a-zA-Z0-9]*"# "}" [EOF]
+                //     __Schema = (*) Schema [EOF]
+                3, // on "grammar", goto 2
+                0, // on "{", error
+                0, // on "}", error
+                0, // on r#"[a-zA-Z0-9]*"#, error
+                // State 1
+                //     __Schema = Schema (*) [EOF]
+                0, // on "grammar", error
+                0, // on "{", error
+                0, // on "}", error
+                0, // on r#"[a-zA-Z0-9]*"#, error
+                // State 2
+                //     Schema = "grammar" (*) "{" r#"[a-zA-Z0-9]*"# "}" [EOF]
+                0, // on "grammar", error
+                4, // on "{", goto 3
+                0, // on "}", error
+                0, // on r#"[a-zA-Z0-9]*"#, error
+                // State 3
+                //     Schema = "grammar" "{" (*) r#"[a-zA-Z0-9]*"# "}" [EOF]
+                0, // on "grammar", error
+                0, // on "{", error
+                0, // on "}", error
+                5, // on r#"[a-zA-Z0-9]*"#, goto 4
+                // State 4
+                //     Schema = "grammar" "{" r#"[a-zA-Z0-9]*"# (*) "}" [EOF]
+                0, // on "grammar", error
+                0, // on "{", error
+                6, // on "}", goto 5
+                0, // on r#"[a-zA-Z0-9]*"#, error
+                // State 5
+                //     Schema = "grammar" "{" r#"[a-zA-Z0-9]*"# "}" (*) [EOF]
+                0, // on "grammar", error
+                0, // on "{", error
+                0, // on "}", error
+                0, // on r#"[a-zA-Z0-9]*"#, error
+            ];
+            const __EOF_ACTION: &'static [i32] = &[
+                0, // on EOF, error
+                -2, // on EOF, reduce `__Schema = Schema => ActionFn(0);`
+                0, // on EOF, error
+                0, // on EOF, error
+                0, // on EOF, error
+                -1, // on EOF, reduce `Schema = "grammar", "{", r#"[a-zA-Z0-9]*"#, "}" => ActionFn(1);`
+            ];
+            const __GOTO: &'static [i32] = &[
+                // State 0
+                2, // on Schema, goto 1
+                0, // on __Schema, error
+                // State 1
+                0, // on Schema, error
+                0, // on __Schema, error
+                // State 2
+                0, // on Schema, error
+                0, // on __Schema, error
+                // State 3
+                0, // on Schema, error
+                0, // on __Schema, error
+                // State 4
+                0, // on Schema, error
+                0, // on __Schema, error
+                // State 5
+                0, // on Schema, error
+                0, // on __Schema, error
+            ];
+            pub fn parse_Schema<
+                'input,
+                T,
+            >(
+                input: &'input str,
+            ) -> Result<String, __lalrpop_util::ParseError<usize,(usize, &'input str),String>> where
+              T: Generator,
+            {
+                let mut __tokens = super::super::super::__intern_token::__Matcher::new(input);
+                let mut __states = vec![0_i32];
+                let mut __symbols = vec![];
+                '__shift: loop {
+                    let __lookahead = match __tokens.next() {
+                        Some(Ok(v)) => v,
+                        None => break '__shift,
+                        Some(Err(e)) => return Err(e),
+                    };
+                    let __integer = match __lookahead {
+                        (_, (0, _), _) if true => 0,
+                        (_, (1, _), _) if true => 1,
+                        (_, (2, _), _) if true => 2,
+                        (_, (3, _), _) if true => 3,
+                        _ => {
+                            return Err(__lalrpop_util::ParseError::UnrecognizedToken {
+                                token: Some(__lookahead),
+                                expected: vec![],
+                            });
+                        }
+                    };
+                    loop {
+                        let __state = *__states.last().unwrap() as usize;
+                        let __action = __ACTION[__state * 4 + __integer];
+                        if __action > 0 {
+                            let __symbol = match __integer {
+                                0 => match __lookahead.1 {
+                                    (0, __tok0) => __Symbol::Term_22grammar_22(__tok0),
+                                    _ => unreachable!(),
+                                },
+                                1 => match __lookahead.1 {
+                                    (1, __tok0) => __Symbol::Term_22_7b_22(__tok0),
+                                    _ => unreachable!(),
+                                },
+                                2 => match __lookahead.1 {
+                                    (2, __tok0) => __Symbol::Term_22_7d_22(__tok0),
+                                    _ => unreachable!(),
+                                },
+                                3 => match __lookahead.1 {
+                                    (3, __tok0) => __Symbol::Termr_23_22_5ba_2dzA_2dZ0_2d9_5d_2a_22_23(__tok0),
+                                    _ => unreachable!(),
+                                },
+                                _ => unreachable!(),
+                            };
+                            __states.push(__action - 1);
+                            __symbols.push((__lookahead.0, __symbol, __lookahead.2));
+                            continue '__shift;
+                        } else if __action < 0 {
+                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<(T)>) {
+                                return r;
+                            }
+                        } else {
+                            return Err(__lalrpop_util::ParseError::UnrecognizedToken {
+                                token: Some(__lookahead),
+                                expected: vec![],
+                            });
+                        }
+                    }
+                }
+                loop {
+                    let __state = *__states.last().unwrap() as usize;
+                    let __action = __EOF_ACTION[__state];
+                    if __action < 0 {
+                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<(T)>) {
+                            return r;
+                        }
+                    } else {
+                        return Err(__lalrpop_util::ParseError::UnrecognizedToken {
+                            token: None,
+                            expected: vec![],
+                        });
+                    }
+                }
+            }
+            pub fn __reduce<
+                'input,
+                T,
+            >(
+                input: &'input str,
+                __action: i32,
+                __lookahead_start: Option<&usize>,
+                __states: &mut ::std::vec::Vec<i32>,
+                __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>,
+                _: ::std::marker::PhantomData<(T)>,
+            ) -> Option<Result<String,__lalrpop_util::ParseError<usize,(usize, &'input str),String>>> where
+              T: Generator,
+            {
+                let __nonterminal = match -__action {
+                    1 => {
+                        // Schema = "grammar", "{", r#"[a-zA-Z0-9]*"#, "}" => ActionFn(1);
+                        let __sym3 = __pop_Term_22_7d_22(__symbols);
+                        let __sym2 = __pop_Termr_23_22_5ba_2dzA_2dZ0_2d9_5d_2a_22_23(__symbols);
+                        let __sym1 = __pop_Term_22_7b_22(__symbols);
+                        let __sym0 = __pop_Term_22grammar_22(__symbols);
+                        let __start = __sym0.0.clone();
+                        let __end = __sym3.2.clone();
+                        let __nt = super::super::super::__action1::<T>(input, __sym0, __sym1, __sym2, __sym3);
+                        let __states_len = __states.len();
+                        __states.truncate(__states_len - 4);
+                        __symbols.push((__start, __Symbol::NtSchema(__nt), __end));
+                        0
+                    }
+                    2 => {
+                        // __Schema = Schema => ActionFn(0);
+                        let __sym0 = __pop_NtSchema(__symbols);
+                        let __start = __sym0.0.clone();
+                        let __end = __sym0.2.clone();
+                        let __nt = super::super::super::__action0::<T>(input, __sym0);
+                        return Some(Ok(__nt));
+                    }
+                    _ => panic!("invalid action code {}", __action)
+                };
+                let __state = *__states.last().unwrap() as usize;
+                let __next_state = __GOTO[__state * 2 + __nonterminal] - 1;
+                __states.push(__next_state);
+                None
+            }
+            fn __pop_Term_22grammar_22<
+              'input,
+            >(
+                __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>
+            ) -> (usize, &'input str, usize) {
+                match __symbols.pop().unwrap() {
+                    (__l, __Symbol::Term_22grammar_22(__v), __r) => (__l, __v, __r),
+                    _ => panic!("symbol type mismatch")
+                }
+            }
+            fn __pop_Term_22_7b_22<
+              'input,
+            >(
+                __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>
+            ) -> (usize, &'input str, usize) {
+                match __symbols.pop().unwrap() {
+                    (__l, __Symbol::Term_22_7b_22(__v), __r) => (__l, __v, __r),
+                    _ => panic!("symbol type mismatch")
+                }
+            }
+            fn __pop_Term_22_7d_22<
+              'input,
+            >(
+                __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>
+            ) -> (usize, &'input str, usize) {
+                match __symbols.pop().unwrap() {
+                    (__l, __Symbol::Term_22_7d_22(__v), __r) => (__l, __v, __r),
+                    _ => panic!("symbol type mismatch")
+                }
+            }
+            fn __pop_Termr_23_22_5ba_2dzA_2dZ0_2d9_5d_2a_22_23<
+              'input,
+            >(
+                __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>
+            ) -> (usize, &'input str, usize) {
+                match __symbols.pop().unwrap() {
+                    (__l, __Symbol::Termr_23_22_5ba_2dzA_2dZ0_2d9_5d_2a_22_23(__v), __r) => (__l, __v, __r),
+                    _ => panic!("symbol type mismatch")
+                }
+            }
+            fn __pop_NtSchema<
+              'input,
+            >(
+                __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>
+            ) -> (usize, String, usize) {
+                match __symbols.pop().unwrap() {
+                    (__l, __Symbol::NtSchema(__v), __r) => (__l, __v, __r),
+                    _ => panic!("symbol type mismatch")
+                }
+            }
+            fn __pop_Nt____Schema<
+              'input,
+            >(
+                __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>
+            ) -> (usize, String, usize) {
+                match __symbols.pop().unwrap() {
+                    (__l, __Symbol::Nt____Schema(__v), __r) => (__l, __v, __r),
+                    _ => panic!("symbol type mismatch")
+                }
+            }
+        }
+        pub use self::__parse__Schema::parse_Schema;
+    }
+}
+pub use self::__parse__Schema::parse_Schema;
+mod __intern_token {
+    extern crate lalrpop_util as __lalrpop_util;
+    pub struct __Matcher<'input> {
+        text: &'input str,
+        consumed: usize,
+    }
+
+    fn __tokenize(text: &str) -> Option<(usize, usize)> {
+        let mut __chars = text.char_indices();
+        let mut __current_match: Option<(usize, usize)> = None;
+        let mut __current_state: usize = 0;
+        loop {
+            match __current_state {
+                0 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        65 ... 90 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        97 ... 102 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        103 => /* 'g' */ {
+                            __current_match = Some((3, __index + 1));
+                            __current_state = 2;
+                            continue;
+                        }
+                        104 ... 122 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        123 => /* '{' */ {
+                            __current_match = Some((1, __index + 1));
+                            __current_state = 3;
+                            continue;
+                        }
+                        125 => /* '}' */ {
+                            __current_match = Some((2, __index + 1));
+                            __current_state = 4;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                1 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        65 ... 90 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        97 ... 122 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                2 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        65 ... 90 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        97 ... 113 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        114 => /* 'r' */ {
+                            __current_match = Some((3, __index + 1));
+                            __current_state = 6;
+                            continue;
+                        }
+                        115 ... 122 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                3 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                4 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                5 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                6 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        65 ... 90 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        97 => /* 'a' */ {
+                            __current_match = Some((3, __index + 1));
+                            __current_state = 7;
+                            continue;
+                        }
+                        98 ... 122 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                7 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        65 ... 90 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        97 ... 108 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        109 => /* 'm' */ {
+                            __current_match = Some((3, __index + 1));
+                            __current_state = 8;
+                            continue;
+                        }
+                        110 ... 122 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                8 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        65 ... 90 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        97 ... 108 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        109 => /* 'm' */ {
+                            __current_match = Some((3, __index + 1));
+                            __current_state = 9;
+                            continue;
+                        }
+                        110 ... 122 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                9 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        65 ... 90 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        97 => /* 'a' */ {
+                            __current_match = Some((3, __index + 1));
+                            __current_state = 10;
+                            continue;
+                        }
+                        98 ... 122 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                10 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        65 ... 90 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        97 ... 113 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        114 => /* 'r' */ {
+                            __current_match = Some((0, __index + 1));
+                            __current_state = 11;
+                            continue;
+                        }
+                        115 ... 122 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                11 => {
+                    let (__index, __ch) = match __chars.next() { Some(p) => p, None => return __current_match };
+                    match __ch as u32 {
+                        48 ... 57 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        65 ... 90 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        97 ... 122 => {
+                            __current_match = Some((3, __index + __ch.len_utf8()));
+                            __current_state = 1;
+                            continue;
+                        }
+                        _ => {
+                            return __current_match;
+                        }
+                    }
+                }
+                _ => { panic!("invalid state {}", __current_state); }
+            }
+        }
+    }
+
+    impl<'input> __Matcher<'input> {
+        pub fn new(s: &'input str) -> __Matcher<'input> {
+            __Matcher { text: s, consumed: 0 }
+        }
+    }
+
+    impl<'input> Iterator for __Matcher<'input> {
+        type Item = Result<(usize, (usize, &'input str), usize), __lalrpop_util::ParseError<usize,(usize, &'input str),String>>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let __text = self.text.trim_left();
+            let __whitespace = self.text.len() - __text.len();
+            let __start_offset = self.consumed + __whitespace;
+            if __text.is_empty() {
+                self.text = __text;
+                self.consumed = __start_offset;
+                None
+            } else {
+                match __tokenize(__text) {
+                    Some((__index, __length)) => {
+                        let __result = &__text[..__length];
+                        let __remaining = &__text[__length..];
+                        let __end_offset = __start_offset + __length;
+                        self.text = __remaining;
+                        self.consumed = __end_offset;
+                        Some(Ok((__start_offset, (__index, __result), __end_offset)))
+                    }
+                    None => {
+                        Some(Err(__lalrpop_util::ParseError::InvalidToken { location: __start_offset }))
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[allow(unused_variables)]
+pub fn __action0<
+    'input,
+    T,
+>(
+    input: &'input str,
+    (_, __0, _): (usize, String, usize),
+) -> String where
+  T: Generator,
+{
+    (__0)
+}
+
+#[allow(unused_variables)]
+pub fn __action1<
+    'input,
+    T,
+>(
+    input: &'input str,
+    (_, _, _): (usize, &'input str, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, id, _): (usize, &'input str, usize),
+    (_, _, _): (usize, &'input str, usize),
+) -> String where
+  T: Generator,
+{
+    T::schema(id)
+}
+
+pub trait __ToTriple<'input, T, > {
+    type Error;
+    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),Self::Error>;
+}
+
+impl<'input, T, > __ToTriple<'input, T, > for (usize, (usize, &'input str), usize) {
+    type Error = String;
+    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),String> {
+        Ok(value)
+    }
+}
+impl<'input, T, > __ToTriple<'input, T, > for Result<(usize, (usize, &'input str), usize),String> {
+    type Error = String;
+    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),String> {
+        value
+    }
+}

--- a/lalrpop-test/src/generics_issue_104_lib.rs
+++ b/lalrpop-test/src/generics_issue_104_lib.rs
@@ -1,0 +1,9 @@
+pub trait Generator {
+    fn schema(s: &str) -> String;
+}
+
+impl Generator for () {
+    fn schema(s: &str) -> String {
+        s.to_string()
+    }
+}

--- a/lalrpop-test/src/inline.rs
+++ b/lalrpop-test/src/inline.rs
@@ -37,7 +37,7 @@ mod __parse__E {
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
-                match try!(__state0(input, &mut __tokens, __lookahead)) {
+                match try!(__state0(input, &mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -80,17 +80,18 @@ mod __parse__E {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state2(input, __tokens, __sym0));
+                        __result = try!(__state2(input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state3(input, __tokens, __sym0));
+                        __result = try!(__state3(input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -103,7 +104,7 @@ mod __parse__E {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::E(__sym0) => {
-                            __result = try!(__state1(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state1(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -132,6 +133,7 @@ mod __parse__E {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, String, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -139,7 +141,7 @@ mod __parse__E {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(input, __sym0);
+                        let __nt = super::super::super::__action0::<>(input, __sym0);
                         let __nt = __Nonterminal::____E((
                             __start,
                             __nt,
@@ -182,6 +184,7 @@ mod __parse__E {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -194,11 +197,11 @@ mod __parse__E {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state2(input, __tokens, __sym1));
+                        __result = try!(__state2(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state5(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -215,7 +218,7 @@ mod __parse__E {
                     match __nt {
                         __Nonterminal::E(__sym1) => {
                             let __sym0 = __sym0.take().unwrap();
-                            __result = try!(__state4(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state4(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -244,6 +247,7 @@ mod __parse__E {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -256,7 +260,7 @@ mod __parse__E {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action1(input, __sym0);
+                        let __nt = super::super::super::__action1::<>(input, __sym0);
                         let __nt = __Nonterminal::E((
                             __start,
                             __nt,
@@ -295,6 +299,7 @@ mod __parse__E {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, String, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -302,7 +307,7 @@ mod __parse__E {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action7::<>(input, __sym0, __sym1);
                         let __nt = __Nonterminal::E((
                             __start,
                             __nt,
@@ -347,6 +352,7 @@ mod __parse__E {
                 __tokens: &mut __TOKENS,
                 __sym0: &mut Option<(usize, &'input str, usize)>,
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -358,16 +364,16 @@ mod __parse__E {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state2(input, __tokens, __sym2));
+                        __result = try!(__state2(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state3(input, __tokens, __sym2));
+                        __result = try!(__state3(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     None => {
                         let __start = __sym1.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action1(input, __sym1);
+                        let __nt = super::super::super::__action1::<>(input, __sym1);
                         let __nt = __Nonterminal::E((
                             __start,
                             __nt,
@@ -388,7 +394,7 @@ mod __parse__E {
                     match __nt {
                         __Nonterminal::E(__sym2) => {
                             let __sym0 = __sym0.take().unwrap();
-                            __result = try!(__state6(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state6(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -420,6 +426,7 @@ mod __parse__E {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, String, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -427,7 +434,7 @@ mod __parse__E {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::E((
                             __start,
                             __nt,
@@ -593,7 +600,7 @@ mod __parse__E {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -608,7 +615,7 @@ mod __parse__E {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -627,6 +634,7 @@ mod __parse__E {
                 __lookahead_start: Option<&usize>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<String,__lalrpop_util::ParseError<usize,(usize, &'input str),()>>>
             {
                 let __nonterminal = match -__action {
@@ -634,7 +642,7 @@ mod __parse__E {
                         // () =  => ActionFn(5);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action5(input, &__start, &__end);
+                        let __nt = super::super::super::__action5::<>(input, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::Nt_28_29(__nt), __end));
@@ -645,7 +653,7 @@ mod __parse__E {
                         let __sym0 = __pop_Term_22L_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action1(input, __sym0);
+                        let __nt = super::super::super::__action1::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtE(__nt), __end));
@@ -657,7 +665,7 @@ mod __parse__E {
                         let __sym0 = __pop_Term_22_26_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action7::<>(input, __sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::NtE(__nt), __end));
@@ -670,7 +678,7 @@ mod __parse__E {
                         let __sym0 = __pop_Term_22_26_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtE(__nt), __end));
@@ -680,7 +688,7 @@ mod __parse__E {
                         // OPT_L =  => ActionFn(6);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action6(input, &__start, &__end);
+                        let __nt = super::super::super::__action6::<>(input, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::NtOPT__L(__nt), __end));
@@ -691,7 +699,7 @@ mod __parse__E {
                         let __sym0 = __pop_Term_22L_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action4(input, __sym0);
+                        let __nt = super::super::super::__action4::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtOPT__L(__nt), __end));
@@ -702,7 +710,7 @@ mod __parse__E {
                         let __sym0 = __pop_NtE(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(input, __sym0);
+                        let __nt = super::super::super::__action0::<>(input, __sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/intern_tok.lalrpop
+++ b/lalrpop-test/src/intern_tok.lalrpop
@@ -2,9 +2,6 @@
 // indirectly the case where there is a type/lifetime parameter
 // (`'input`) that is not used in any nonterminal return type.
 
-
-use util::tok::Tok;
-
 grammar;
 
 pub Items: Vec<(usize, usize)> = {

--- a/lalrpop-test/src/intern_tok.rs
+++ b/lalrpop-test/src/intern_tok.rs
@@ -1,10 +1,8 @@
-use util::tok::Tok;
 extern crate lalrpop_util as __lalrpop_util;
 
 mod __parse__Items {
     #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
 
-    use util::tok::Tok;
     extern crate lalrpop_util as __lalrpop_util;
     pub fn parse_Items<
         'input,
@@ -26,7 +24,6 @@ mod __parse__Items {
         mod __parse__Items {
             #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
 
-            use util::tok::Tok;
             extern crate lalrpop_util as __lalrpop_util;
             pub fn parse_Items<
                 'input,
@@ -40,7 +37,7 @@ mod __parse__Items {
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
-                match try!(__state0(input, &mut __tokens, __lookahead)) {
+                match try!(__state0(input, &mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -91,6 +88,7 @@ mod __parse__Items {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -100,7 +98,7 @@ mod __parse__Items {
                     None => {
                         let __start: usize = ::std::default::Default::default();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action9(input, &__start, &__end);
+                        let __nt = super::super::super::__action9::<>(input, &__start, &__end);
                         let __nt = __Nonterminal::Items((
                             __start,
                             __nt,
@@ -119,7 +117,7 @@ mod __parse__Items {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Items(__sym0) => {
-                            __result = try!(__state1(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state1(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -154,23 +152,24 @@ mod __parse__Items {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, Vec<(usize, usize)>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state3(input, __tokens, __sym1));
+                        __result = try!(__state3(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state4(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(input, __sym0);
+                        let __nt = super::super::super::__action0::<>(input, __sym0);
                         let __nt = __Nonterminal::____Items((
                             __start,
                             __nt,
@@ -190,7 +189,7 @@ mod __parse__Items {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Spanned_3c_22_2b_22_3e(__sym1) => {
-                            __result = try!(__state2(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state2(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -221,6 +220,7 @@ mod __parse__Items {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, Vec<(usize, usize)>, usize),
                 __sym1: (usize, (usize, usize), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -230,7 +230,7 @@ mod __parse__Items {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action2(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action2::<>(input, __sym0, __sym1);
                         let __nt = __Nonterminal::Items((
                             __start,
                             __nt,
@@ -267,6 +267,7 @@ mod __parse__Items {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -281,7 +282,7 @@ mod __parse__Items {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action10(input, __sym0);
+                        let __nt = super::super::super::__action10::<>(input, __sym0);
                         let __nt = __Nonterminal::Spanned_3c_22_2b_22_3e((
                             __start,
                             __nt,
@@ -319,6 +320,7 @@ mod __parse__Items {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Vec<(usize, usize)>, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -333,7 +335,7 @@ mod __parse__Items {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action3(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action3::<>(input, __sym0, __sym1);
                         let __nt = __Nonterminal::Items((
                             __start,
                             __nt,
@@ -358,7 +360,6 @@ mod __parse__Items {
         mod __parse__Items {
             #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
 
-            use util::tok::Tok;
             extern crate lalrpop_util as __lalrpop_util;
             #[allow(dead_code)]
             pub enum __Symbol<'input> {
@@ -487,7 +488,7 @@ mod __parse__Items {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -502,7 +503,7 @@ mod __parse__Items {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -521,6 +522,7 @@ mod __parse__Items {
                 __lookahead_start: Option<&usize>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<Vec<(usize, usize)>,__lalrpop_util::ParseError<usize,(usize, &'input str),()>>>
             {
                 let __nonterminal = match -__action {
@@ -528,7 +530,7 @@ mod __parse__Items {
                         // @L =  => ActionFn(6);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action6(input, &__start, &__end);
+                        let __nt = super::super::super::__action6::<>(input, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::Nt_40L(__nt), __end));
@@ -538,7 +540,7 @@ mod __parse__Items {
                         // @R =  => ActionFn(5);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action5(input, &__start, &__end);
+                        let __nt = super::super::super::__action5::<>(input, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::Nt_40R(__nt), __end));
@@ -548,7 +550,7 @@ mod __parse__Items {
                         // Items =  => ActionFn(9);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action9(input, &__start, &__end);
+                        let __nt = super::super::super::__action9::<>(input, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::NtItems(__nt), __end));
@@ -560,7 +562,7 @@ mod __parse__Items {
                         let __sym0 = __pop_NtItems(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action2(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action2::<>(input, __sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::NtItems(__nt), __end));
@@ -572,7 +574,7 @@ mod __parse__Items {
                         let __sym0 = __pop_NtItems(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action3(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action3::<>(input, __sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::NtItems(__nt), __end));
@@ -583,7 +585,7 @@ mod __parse__Items {
                         let __sym0 = __pop_Term_22_2b_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action10(input, __sym0);
+                        let __nt = super::super::super::__action10::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtSpanned_3c_22_2b_22_3e(__nt), __end));
@@ -594,7 +596,7 @@ mod __parse__Items {
                         let __sym0 = __pop_NtItems(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(input, __sym0);
+                        let __nt = super::super::super::__action0::<>(input, __sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/lifetime_tok.rs
+++ b/lalrpop-test/src/lifetime_tok.rs
@@ -48,7 +48,7 @@ mod __parse__Expr {
                     None => None,
                     Some(Err(e)) => return Err(__lalrpop_util::ParseError::User { error: e }),
                 };
-                match try!(__state0(&mut __tokens, __lookahead)) {
+                match try!(__state0(&mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -94,18 +94,19 @@ mod __parse__Expr {
             >(
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), LtTok<'input>, ())>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __lalrpop_util::ParseError<(),LtTok<'input>,()>>
             {
                 let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
                 match __lookahead {
                     Some((__loc1, LtTok::Other(__tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state3(__tokens, __sym0));
+                        __result = try!(__state3(__tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     None => {
                         let __start: () = ::std::default::Default::default();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action6(&__start, &__end);
+                        let __nt = super::super::super::__action6::<>(&__start, &__end);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -124,10 +125,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym0) => {
-                            __result = try!(__state1(__tokens, __lookahead, __sym0));
+                            __result = try!(__state1(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Other_2b(__sym0) => {
-                            __result = try!(__state2(__tokens, __lookahead, __sym0));
+                            __result = try!(__state2(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -155,6 +156,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), LtTok<'input>, ())>,
                 __sym0: ((), Vec<&'input str>, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __lalrpop_util::ParseError<(),LtTok<'input>,()>>
             {
                 let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
@@ -162,7 +164,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(__sym0);
+                        let __nt = super::super::super::__action0::<>(__sym0);
                         let __nt = __Nonterminal::____Expr((
                             __start,
                             __nt,
@@ -201,19 +203,20 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), LtTok<'input>, ())>,
                 __sym0: ((), ::std::vec::Vec<&'input str>, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __lalrpop_util::ParseError<(),LtTok<'input>,()>>
             {
                 let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
                 match __lookahead {
                     Some((__loc1, LtTok::Other(__tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(__tokens, __sym0, __sym1));
+                        __result = try!(__state4(__tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(__sym0);
+                        let __nt = super::super::super::__action7::<>(__sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -249,6 +252,7 @@ mod __parse__Expr {
             >(
                 __tokens: &mut __TOKENS,
                 __sym0: ((), &'input str, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __lalrpop_util::ParseError<(),LtTok<'input>,()>>
             {
                 let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
@@ -262,7 +266,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action4(__sym0);
+                        let __nt = super::super::super::__action4::<>(__sym0);
                         let __nt = __Nonterminal::Other_2b((
                             __start,
                             __nt,
@@ -299,6 +303,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), ::std::vec::Vec<&'input str>, ()),
                 __sym1: ((), &'input str, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), LtTok<'input>, ())>, __Nonterminal<'input>), __lalrpop_util::ParseError<(),LtTok<'input>,()>>
             {
                 let mut __result: (Option<((), LtTok<'input>, ())>, __Nonterminal<'input>);
@@ -312,7 +317,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action5(__sym0, __sym1);
+                        let __nt = super::super::super::__action5::<>(__sym0, __sym1);
                         let __nt = __Nonterminal::Other_2b((
                             __start,
                             __nt,
@@ -448,7 +453,7 @@ mod __parse__Expr {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -463,7 +468,7 @@ mod __parse__Expr {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -481,6 +486,7 @@ mod __parse__Expr {
                 __lookahead_start: Option<&()>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<((),__Symbol<'input>,())>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<Vec<&'input str>,__lalrpop_util::ParseError<(),LtTok<'input>,()>>>
             {
                 let __nonterminal = match -__action {
@@ -488,7 +494,7 @@ mod __parse__Expr {
                         // Expr =  => ActionFn(6);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action6(&__start, &__end);
+                        let __nt = super::super::super::__action6::<>(&__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -499,7 +505,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtOther_2b(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(__sym0);
+                        let __nt = super::super::super::__action7::<>(__sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -509,7 +515,7 @@ mod __parse__Expr {
                         // Other* =  => ActionFn(2);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action2(&__start, &__end);
+                        let __nt = super::super::super::__action2::<>(&__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::NtOther_2a(__nt), __end));
@@ -520,7 +526,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtOther_2b(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(__sym0);
+                        let __nt = super::super::super::__action3::<>(__sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtOther_2a(__nt), __end));
@@ -531,7 +537,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_TermOther(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action4(__sym0);
+                        let __nt = super::super::super::__action4::<>(__sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtOther_2b(__nt), __end));
@@ -543,7 +549,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtOther_2b(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action5(__sym0, __sym1);
+                        let __nt = super::super::super::__action5::<>(__sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::NtOther_2b(__nt), __end));
@@ -554,7 +560,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(__sym0);
+                        let __nt = super::super::super::__action0::<>(__sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/loc.rs
+++ b/lalrpop-test/src/loc.rs
@@ -46,7 +46,7 @@ mod __parse__Items {
                     None => None,
                     Some(Err(e)) => return Err(__lalrpop_util::ParseError::User { error: e }),
                 };
-                match try!(__state0(&mut __tokens, __lookahead)) {
+                match try!(__state0(&mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -95,6 +95,7 @@ mod __parse__Items {
             >(
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
@@ -104,7 +105,7 @@ mod __parse__Items {
                     None => {
                         let __start: usize = ::std::default::Default::default();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action9(&__start, &__end);
+                        let __nt = super::super::super::__action9::<>(&__start, &__end);
                         let __nt = __Nonterminal::Items((
                             __start,
                             __nt,
@@ -123,7 +124,7 @@ mod __parse__Items {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Items(__sym0) => {
-                            __result = try!(__state1(__tokens, __lookahead, __sym0));
+                            __result = try!(__state1(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -156,23 +157,24 @@ mod __parse__Items {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, Vec<(usize, usize)>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Plus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state3(__tokens, __sym1));
+                        __result = try!(__state3(__tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(__tokens, __sym0, __sym1));
+                        __result = try!(__state4(__tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(__sym0);
+                        let __nt = super::super::super::__action0::<>(__sym0);
                         let __nt = __Nonterminal::____Items((
                             __start,
                             __nt,
@@ -192,7 +194,7 @@ mod __parse__Items {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Spanned_3c_22_2b_22_3e(__sym1) => {
-                            __result = try!(__state2(__tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state2(__tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -221,6 +223,7 @@ mod __parse__Items {
                 __lookahead: Option<(usize, Tok, usize)>,
                 __sym0: (usize, Vec<(usize, usize)>, usize),
                 __sym1: (usize, (usize, usize), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
@@ -230,7 +233,7 @@ mod __parse__Items {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action2(__sym0, __sym1);
+                        let __nt = super::super::super::__action2::<>(__sym0, __sym1);
                         let __nt = __Nonterminal::Items((
                             __start,
                             __nt,
@@ -265,6 +268,7 @@ mod __parse__Items {
             >(
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
@@ -279,7 +283,7 @@ mod __parse__Items {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action10(__sym0);
+                        let __nt = super::super::super::__action10::<>(__sym0);
                         let __nt = __Nonterminal::Spanned_3c_22_2b_22_3e((
                             __start,
                             __nt,
@@ -315,6 +319,7 @@ mod __parse__Items {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, Vec<(usize, usize)>, usize),
                 __sym1: (usize, Tok, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, Tok, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,Tok,()>>
             {
                 let mut __result: (Option<(usize, Tok, usize)>, __Nonterminal<>);
@@ -329,7 +334,7 @@ mod __parse__Items {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action3(__sym0, __sym1);
+                        let __nt = super::super::super::__action3::<>(__sym0, __sym1);
                         let __nt = __Nonterminal::Items((
                             __start,
                             __nt,
@@ -486,7 +491,7 @@ mod __parse__Items {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -501,7 +506,7 @@ mod __parse__Items {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -518,6 +523,7 @@ mod __parse__Items {
                 __lookahead_start: Option<&usize>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<>,usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<Vec<(usize, usize)>,__lalrpop_util::ParseError<usize,Tok,()>>>
             {
                 let __nonterminal = match -__action {
@@ -525,7 +531,7 @@ mod __parse__Items {
                         // @L =  => ActionFn(6);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action6(&__start, &__end);
+                        let __nt = super::super::super::__action6::<>(&__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::Nt_40L(__nt), __end));
@@ -535,7 +541,7 @@ mod __parse__Items {
                         // @R =  => ActionFn(5);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action5(&__start, &__end);
+                        let __nt = super::super::super::__action5::<>(&__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::Nt_40R(__nt), __end));
@@ -545,7 +551,7 @@ mod __parse__Items {
                         // Items =  => ActionFn(9);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action9(&__start, &__end);
+                        let __nt = super::super::super::__action9::<>(&__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::NtItems(__nt), __end));
@@ -557,7 +563,7 @@ mod __parse__Items {
                         let __sym0 = __pop_NtItems(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action2(__sym0, __sym1);
+                        let __nt = super::super::super::__action2::<>(__sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::NtItems(__nt), __end));
@@ -569,7 +575,7 @@ mod __parse__Items {
                         let __sym0 = __pop_NtItems(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action3(__sym0, __sym1);
+                        let __nt = super::super::super::__action3::<>(__sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::NtItems(__nt), __end));
@@ -580,7 +586,7 @@ mod __parse__Items {
                         let __sym0 = __pop_Term_22_2b_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action10(__sym0);
+                        let __nt = super::super::super::__action10::<>(__sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtSpanned_3c_22_2b_22_3e(__nt), __end));
@@ -591,7 +597,7 @@ mod __parse__Items {
                         let __sym0 = __pop_NtItems(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(__sym0);
+                        let __nt = super::super::super::__action0::<>(__sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/loc_issue_90.rs
+++ b/lalrpop-test/src/loc_issue_90.rs
@@ -40,7 +40,7 @@ mod __parse__Expression2 {
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
-                match try!(__state0(input, &mut __tokens, __lookahead)) {
+                match try!(__state0(input, &mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -106,29 +106,30 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym0));
+                        __result = try!(__state4(input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym0));
+                        __result = try!(__state5(input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(input, __tokens, __sym0));
+                        __result = try!(__state6(input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (7, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state7(input, __tokens, __sym0));
+                        __result = try!(__state7(input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (8, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state8(input, __tokens, __sym0));
+                        __result = try!(__state8(input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -141,13 +142,13 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expression1(__sym0) => {
-                            __result = try!(__state1(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state1(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Expression2(__sym0) => {
-                            __result = try!(__state2(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state2(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Wacky(__sym0) => {
-                            __result = try!(__state3(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state3(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -176,6 +177,7 @@ mod __parse__Expression2 {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -184,7 +186,7 @@ mod __parse__Expression2 {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action29(input, __sym0);
+                        let __nt = super::super::super::__action29::<>(input, __sym0);
                         let __nt = __Nonterminal::Expression2((
                             __start,
                             __nt,
@@ -226,18 +228,19 @@ mod __parse__Expression2 {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
                 match __lookahead {
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state10(input, __tokens, __sym1));
+                        __result = try!(__state10(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(input, __sym0);
+                        let __nt = super::super::super::__action0::<>(input, __sym0);
                         let __nt = __Nonterminal::____Expression2((
                             __start,
                             __nt,
@@ -257,7 +260,7 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expression2Op(__sym1) => {
-                            __result = try!(__state9(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state9(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -287,6 +290,7 @@ mod __parse__Expression2 {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -295,7 +299,7 @@ mod __parse__Expression2 {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0);
+                        let __nt = super::super::super::__action8::<>(input, __sym0);
                         let __nt = __Nonterminal::Expression1((
                             __start,
                             __nt,
@@ -336,6 +340,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -347,7 +352,7 @@ mod __parse__Expression2 {
                 match __lookahead {
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state12(input, __tokens, __sym1));
+                        __result = try!(__state12(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((_, (0, _), _)) |
                     Some((_, (1, _), _)) |
@@ -356,7 +361,7 @@ mod __parse__Expression2 {
                     Some((_, (8, _), _)) => {
                         let __start = __sym0.2.clone();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action31(input, &__start, &__end);
+                        let __nt = super::super::super::__action31::<>(input, &__start, &__end);
                         let __nt = __Nonterminal::Maybe((
                             __start,
                             __nt,
@@ -375,7 +380,7 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Maybe(__sym1) => {
-                            __result = try!(__state11(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state11(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -427,6 +432,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -439,23 +445,23 @@ mod __parse__Expression2 {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(input, __tokens, __sym1));
+                        __result = try!(__state16(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state17(input, __tokens, __sym1));
+                        __result = try!(__state17(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state18(input, __tokens, __sym1));
+                        __result = try!(__state18(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (7, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state19(input, __tokens, __sym1));
+                        __result = try!(__state19(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (8, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state20(input, __tokens, __sym1));
+                        __result = try!(__state20(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -471,13 +477,13 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expression1(__sym1) => {
-                            __result = try!(__state13(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state13(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Expression2(__sym1) => {
-                            __result = try!(__state14(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state14(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Wacky(__sym1) => {
-                            __result = try!(__state15(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state15(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -505,6 +511,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -518,7 +525,7 @@ mod __parse__Expression2 {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action33(input, __sym0);
+                        let __nt = super::super::super::__action33::<>(input, __sym0);
                         let __nt = __Nonterminal::Wacky((
                             __start,
                             __nt,
@@ -557,6 +564,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -570,7 +578,7 @@ mod __parse__Expression2 {
                     None => {
                         let __start = __sym0.2.clone();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action34(input, &__start, &__end);
+                        let __nt = super::super::super::__action34::<>(input, &__start, &__end);
                         let __nt = __Nonterminal::Wonky((
                             __start,
                             __nt,
@@ -589,7 +597,7 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Wonky(__sym1) => {
-                            __result = try!(__state21(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state21(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -618,6 +626,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -631,7 +640,7 @@ mod __parse__Expression2 {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action26(input, __sym0);
+                        let __nt = super::super::super::__action26::<>(input, __sym0);
                         let __nt = __Nonterminal::Expression1((
                             __start,
                             __nt,
@@ -682,29 +691,30 @@ mod __parse__Expression2 {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, Box<Expr<'input>>, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym2));
+                        __result = try!(__state4(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym2));
+                        __result = try!(__state5(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(input, __tokens, __sym2));
+                        __result = try!(__state6(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (7, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state7(input, __tokens, __sym2));
+                        __result = try!(__state7(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (8, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state8(input, __tokens, __sym2));
+                        __result = try!(__state8(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -717,11 +727,11 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expression1(__sym2) => {
-                            __result = try!(__state22(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state22(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         __Nonterminal::Wacky(__sym2) => {
-                            __result = try!(__state3(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -749,6 +759,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -765,7 +776,7 @@ mod __parse__Expression2 {
                     Some((_, (8, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action30(input, __sym0);
+                        let __nt = super::super::super::__action30::<>(input, __sym0);
                         let __nt = __Nonterminal::Expression2Op((
                             __start,
                             __nt,
@@ -816,29 +827,30 @@ mod __parse__Expression2 {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym2));
+                        __result = try!(__state4(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym2));
+                        __result = try!(__state5(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(input, __tokens, __sym2));
+                        __result = try!(__state6(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (7, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state7(input, __tokens, __sym2));
+                        __result = try!(__state7(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (8, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state8(input, __tokens, __sym2));
+                        __result = try!(__state8(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -851,11 +863,11 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expression1(__sym2) => {
-                            __result = try!(__state23(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state23(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         __Nonterminal::Wacky(__sym2) => {
-                            __result = try!(__state3(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -883,6 +895,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -894,7 +907,7 @@ mod __parse__Expression2 {
                 match __lookahead {
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state24(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state24(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -926,6 +939,7 @@ mod __parse__Expression2 {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -934,7 +948,7 @@ mod __parse__Expression2 {
                     Some((_, (3, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action29(input, __sym0);
+                        let __nt = super::super::super::__action29::<>(input, __sym0);
                         let __nt = __Nonterminal::Expression2((
                             __start,
                             __nt,
@@ -977,6 +991,7 @@ mod __parse__Expression2 {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: &mut Option<(usize, &'input str, usize)>,
                 __sym1: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -984,12 +999,12 @@ mod __parse__Expression2 {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state26(input, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state26(input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state10(input, __tokens, __sym2));
+                        __result = try!(__state10(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1002,7 +1017,7 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expression2Op(__sym2) => {
-                            __result = try!(__state25(input, __tokens, __lookahead, __sym1, __sym2));
+                            __result = try!(__state25(input, __tokens, __lookahead, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1032,6 +1047,7 @@ mod __parse__Expression2 {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1040,7 +1056,7 @@ mod __parse__Expression2 {
                     Some((_, (3, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0);
+                        let __nt = super::super::super::__action8::<>(input, __sym0);
                         let __nt = __Nonterminal::Expression1((
                             __start,
                             __nt,
@@ -1081,6 +1097,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1092,7 +1109,7 @@ mod __parse__Expression2 {
                 match __lookahead {
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state12(input, __tokens, __sym1));
+                        __result = try!(__state12(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((_, (0, _), _)) |
                     Some((_, (1, _), _)) |
@@ -1101,7 +1118,7 @@ mod __parse__Expression2 {
                     Some((_, (8, _), _)) => {
                         let __start = __sym0.2.clone();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action31(input, &__start, &__end);
+                        let __nt = super::super::super::__action31::<>(input, &__start, &__end);
                         let __nt = __Nonterminal::Maybe((
                             __start,
                             __nt,
@@ -1120,7 +1137,7 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Maybe(__sym1) => {
-                            __result = try!(__state27(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state27(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1172,6 +1189,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1184,23 +1202,23 @@ mod __parse__Expression2 {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(input, __tokens, __sym1));
+                        __result = try!(__state16(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state17(input, __tokens, __sym1));
+                        __result = try!(__state17(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state18(input, __tokens, __sym1));
+                        __result = try!(__state18(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (7, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state19(input, __tokens, __sym1));
+                        __result = try!(__state19(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (8, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state20(input, __tokens, __sym1));
+                        __result = try!(__state20(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1216,13 +1234,13 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expression1(__sym1) => {
-                            __result = try!(__state13(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state13(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Expression2(__sym1) => {
-                            __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Wacky(__sym1) => {
-                            __result = try!(__state15(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state15(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1250,6 +1268,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1263,7 +1282,7 @@ mod __parse__Expression2 {
                     Some((_, (3, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action33(input, __sym0);
+                        let __nt = super::super::super::__action33::<>(input, __sym0);
                         let __nt = __Nonterminal::Wacky((
                             __start,
                             __nt,
@@ -1302,6 +1321,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1315,7 +1335,7 @@ mod __parse__Expression2 {
                     Some((_, (3, _), _)) => {
                         let __start = __sym0.2.clone();
                         let __end = __lookahead.as_ref().map(|o| o.0.clone()).unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action34(input, &__start, &__end);
+                        let __nt = super::super::super::__action34::<>(input, &__start, &__end);
                         let __nt = __Nonterminal::Wonky((
                             __start,
                             __nt,
@@ -1334,7 +1354,7 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Wonky(__sym1) => {
-                            __result = try!(__state29(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state29(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1363,6 +1383,7 @@ mod __parse__Expression2 {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1376,7 +1397,7 @@ mod __parse__Expression2 {
                     Some((_, (3, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action26(input, __sym0);
+                        let __nt = super::super::super::__action26::<>(input, __sym0);
                         let __nt = __Nonterminal::Expression1((
                             __start,
                             __nt,
@@ -1415,6 +1436,7 @@ mod __parse__Expression2 {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1423,7 +1445,7 @@ mod __parse__Expression2 {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action7::<>(input, __sym0, __sym1);
                         let __nt = __Nonterminal::Expression1((
                             __start,
                             __nt,
@@ -1463,6 +1485,7 @@ mod __parse__Expression2 {
                 __sym0: (usize, Box<Expr<'input>>, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
                 __sym2: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1471,7 +1494,7 @@ mod __parse__Expression2 {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action28(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action28::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expression2((
                             __start,
                             __nt,
@@ -1511,6 +1534,7 @@ mod __parse__Expression2 {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
                 __sym2: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1519,7 +1543,7 @@ mod __parse__Expression2 {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action27(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action27::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expression1((
                             __start,
                             __nt,
@@ -1557,6 +1581,7 @@ mod __parse__Expression2 {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1573,7 +1598,7 @@ mod __parse__Expression2 {
                     Some((_, (8, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action32(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action32::<>(input, __sym0, __sym1);
                         let __nt = __Nonterminal::Maybe((
                             __start,
                             __nt,
@@ -1624,29 +1649,30 @@ mod __parse__Expression2 {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, Box<Expr<'input>>, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(input, __tokens, __sym2));
+                        __result = try!(__state16(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state17(input, __tokens, __sym2));
+                        __result = try!(__state17(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state18(input, __tokens, __sym2));
+                        __result = try!(__state18(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (7, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state19(input, __tokens, __sym2));
+                        __result = try!(__state19(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (8, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state20(input, __tokens, __sym2));
+                        __result = try!(__state20(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1659,11 +1685,11 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expression1(__sym2) => {
-                            __result = try!(__state30(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state30(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         __Nonterminal::Wacky(__sym2) => {
-                            __result = try!(__state15(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state15(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1693,6 +1719,7 @@ mod __parse__Expression2 {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
                 __sym2: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1706,7 +1733,7 @@ mod __parse__Expression2 {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action25(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action25::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expression1((
                             __start,
                             __nt,
@@ -1757,29 +1784,30 @@ mod __parse__Expression2 {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state16(input, __tokens, __sym2));
+                        __result = try!(__state16(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state17(input, __tokens, __sym2));
+                        __result = try!(__state17(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state18(input, __tokens, __sym2));
+                        __result = try!(__state18(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (7, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state19(input, __tokens, __sym2));
+                        __result = try!(__state19(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (8, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state20(input, __tokens, __sym2));
+                        __result = try!(__state20(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1792,11 +1820,11 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expression1(__sym2) => {
-                            __result = try!(__state31(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state31(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         __Nonterminal::Wacky(__sym2) => {
-                            __result = try!(__state15(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state15(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1830,6 +1858,7 @@ mod __parse__Expression2 {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: &mut Option<(usize, &'input str, usize)>,
                 __sym1: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1837,12 +1866,12 @@ mod __parse__Expression2 {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state32(input, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state32(input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state10(input, __tokens, __sym2));
+                        __result = try!(__state10(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1855,7 +1884,7 @@ mod __parse__Expression2 {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expression2Op(__sym2) => {
-                            __result = try!(__state25(input, __tokens, __lookahead, __sym1, __sym2));
+                            __result = try!(__state25(input, __tokens, __lookahead, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1886,6 +1915,7 @@ mod __parse__Expression2 {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1894,7 +1924,7 @@ mod __parse__Expression2 {
                     Some((_, (3, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action7::<>(input, __sym0, __sym1);
                         let __nt = __Nonterminal::Expression1((
                             __start,
                             __nt,
@@ -1934,6 +1964,7 @@ mod __parse__Expression2 {
                 __sym0: (usize, Box<Expr<'input>>, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
                 __sym2: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1942,7 +1973,7 @@ mod __parse__Expression2 {
                     Some((_, (3, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action28(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action28::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expression2((
                             __start,
                             __nt,
@@ -1982,6 +2013,7 @@ mod __parse__Expression2 {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
                 __sym2: (usize, Box<Expr<'input>>, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -1990,7 +2022,7 @@ mod __parse__Expression2 {
                     Some((_, (3, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action27(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action27::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expression1((
                             __start,
                             __nt,
@@ -2029,6 +2061,7 @@ mod __parse__Expression2 {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, Box<Expr<'input>>, usize),
                 __sym2: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<'input>);
@@ -2042,7 +2075,7 @@ mod __parse__Expression2 {
                     Some((_, (3, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action25(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action25::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expression1((
                             __start,
                             __nt,
@@ -2985,7 +3018,7 @@ mod __parse__Expression2 {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -3000,7 +3033,7 @@ mod __parse__Expression2 {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -3019,6 +3052,7 @@ mod __parse__Expression2 {
                 __lookahead_start: Option<&usize>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<Box<Expr<'input>>,__lalrpop_util::ParseError<usize,(usize, &'input str),()>>>
             {
                 let __nonterminal = match -__action {
@@ -3026,7 +3060,7 @@ mod __parse__Expression2 {
                         // @L =  => ActionFn(14);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action14(input, &__start, &__end);
+                        let __nt = super::super::super::__action14::<>(input, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::Nt_40L(__nt), __end));
@@ -3036,7 +3070,7 @@ mod __parse__Expression2 {
                         // @R =  => ActionFn(13);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action13(input, &__start, &__end);
+                        let __nt = super::super::super::__action13::<>(input, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::Nt_40R(__nt), __end));
@@ -3049,7 +3083,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_Term_22_28_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action25(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action25::<>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpression1(__nt), __end));
@@ -3060,7 +3094,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_Termr_23_22_5c_5cw_2b_22_23(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action26(input, __sym0);
+                        let __nt = super::super::super::__action26::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpression1(__nt), __end));
@@ -3073,7 +3107,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_Term_22_26_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action27(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action27::<>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpression1(__nt), __end));
@@ -3085,7 +3119,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_Term_22wonky_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action7::<>(input, __sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::NtExpression1(__nt), __end));
@@ -3096,7 +3130,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_NtWacky(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0);
+                        let __nt = super::super::super::__action8::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpression1(__nt), __end));
@@ -3109,7 +3143,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_NtExpression2(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action28(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action28::<>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpression2(__nt), __end));
@@ -3120,7 +3154,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_NtExpression1(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action29(input, __sym0);
+                        let __nt = super::super::super::__action29::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpression2(__nt), __end));
@@ -3131,7 +3165,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_Term_22_2a_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action30(input, __sym0);
+                        let __nt = super::super::super::__action30::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpression2Op(__nt), __end));
@@ -3141,7 +3175,7 @@ mod __parse__Expression2 {
                         // Maybe =  => ActionFn(31);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action31(input, &__start, &__end);
+                        let __nt = super::super::super::__action31::<>(input, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::NtMaybe(__nt), __end));
@@ -3153,7 +3187,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_Term_22_5b_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action32(input, __sym0, __sym1);
+                        let __nt = super::super::super::__action32::<>(input, __sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::NtMaybe(__nt), __end));
@@ -3164,7 +3198,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_Term_22wacky_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action33(input, __sym0);
+                        let __nt = super::super::super::__action33::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtWacky(__nt), __end));
@@ -3174,7 +3208,7 @@ mod __parse__Expression2 {
                         // Wonky =  => ActionFn(34);
                         let __start = __symbols.last().map(|s| s.2.clone()).unwrap_or_default();
                         let __end = __lookahead_start.cloned().unwrap_or_else(|| __start.clone());
-                        let __nt = super::super::super::__action34(input, &__start, &__end);
+                        let __nt = super::super::super::__action34::<>(input, &__start, &__end);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 0);
                         __symbols.push((__start, __Symbol::NtWonky(__nt), __end));
@@ -3185,7 +3219,7 @@ mod __parse__Expression2 {
                         let __sym0 = __pop_NtExpression2(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(input, __sym0);
+                        let __nt = super::super::super::__action0::<>(input, __sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)
@@ -3456,17 +3490,17 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
@@ -3496,12 +3530,12 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
@@ -3526,7 +3560,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
@@ -3536,7 +3570,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
@@ -3566,7 +3600,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
@@ -3581,7 +3615,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
@@ -3596,7 +3630,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
@@ -3641,7 +3675,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
@@ -3661,7 +3695,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 5;
                             continue;
@@ -3716,7 +3750,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -3741,7 +3775,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -3801,7 +3835,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -3821,7 +3855,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -3831,7 +3865,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -3891,7 +3925,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -3981,7 +4015,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4011,7 +4045,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4051,12 +4085,12 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4176,7 +4210,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4231,7 +4265,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4271,7 +4305,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4281,7 +4315,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4291,7 +4325,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4331,7 +4365,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4341,12 +4375,12 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4366,12 +4400,12 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4396,7 +4430,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4416,7 +4450,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4431,17 +4465,17 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4471,7 +4505,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4491,12 +4525,12 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4521,7 +4555,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4556,7 +4590,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4671,7 +4705,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4776,7 +4810,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4866,17 +4900,17 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4896,7 +4930,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4946,17 +4980,17 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4971,12 +5005,12 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4986,7 +5020,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -4996,17 +5030,17 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -5031,7 +5065,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -5071,12 +5105,12 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -5086,7 +5120,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -5141,7 +5175,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -5301,7 +5335,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -5481,7 +5515,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -5561,7 +5595,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 5;
                             continue;
@@ -5636,7 +5670,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -5731,7 +5765,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -5746,7 +5780,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -5826,7 +5860,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -6321,7 +6355,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -6341,7 +6375,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -6386,7 +6420,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -6516,12 +6550,12 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -6536,32 +6570,32 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -6576,32 +6610,32 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -6611,7 +6645,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -6636,7 +6670,7 @@ mod __intern_token {
                             __current_state = 5;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 5;
                             continue;
@@ -6771,17 +6805,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -6811,12 +6845,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -6841,7 +6875,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -6851,7 +6885,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -6881,7 +6915,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -6896,7 +6930,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -6911,7 +6945,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -6956,7 +6990,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -6976,7 +7010,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -7031,7 +7065,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7056,7 +7090,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7116,7 +7150,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7136,7 +7170,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7146,7 +7180,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7206,7 +7240,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7296,7 +7330,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7326,7 +7360,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7366,12 +7400,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7491,7 +7525,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7546,7 +7580,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7586,7 +7620,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7596,7 +7630,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7606,7 +7640,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7646,7 +7680,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7656,12 +7690,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7681,12 +7715,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7711,7 +7745,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7731,7 +7765,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7746,17 +7780,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7786,7 +7820,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7806,12 +7840,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7836,7 +7870,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7871,7 +7905,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -7986,7 +8020,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8091,7 +8125,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8181,17 +8215,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8211,7 +8245,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8261,17 +8295,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8286,12 +8320,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8301,7 +8335,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8311,17 +8345,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8346,7 +8380,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8386,12 +8420,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8401,7 +8435,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8456,7 +8490,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8616,7 +8650,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8796,7 +8830,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8876,7 +8910,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -8951,7 +8985,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9046,7 +9080,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9061,7 +9095,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9141,7 +9175,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9636,7 +9670,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9656,7 +9690,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9701,7 +9735,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9831,12 +9865,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9851,32 +9885,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9891,32 +9925,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9926,7 +9960,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -9951,7 +9985,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -10085,17 +10119,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -10125,12 +10159,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -10155,7 +10189,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -10165,7 +10199,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -10195,7 +10229,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -10210,7 +10244,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -10225,7 +10259,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -10270,7 +10304,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -10290,7 +10324,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -10345,7 +10379,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10370,7 +10404,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10430,7 +10464,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10450,7 +10484,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10460,7 +10494,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10520,7 +10554,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10610,7 +10644,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10640,7 +10674,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10680,12 +10714,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10805,7 +10839,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10860,7 +10894,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10900,7 +10934,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10910,7 +10944,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10920,7 +10954,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10960,7 +10994,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10970,12 +11004,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -10995,12 +11029,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11025,7 +11059,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11045,7 +11079,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11060,17 +11094,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11100,7 +11134,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11120,12 +11154,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11150,7 +11184,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11185,7 +11219,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11300,7 +11334,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11405,7 +11439,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11495,17 +11529,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11525,7 +11559,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11575,17 +11609,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11600,12 +11634,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11615,7 +11649,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11625,17 +11659,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11660,7 +11694,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11700,12 +11734,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11715,7 +11749,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11770,7 +11804,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -11930,7 +11964,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -12110,7 +12144,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -12190,7 +12224,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -12265,7 +12299,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -12360,7 +12394,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -12375,7 +12409,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -12455,7 +12489,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -12950,7 +12984,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -12970,7 +13004,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -13015,7 +13049,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -13145,12 +13179,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -13165,32 +13199,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -13205,32 +13239,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -13240,7 +13274,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -13265,7 +13299,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -13376,17 +13410,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -13416,12 +13450,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -13446,7 +13480,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -13456,7 +13490,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -13486,7 +13520,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -13501,7 +13535,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -13516,7 +13550,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -13561,7 +13595,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -13581,7 +13615,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -13636,7 +13670,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -13661,7 +13695,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -13721,7 +13755,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -13741,7 +13775,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -13751,7 +13785,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -13811,7 +13845,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -13901,7 +13935,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -13931,7 +13965,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -13971,12 +14005,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14096,7 +14130,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14151,7 +14185,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14191,7 +14225,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14201,7 +14235,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14211,7 +14245,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14251,7 +14285,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14261,12 +14295,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14286,12 +14320,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14316,7 +14350,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14336,7 +14370,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14351,17 +14385,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14391,7 +14425,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14411,12 +14445,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14441,7 +14475,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14476,7 +14510,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14591,7 +14625,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14696,7 +14730,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14786,17 +14820,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14816,7 +14850,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14866,17 +14900,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14891,12 +14925,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14906,7 +14940,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14916,17 +14950,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14951,7 +14985,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -14991,12 +15025,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -15006,7 +15040,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -15061,7 +15095,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -15221,7 +15255,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -15401,7 +15435,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -15481,7 +15515,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -15556,7 +15590,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -15651,7 +15685,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -15666,7 +15700,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -15746,7 +15780,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -16241,7 +16275,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -16261,7 +16295,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -16306,7 +16340,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -16436,12 +16470,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -16456,32 +16490,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -16496,32 +16530,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -16531,7 +16565,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -16556,7 +16590,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -16669,17 +16703,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -16709,12 +16743,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -16739,7 +16773,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -16749,7 +16783,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -16779,7 +16813,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -16794,7 +16828,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -16809,7 +16843,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -16854,7 +16888,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -16874,7 +16908,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -16929,7 +16963,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -16954,7 +16988,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17014,7 +17048,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17034,7 +17068,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17044,7 +17078,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17104,7 +17138,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17194,7 +17228,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17224,7 +17258,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17264,12 +17298,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17389,7 +17423,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17444,7 +17478,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17484,7 +17518,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17494,7 +17528,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17504,7 +17538,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17544,7 +17578,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17554,12 +17588,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17579,12 +17613,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17609,7 +17643,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17629,7 +17663,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17644,17 +17678,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17684,7 +17718,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17704,12 +17738,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17734,7 +17768,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17769,7 +17803,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17884,7 +17918,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -17989,7 +18023,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18079,17 +18113,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18109,7 +18143,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18159,17 +18193,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18184,12 +18218,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18199,7 +18233,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18209,17 +18243,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18244,7 +18278,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18284,12 +18318,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18299,7 +18333,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18354,7 +18388,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18514,7 +18548,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18694,7 +18728,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18774,7 +18808,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -18849,7 +18883,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -18944,7 +18978,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -18959,7 +18993,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -19039,7 +19073,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -19534,7 +19568,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -19554,7 +19588,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -19599,7 +19633,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -19729,12 +19763,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -19749,32 +19783,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -19789,32 +19823,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -19824,7 +19858,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -19849,7 +19883,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -19962,17 +19996,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -20002,12 +20036,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -20032,7 +20066,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -20042,7 +20076,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -20072,7 +20106,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -20087,7 +20121,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -20102,7 +20136,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -20147,7 +20181,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -20167,7 +20201,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -20222,7 +20256,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20247,7 +20281,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20307,7 +20341,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20327,7 +20361,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20337,7 +20371,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20397,7 +20431,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20487,7 +20521,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20517,7 +20551,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20557,12 +20591,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20682,7 +20716,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20737,7 +20771,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20777,7 +20811,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20787,7 +20821,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20797,7 +20831,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20837,7 +20871,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20847,12 +20881,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20872,12 +20906,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20902,7 +20936,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20922,7 +20956,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20937,17 +20971,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20977,7 +21011,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -20997,12 +21031,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21027,7 +21061,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21062,7 +21096,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21177,7 +21211,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21282,7 +21316,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21372,17 +21406,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21402,7 +21436,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21452,17 +21486,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21477,12 +21511,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21492,7 +21526,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21502,17 +21536,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21537,7 +21571,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21577,12 +21611,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21592,7 +21626,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21647,7 +21681,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21807,7 +21841,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -21987,7 +22021,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -22067,7 +22101,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -22142,7 +22176,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -22237,7 +22271,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -22252,7 +22286,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -22332,7 +22366,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -22827,7 +22861,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -22847,7 +22881,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -22892,7 +22926,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -23022,12 +23056,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -23042,32 +23076,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -23082,32 +23116,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -23117,7 +23151,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -23142,7 +23176,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -23255,17 +23289,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -23295,12 +23329,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -23325,7 +23359,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -23335,7 +23369,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -23365,7 +23399,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -23380,7 +23414,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -23395,7 +23429,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -23440,7 +23474,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -23460,7 +23494,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -23515,7 +23549,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -23540,7 +23574,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -23600,7 +23634,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -23620,7 +23654,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -23630,7 +23664,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -23690,7 +23724,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -23780,7 +23814,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -23810,7 +23844,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -23850,12 +23884,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -23975,7 +24009,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24030,7 +24064,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24070,7 +24104,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24080,7 +24114,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24090,7 +24124,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24130,7 +24164,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24140,12 +24174,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24165,12 +24199,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24195,7 +24229,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24215,7 +24249,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24230,17 +24264,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24270,7 +24304,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24290,12 +24324,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24320,7 +24354,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24355,7 +24389,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24470,7 +24504,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24575,7 +24609,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24665,17 +24699,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24695,7 +24729,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24745,17 +24779,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24770,12 +24804,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24785,7 +24819,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24795,17 +24829,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24830,7 +24864,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24870,12 +24904,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24885,7 +24919,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -24940,7 +24974,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -25100,7 +25134,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -25280,7 +25314,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -25360,7 +25394,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -25435,7 +25469,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -25530,7 +25564,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -25545,7 +25579,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -25625,7 +25659,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -26120,7 +26154,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -26140,7 +26174,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -26185,7 +26219,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -26315,12 +26349,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -26335,32 +26369,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -26375,32 +26409,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -26410,7 +26444,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -26435,7 +26469,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -26548,17 +26582,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -26588,12 +26622,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -26618,7 +26652,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -26628,7 +26662,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -26658,7 +26692,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -26673,7 +26707,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -26688,7 +26722,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -26733,7 +26767,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -26753,7 +26787,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -26808,7 +26842,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -26833,7 +26867,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -26893,7 +26927,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -26913,7 +26947,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -26923,7 +26957,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -26983,7 +27017,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27073,7 +27107,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27103,7 +27137,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27143,12 +27177,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27268,7 +27302,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27323,7 +27357,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27363,7 +27397,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27373,7 +27407,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27383,7 +27417,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27423,7 +27457,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27433,12 +27467,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27458,12 +27492,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27488,7 +27522,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27508,7 +27542,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27523,17 +27557,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27563,7 +27597,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27583,12 +27617,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27613,7 +27647,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27648,7 +27682,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27763,7 +27797,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27868,7 +27902,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27958,17 +27992,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -27988,7 +28022,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28038,17 +28072,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28063,12 +28097,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28078,7 +28112,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28088,17 +28122,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28123,7 +28157,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28163,12 +28197,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28178,7 +28212,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28233,7 +28267,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28393,7 +28427,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28573,7 +28607,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28653,7 +28687,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -28728,7 +28762,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -28823,7 +28857,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -28838,7 +28872,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -28918,7 +28952,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -29413,7 +29447,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -29433,7 +29467,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -29478,7 +29512,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -29608,12 +29642,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -29628,32 +29662,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -29668,32 +29702,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -29703,7 +29737,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -29728,7 +29762,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -29841,17 +29875,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -29881,12 +29915,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -29911,7 +29945,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -29921,7 +29955,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -29951,7 +29985,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -29966,7 +30000,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -29981,7 +30015,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -30026,7 +30060,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -30046,7 +30080,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -30101,7 +30135,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30126,7 +30160,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30186,7 +30220,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30206,7 +30240,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30216,7 +30250,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30276,7 +30310,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30366,7 +30400,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30396,7 +30430,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30436,12 +30470,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30561,7 +30595,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30616,7 +30650,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30656,7 +30690,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30666,7 +30700,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30676,7 +30710,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30716,7 +30750,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30726,12 +30760,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30751,12 +30785,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30781,7 +30815,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30801,7 +30835,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30816,17 +30850,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30856,7 +30890,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30876,12 +30910,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30906,7 +30940,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -30941,7 +30975,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31056,7 +31090,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31161,7 +31195,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31251,17 +31285,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31281,7 +31315,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31331,17 +31365,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31356,12 +31390,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31371,7 +31405,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31381,17 +31415,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31416,7 +31450,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31456,12 +31490,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31471,7 +31505,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31526,7 +31560,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31686,7 +31720,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31866,7 +31900,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -31946,7 +31980,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -32021,7 +32055,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -32116,7 +32150,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -32131,7 +32165,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -32211,7 +32245,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -32706,7 +32740,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -32726,7 +32760,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -32771,7 +32805,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -32901,12 +32935,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -32921,32 +32955,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -32961,32 +32995,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -32996,7 +33030,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -33021,7 +33055,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -33134,17 +33168,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -33174,12 +33208,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -33204,7 +33238,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -33214,7 +33248,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -33244,7 +33278,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -33259,7 +33293,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -33274,7 +33308,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -33319,7 +33353,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -33339,7 +33373,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -33394,7 +33428,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33419,7 +33453,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33479,7 +33513,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33499,7 +33533,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33509,7 +33543,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33569,7 +33603,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33659,7 +33693,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33689,7 +33723,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33729,12 +33763,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33854,7 +33888,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33909,7 +33943,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33949,7 +33983,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33959,7 +33993,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -33969,7 +34003,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34009,7 +34043,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34019,12 +34053,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34044,12 +34078,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34074,7 +34108,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34094,7 +34128,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34109,17 +34143,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34149,7 +34183,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34169,12 +34203,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34199,7 +34233,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34234,7 +34268,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34349,7 +34383,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34454,7 +34488,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34544,17 +34578,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34574,7 +34608,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34624,17 +34658,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34649,12 +34683,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34664,7 +34698,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34674,17 +34708,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34709,7 +34743,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34749,12 +34783,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34764,7 +34798,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34819,7 +34853,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -34979,7 +35013,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -35159,7 +35193,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -35239,7 +35273,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -35314,7 +35348,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -35409,7 +35443,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -35424,7 +35458,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -35504,7 +35538,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -35999,7 +36033,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -36019,7 +36053,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -36064,7 +36098,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -36194,12 +36228,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -36214,32 +36248,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -36254,32 +36288,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -36289,7 +36323,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -36314,7 +36348,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -36417,17 +36451,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -36457,12 +36491,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -36487,7 +36521,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -36497,7 +36531,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -36527,7 +36561,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -36542,7 +36576,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -36557,7 +36591,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -36602,7 +36636,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -36622,7 +36656,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -36677,7 +36711,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -36702,7 +36736,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -36762,7 +36796,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -36782,7 +36816,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -36792,7 +36826,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -36852,7 +36886,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -36942,7 +36976,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -36972,7 +37006,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37012,12 +37046,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37137,7 +37171,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37192,7 +37226,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37232,7 +37266,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37242,7 +37276,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37252,7 +37286,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37292,7 +37326,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37302,12 +37336,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37327,12 +37361,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37357,7 +37391,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37377,7 +37411,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37392,17 +37426,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37432,7 +37466,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37452,12 +37486,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37482,7 +37516,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37517,7 +37551,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37632,7 +37666,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37737,7 +37771,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37827,17 +37861,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37857,7 +37891,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37907,17 +37941,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37932,12 +37966,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37947,7 +37981,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37957,17 +37991,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -37992,7 +38026,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -38032,12 +38066,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -38047,7 +38081,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -38102,7 +38136,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -38262,7 +38296,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -38442,7 +38476,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -38522,7 +38556,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -38597,7 +38631,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -38692,7 +38726,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -38707,7 +38741,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -38787,7 +38821,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -39282,7 +39316,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -39302,7 +39336,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -39347,7 +39381,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -39477,12 +39511,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -39497,32 +39531,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -39537,32 +39571,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -39572,7 +39606,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -39597,7 +39631,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -39700,17 +39734,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        170 => /* '\u{aa}' */ {
+                        170 => /* 'ª' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        181 => /* '\u{b5}' */ {
+                        181 => /* 'µ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        186 => /* '\u{ba}' */ {
+                        186 => /* 'º' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -39740,12 +39774,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        748 => /* '\u{2ec}' */ {
+                        748 => /* 'ˬ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
                         }
-                        750 => /* '\u{2ee}' */ {
+                        750 => /* 'ˮ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -39770,7 +39804,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        902 => /* '\u{386}' */ {
+                        902 => /* 'Ά' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -39780,7 +39814,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        908 => /* '\u{38c}' */ {
+                        908 => /* 'Ό' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -39810,7 +39844,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1369 => /* '\u{559}' */ {
+                        1369 => /* 'ՙ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -39825,7 +39859,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1471 => /* '\u{5bf}' */ {
+                        1471 => /* 'ֿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -39840,7 +39874,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1479 => /* '\u{5c7}' */ {
+                        1479 => /* 'ׇ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -39885,7 +39919,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        1791 => /* '\u{6ff}' */ {
+                        1791 => /* 'ۿ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -39905,7 +39939,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2042 => /* '\u{7fa}' */ {
+                        2042 => /* 'ߺ' */ {
                             __current_match = Some((8, __index + 2));
                             __current_state = 10;
                             continue;
@@ -39960,7 +39994,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2482 => /* '\u{9b2}' */ {
+                        2482 => /* 'ল' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -39985,7 +40019,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2519 => /* '\u{9d7}' */ {
+                        2519 => /* 'ৗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40045,7 +40079,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2620 => /* '\u{a3c}' */ {
+                        2620 => /* '਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40065,7 +40099,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2641 => /* '\u{a51}' */ {
+                        2641 => /* 'ੑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40075,7 +40109,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2654 => /* '\u{a5e}' */ {
+                        2654 => /* 'ਫ਼' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40135,7 +40169,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2768 => /* '\u{ad0}' */ {
+                        2768 => /* 'ૐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40225,7 +40259,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2929 => /* '\u{b71}' */ {
+                        2929 => /* 'ୱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40255,7 +40289,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        2972 => /* '\u{b9c}' */ {
+                        2972 => /* 'ஜ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40295,12 +40329,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3024 => /* '\u{bd0}' */ {
+                        3024 => /* 'ௐ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3031 => /* '\u{bd7}' */ {
+                        3031 => /* 'ௗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40420,7 +40454,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3294 => /* '\u{cde}' */ {
+                        3294 => /* 'ೞ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40475,7 +40509,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3415 => /* '\u{d57}' */ {
+                        3415 => /* 'ൗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40515,7 +40549,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3517 => /* '\u{dbd}' */ {
+                        3517 => /* 'ල' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40525,7 +40559,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3530 => /* '\u{dca}' */ {
+                        3530 => /* '්' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40535,7 +40569,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3542 => /* '\u{dd6}' */ {
+                        3542 => /* 'ූ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40575,7 +40609,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3716 => /* '\u{e84}' */ {
+                        3716 => /* 'ຄ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40585,12 +40619,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3722 => /* '\u{e8a}' */ {
+                        3722 => /* 'ຊ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3725 => /* '\u{e8d}' */ {
+                        3725 => /* 'ຍ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40610,12 +40644,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3749 => /* '\u{ea5}' */ {
+                        3749 => /* 'ລ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3751 => /* '\u{ea7}' */ {
+                        3751 => /* 'ວ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40640,7 +40674,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3782 => /* '\u{ec6}' */ {
+                        3782 => /* 'ໆ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40660,7 +40694,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3840 => /* '\u{f00}' */ {
+                        3840 => /* 'ༀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40675,17 +40709,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        3893 => /* '\u{f35}' */ {
+                        3893 => /* '༵' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3895 => /* '\u{f37}' */ {
+                        3895 => /* '༷' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        3897 => /* '\u{f39}' */ {
+                        3897 => /* '༹' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40715,7 +40749,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4038 => /* '\u{fc6}' */ {
+                        4038 => /* '࿆' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40735,12 +40769,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4295 => /* '\u{10c7}' */ {
+                        4295 => /* 'Ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        4301 => /* '\u{10cd}' */ {
+                        4301 => /* 'Ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40765,7 +40799,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4696 => /* '\u{1258}' */ {
+                        4696 => /* 'ቘ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40800,7 +40834,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        4800 => /* '\u{12c0}' */ {
+                        4800 => /* 'ዀ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -40915,7 +40949,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6103 => /* '\u{17d7}' */ {
+                        6103 => /* 'ៗ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41020,7 +41054,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        6823 => /* '\u{1aa7}' */ {
+                        6823 => /* 'ᪧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41110,17 +41144,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8025 => /* '\u{1f59}' */ {
+                        8025 => /* 'Ὑ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8027 => /* '\u{1f5b}' */ {
+                        8027 => /* 'Ὓ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8029 => /* '\u{1f5d}' */ {
+                        8029 => /* 'Ὕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41140,7 +41174,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8126 => /* '\u{1fbe}' */ {
+                        8126 => /* 'ι' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41190,17 +41224,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8276 => /* '\u{2054}' */ {
+                        8276 => /* '⁔' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8305 => /* '\u{2071}' */ {
+                        8305 => /* 'ⁱ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8319 => /* '\u{207f}' */ {
+                        8319 => /* 'ⁿ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41215,12 +41249,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8450 => /* '\u{2102}' */ {
+                        8450 => /* 'ℂ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8455 => /* '\u{2107}' */ {
+                        8455 => /* 'ℇ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41230,7 +41264,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8469 => /* '\u{2115}' */ {
+                        8469 => /* 'ℕ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41240,17 +41274,17 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8484 => /* '\u{2124}' */ {
+                        8484 => /* 'ℤ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8486 => /* '\u{2126}' */ {
+                        8486 => /* 'Ω' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        8488 => /* '\u{2128}' */ {
+                        8488 => /* 'ℨ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41275,7 +41309,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        8526 => /* '\u{214e}' */ {
+                        8526 => /* 'ⅎ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41315,12 +41349,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11559 => /* '\u{2d27}' */ {
+                        11559 => /* 'ⴧ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
                         }
-                        11565 => /* '\u{2d2d}' */ {
+                        11565 => /* 'ⴭ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41330,7 +41364,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11631 => /* '\u{2d6f}' */ {
+                        11631 => /* 'ⵯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41385,7 +41419,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        11823 => /* '\u{2e2f}' */ {
+                        11823 => /* 'ⸯ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41545,7 +41579,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        43259 => /* '\u{a8fb}' */ {
+                        43259 => /* 'ꣻ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41725,7 +41759,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        64318 => /* '\u{fb3e}' */ {
+                        64318 => /* 'מּ' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41805,7 +41839,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        65343 => /* '\u{ff3f}' */ {
+                        65343 => /* '＿' */ {
                             __current_match = Some((8, __index + 3));
                             __current_state = 10;
                             continue;
@@ -41880,7 +41914,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        66045 => /* '\u{101fd}' */ {
+                        66045 => /* '𐇽' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -41975,7 +42009,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67592 => /* '\u{10808}' */ {
+                        67592 => /* '𐠈' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -41990,7 +42024,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        67644 => /* '\u{1083c}' */ {
+                        67644 => /* '𐠼' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -42070,7 +42104,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        68159 => /* '\u{10a3f}' */ {
+                        68159 => /* '𐨿' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -42565,7 +42599,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119970 => /* '\u{1d4a2}' */ {
+                        119970 => /* '𝒢' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -42585,7 +42619,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        119995 => /* '\u{1d4bb}' */ {
+                        119995 => /* '𝒻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -42630,7 +42664,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        120134 => /* '\u{1d546}' */ {
+                        120134 => /* '𝕆' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -42760,12 +42794,12 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126500 => /* '\u{1ee24}' */ {
+                        126500 => /* '𞸤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126503 => /* '\u{1ee27}' */ {
+                        126503 => /* '𞸧' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -42780,32 +42814,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126521 => /* '\u{1ee39}' */ {
+                        126521 => /* '𞸹' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126523 => /* '\u{1ee3b}' */ {
+                        126523 => /* '𞸻' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126530 => /* '\u{1ee42}' */ {
+                        126530 => /* '𞹂' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126535 => /* '\u{1ee47}' */ {
+                        126535 => /* '𞹇' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126537 => /* '\u{1ee49}' */ {
+                        126537 => /* '𞹉' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126539 => /* '\u{1ee4b}' */ {
+                        126539 => /* '𞹋' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -42820,32 +42854,32 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126548 => /* '\u{1ee54}' */ {
+                        126548 => /* '𞹔' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126551 => /* '\u{1ee57}' */ {
+                        126551 => /* '𞹗' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126553 => /* '\u{1ee59}' */ {
+                        126553 => /* '𞹙' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126555 => /* '\u{1ee5b}' */ {
+                        126555 => /* '𞹛' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126557 => /* '\u{1ee5d}' */ {
+                        126557 => /* '𞹝' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
                         }
-                        126559 => /* '\u{1ee5f}' */ {
+                        126559 => /* '𞹟' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -42855,7 +42889,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126564 => /* '\u{1ee64}' */ {
+                        126564 => /* '𞹤' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;
@@ -42880,7 +42914,7 @@ mod __intern_token {
                             __current_state = 10;
                             continue;
                         }
-                        126590 => /* '\u{1ee7e}' */ {
+                        126590 => /* '𞹾' */ {
                             __current_match = Some((8, __index + 4));
                             __current_state = 10;
                             continue;

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -30,6 +30,9 @@ mod expr_arena_ast;
 /// expr defined with a generic type `F`
 mod expr_generic;
 
+mod generics_issue_104;
+mod generics_issue_104_lib;
+
 /// test of inlining
 mod inline;
 
@@ -282,7 +285,7 @@ fn issue_55_test1() {
     // Issue 55 caused us to either accept NO assoc types or assoc
     // types both before and after, so check that we can parse with
     // assoc types on either side.
-    
+
     let (a, b, c) = issue_55::parse_E("{ type X; type Y; enum Z { } }").unwrap();
     assert_eq!(a, vec!["X", "Y"]);
     assert_eq!(b, "Z");
@@ -298,4 +301,12 @@ fn issue_55_test1() {
 fn unit_test1() {
     assert!(unit::parse_Expr("3 + 4 * 5").is_ok());
     assert!(unit::parse_Expr("3 + +").is_err());
+}
+
+#[test]
+fn generics_issue_104_test1() {
+    // The real thing `generics_issue_104` is testing is that the code
+    // *compiles*, even though the type parameter `T` does not appear
+    // in any of the arguments.
+    assert!(generics_issue_104::parse_Schema::<()>("grammar { foo }").is_ok());
 }

--- a/lalrpop-test/src/sub.rs
+++ b/lalrpop-test/src/sub.rs
@@ -46,7 +46,7 @@ mod __parse__S {
                     None => None,
                     Some(Err(e)) => return Err(__lalrpop_util::ParseError::User { error: e }),
                 };
-                match try!(__state0(&mut __tokens, __lookahead)) {
+                match try!(__state0(&mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -95,17 +95,18 @@ mod __parse__S {
             >(
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym0 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(__tokens, __sym0));
+                        __result = try!(__state4(__tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(__tokens, __sym0));
+                        __result = try!(__state5(__tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -118,13 +119,13 @@ mod __parse__S {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::E(__sym0) => {
-                            __result = try!(__state1(__tokens, __lookahead, __sym0));
+                            __result = try!(__state1(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::S(__sym0) => {
-                            __result = try!(__state2(__tokens, __lookahead, __sym0));
+                            __result = try!(__state2(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::T(__sym0) => {
-                            __result = try!(__state3(__tokens, __lookahead, __sym0));
+                            __result = try!(__state3(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -153,19 +154,20 @@ mod __parse__S {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state6(__tokens, __sym0, __sym1));
+                        __result = try!(__state6(__tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action1(__sym0);
+                        let __nt = super::super::super::__action1::<>(__sym0);
                         let __nt = __Nonterminal::S((
                             __start,
                             __nt,
@@ -201,6 +203,7 @@ mod __parse__S {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -208,7 +211,7 @@ mod __parse__S {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(__sym0);
+                        let __nt = super::super::super::__action0::<>(__sym0);
                         let __nt = __Nonterminal::____S((
                             __start,
                             __nt,
@@ -244,6 +247,7 @@ mod __parse__S {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -252,7 +256,7 @@ mod __parse__S {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(__sym0);
+                        let __nt = super::super::super::__action3::<>(__sym0);
                         let __nt = __Nonterminal::E((
                             __start,
                             __nt,
@@ -298,6 +302,7 @@ mod __parse__S {
             >(
                 __tokens: &mut __TOKENS,
                 __sym0: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -310,11 +315,11 @@ mod __parse__S {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(__tokens, __sym1));
+                        __result = try!(__state9(__tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state10(__tokens, __sym1));
+                        __result = try!(__state10(__tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -330,10 +335,10 @@ mod __parse__S {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::E(__sym1) => {
-                            __result = try!(__state7(__tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state7(__tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::T(__sym1) => {
-                            __result = try!(__state8(__tokens, __lookahead, __sym1));
+                            __result = try!(__state8(__tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -359,6 +364,7 @@ mod __parse__S {
             >(
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -372,7 +378,7 @@ mod __parse__S {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action4(__sym0);
+                        let __nt = super::super::super::__action4::<>(__sym0);
                         let __nt = __Nonterminal::T((
                             __start,
                             __nt,
@@ -412,6 +418,7 @@ mod __parse__S {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -423,11 +430,11 @@ mod __parse__S {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state4(__tokens, __sym2));
+                        __result = try!(__state4(__tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(__tokens, __sym2));
+                        __result = try!(__state5(__tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -440,7 +447,7 @@ mod __parse__S {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::T(__sym2) => {
-                            __result = try!(__state11(__tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state11(__tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -471,6 +478,7 @@ mod __parse__S {
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: &mut Option<((), Tok, ())>,
                 __sym1: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -478,12 +486,12 @@ mod __parse__S {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state12(__tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state12(__tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state13(__tokens, __sym1, __sym2));
+                        __result = try!(__state13(__tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -513,6 +521,7 @@ mod __parse__S {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -521,7 +530,7 @@ mod __parse__S {
                     Some((_, Tok::Minus, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(__sym0);
+                        let __nt = super::super::super::__action3::<>(__sym0);
                         let __nt = __Nonterminal::E((
                             __start,
                             __nt,
@@ -567,6 +576,7 @@ mod __parse__S {
             >(
                 __tokens: &mut __TOKENS,
                 __sym0: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -579,11 +589,11 @@ mod __parse__S {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(__tokens, __sym1));
+                        __result = try!(__state9(__tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state10(__tokens, __sym1));
+                        __result = try!(__state10(__tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -599,10 +609,10 @@ mod __parse__S {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::E(__sym1) => {
-                            __result = try!(__state14(__tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state14(__tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::T(__sym1) => {
-                            __result = try!(__state8(__tokens, __lookahead, __sym1));
+                            __result = try!(__state8(__tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -628,6 +638,7 @@ mod __parse__S {
             >(
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -641,7 +652,7 @@ mod __parse__S {
                     Some((_, Tok::Minus, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action4(__sym0);
+                        let __nt = super::super::super::__action4::<>(__sym0);
                         let __nt = __Nonterminal::T((
                             __start,
                             __nt,
@@ -679,6 +690,7 @@ mod __parse__S {
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -687,7 +699,7 @@ mod __parse__S {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(__sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(__sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::E((
                             __start,
                             __nt,
@@ -724,6 +736,7 @@ mod __parse__S {
                 __sym0: ((), Tok, ()),
                 __sym1: ((), i32, ()),
                 __sym2: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -737,7 +750,7 @@ mod __parse__S {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(__sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(__sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::T((
                             __start,
                             __nt,
@@ -777,6 +790,7 @@ mod __parse__S {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -788,11 +802,11 @@ mod __parse__S {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state9(__tokens, __sym2));
+                        __result = try!(__state9(__tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state10(__tokens, __sym2));
+                        __result = try!(__state10(__tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -805,7 +819,7 @@ mod __parse__S {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::T(__sym2) => {
-                            __result = try!(__state15(__tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state15(__tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -836,6 +850,7 @@ mod __parse__S {
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: &mut Option<((), Tok, ())>,
                 __sym1: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -843,12 +858,12 @@ mod __parse__S {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state16(__tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state16(__tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                         let __sym2 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state13(__tokens, __sym1, __sym2));
+                        __result = try!(__state13(__tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -880,6 +895,7 @@ mod __parse__S {
                 __sym0: ((), i32, ()),
                 __sym1: ((), Tok, ()),
                 __sym2: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -888,7 +904,7 @@ mod __parse__S {
                     Some((_, Tok::Minus, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(__sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(__sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::E((
                             __start,
                             __nt,
@@ -925,6 +941,7 @@ mod __parse__S {
                 __sym0: ((), Tok, ()),
                 __sym1: ((), i32, ()),
                 __sym2: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -938,7 +955,7 @@ mod __parse__S {
                     Some((_, Tok::Minus, _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(__sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(__sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::T((
                             __start,
                             __nt,
@@ -1275,7 +1292,7 @@ mod __parse__S {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -1290,7 +1307,7 @@ mod __parse__S {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -1307,6 +1324,7 @@ mod __parse__S {
                 __lookahead_start: Option<&()>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<((),__Symbol<>,())>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<i32,__lalrpop_util::ParseError<(),Tok,()>>>
             {
                 let __nonterminal = match -__action {
@@ -1317,7 +1335,7 @@ mod __parse__S {
                         let __sym0 = __pop_NtE(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(__sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(__sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtE(__nt), __end));
@@ -1328,7 +1346,7 @@ mod __parse__S {
                         let __sym0 = __pop_NtT(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(__sym0);
+                        let __nt = super::super::super::__action3::<>(__sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtE(__nt), __end));
@@ -1339,7 +1357,7 @@ mod __parse__S {
                         let __sym0 = __pop_NtE(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action1(__sym0);
+                        let __nt = super::super::super::__action1::<>(__sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtS(__nt), __end));
@@ -1350,7 +1368,7 @@ mod __parse__S {
                         let __sym0 = __pop_TermNum(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action4(__sym0);
+                        let __nt = super::super::super::__action4::<>(__sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtT(__nt), __end));
@@ -1363,7 +1381,7 @@ mod __parse__S {
                         let __sym0 = __pop_Term_22_28_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(__sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(__sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtT(__nt), __end));
@@ -1374,7 +1392,7 @@ mod __parse__S {
                         let __sym0 = __pop_NtS(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(__sym0);
+                        let __nt = super::super::super::__action0::<>(__sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/sub_ascent.rs
+++ b/lalrpop-test/src/sub_ascent.rs
@@ -21,7 +21,7 @@ mod __parse__S {
             None => None,
             Some(Err(e)) => return Err(__lalrpop_util::ParseError::User { error: e }),
         };
-        match try!(__state0(&mut __tokens, __lookahead)) {
+        match try!(__state0(&mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
             (Some(__lookahead), _) => {
                 Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
             }
@@ -70,17 +70,18 @@ mod __parse__S {
     >(
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                 let __sym0 = (__loc1, (__tok), __loc2);
-                __result = try!(__state4(__tokens, __sym0));
+                __result = try!(__state4(__tokens, __sym0, ::std::marker::PhantomData::<()>));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym0 = (__loc1, (__tok0), __loc2);
-                __result = try!(__state5(__tokens, __sym0));
+                __result = try!(__state5(__tokens, __sym0, ::std::marker::PhantomData::<()>));
             }
             _ => {
                 return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -93,13 +94,13 @@ mod __parse__S {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::E(__sym0) => {
-                    __result = try!(__state1(__tokens, __lookahead, __sym0));
+                    __result = try!(__state1(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                 }
                 __Nonterminal::S(__sym0) => {
-                    __result = try!(__state2(__tokens, __lookahead, __sym0));
+                    __result = try!(__state2(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                 }
                 __Nonterminal::T(__sym0) => {
-                    __result = try!(__state3(__tokens, __lookahead, __sym0));
+                    __result = try!(__state3(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -128,19 +129,20 @@ mod __parse__S {
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
         __sym0: ((), i32, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
         match __lookahead {
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                 let __sym1 = (__loc1, (__tok), __loc2);
-                __result = try!(__state6(__tokens, __sym0, __sym1));
+                __result = try!(__state6(__tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                 return Ok(__result);
             }
             None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
-                let __nt = super::__action1(__sym0);
+                let __nt = super::__action1::<>(__sym0);
                 let __nt = __Nonterminal::S((
                     __start,
                     __nt,
@@ -176,6 +178,7 @@ mod __parse__S {
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
         __sym0: ((), i32, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -183,7 +186,7 @@ mod __parse__S {
             None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
-                let __nt = super::__action0(__sym0);
+                let __nt = super::__action0::<>(__sym0);
                 let __nt = __Nonterminal::____S((
                     __start,
                     __nt,
@@ -219,6 +222,7 @@ mod __parse__S {
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
         __sym0: ((), i32, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -227,7 +231,7 @@ mod __parse__S {
             None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
-                let __nt = super::__action3(__sym0);
+                let __nt = super::__action3::<>(__sym0);
                 let __nt = __Nonterminal::E((
                     __start,
                     __nt,
@@ -273,6 +277,7 @@ mod __parse__S {
     >(
         __tokens: &mut __TOKENS,
         __sym0: ((), Tok, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -285,11 +290,11 @@ mod __parse__S {
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                 let __sym1 = (__loc1, (__tok), __loc2);
-                __result = try!(__state9(__tokens, __sym1));
+                __result = try!(__state9(__tokens, __sym1, ::std::marker::PhantomData::<()>));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__state10(__tokens, __sym1));
+                __result = try!(__state10(__tokens, __sym1, ::std::marker::PhantomData::<()>));
             }
             _ => {
                 return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -305,10 +310,10 @@ mod __parse__S {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::E(__sym1) => {
-                    __result = try!(__state7(__tokens, __lookahead, __sym0, __sym1));
+                    __result = try!(__state7(__tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                 }
                 __Nonterminal::T(__sym1) => {
-                    __result = try!(__state8(__tokens, __lookahead, __sym1));
+                    __result = try!(__state8(__tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -334,6 +339,7 @@ mod __parse__S {
     >(
         __tokens: &mut __TOKENS,
         __sym0: ((), i32, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -347,7 +353,7 @@ mod __parse__S {
             None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
-                let __nt = super::__action4(__sym0);
+                let __nt = super::__action4::<>(__sym0);
                 let __nt = __Nonterminal::T((
                     __start,
                     __nt,
@@ -387,6 +393,7 @@ mod __parse__S {
         __tokens: &mut __TOKENS,
         __sym0: ((), i32, ()),
         __sym1: ((), Tok, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -398,11 +405,11 @@ mod __parse__S {
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
-                __result = try!(__state4(__tokens, __sym2));
+                __result = try!(__state4(__tokens, __sym2, ::std::marker::PhantomData::<()>));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__state5(__tokens, __sym2));
+                __result = try!(__state5(__tokens, __sym2, ::std::marker::PhantomData::<()>));
             }
             _ => {
                 return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -415,7 +422,7 @@ mod __parse__S {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::T(__sym2) => {
-                    __result = try!(__state11(__tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state11(__tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                     return Ok(__result);
                 }
                 _ => {
@@ -446,6 +453,7 @@ mod __parse__S {
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), Tok, ())>,
         __sym1: ((), i32, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -453,12 +461,12 @@ mod __parse__S {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__state12(__tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state12(__tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
-                __result = try!(__state13(__tokens, __sym1, __sym2));
+                __result = try!(__state13(__tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                 return Ok(__result);
             }
             _ => {
@@ -488,6 +496,7 @@ mod __parse__S {
         __tokens: &mut __TOKENS,
         __lookahead: Option<((), Tok, ())>,
         __sym0: ((), i32, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -496,7 +505,7 @@ mod __parse__S {
             Some((_, Tok::Minus, _)) => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
-                let __nt = super::__action3(__sym0);
+                let __nt = super::__action3::<>(__sym0);
                 let __nt = __Nonterminal::E((
                     __start,
                     __nt,
@@ -542,6 +551,7 @@ mod __parse__S {
     >(
         __tokens: &mut __TOKENS,
         __sym0: ((), Tok, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -554,11 +564,11 @@ mod __parse__S {
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                 let __sym1 = (__loc1, (__tok), __loc2);
-                __result = try!(__state9(__tokens, __sym1));
+                __result = try!(__state9(__tokens, __sym1, ::std::marker::PhantomData::<()>));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym1 = (__loc1, (__tok0), __loc2);
-                __result = try!(__state10(__tokens, __sym1));
+                __result = try!(__state10(__tokens, __sym1, ::std::marker::PhantomData::<()>));
             }
             _ => {
                 return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -574,10 +584,10 @@ mod __parse__S {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::E(__sym1) => {
-                    __result = try!(__state14(__tokens, __lookahead, __sym0, __sym1));
+                    __result = try!(__state14(__tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                 }
                 __Nonterminal::T(__sym1) => {
-                    __result = try!(__state8(__tokens, __lookahead, __sym1));
+                    __result = try!(__state8(__tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                 }
                 _ => {
                     return Ok((__lookahead, __nt));
@@ -603,6 +613,7 @@ mod __parse__S {
     >(
         __tokens: &mut __TOKENS,
         __sym0: ((), i32, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -616,7 +627,7 @@ mod __parse__S {
             Some((_, Tok::Minus, _)) => {
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
-                let __nt = super::__action4(__sym0);
+                let __nt = super::__action4::<>(__sym0);
                 let __nt = __Nonterminal::T((
                     __start,
                     __nt,
@@ -654,6 +665,7 @@ mod __parse__S {
         __sym0: ((), i32, ()),
         __sym1: ((), Tok, ()),
         __sym2: ((), i32, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -662,7 +674,7 @@ mod __parse__S {
             None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
-                let __nt = super::__action2(__sym0, __sym1, __sym2);
+                let __nt = super::__action2::<>(__sym0, __sym1, __sym2);
                 let __nt = __Nonterminal::E((
                     __start,
                     __nt,
@@ -699,6 +711,7 @@ mod __parse__S {
         __sym0: ((), Tok, ()),
         __sym1: ((), i32, ()),
         __sym2: ((), Tok, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -712,7 +725,7 @@ mod __parse__S {
             None => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
-                let __nt = super::__action5(__sym0, __sym1, __sym2);
+                let __nt = super::__action5::<>(__sym0, __sym1, __sym2);
                 let __nt = __Nonterminal::T((
                     __start,
                     __nt,
@@ -752,6 +765,7 @@ mod __parse__S {
         __tokens: &mut __TOKENS,
         __sym0: ((), i32, ()),
         __sym1: ((), Tok, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -763,11 +777,11 @@ mod __parse__S {
         match __lookahead {
             Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
-                __result = try!(__state9(__tokens, __sym2));
+                __result = try!(__state9(__tokens, __sym2, ::std::marker::PhantomData::<()>));
             }
             Some((__loc1, Tok::Num(__tok0), __loc2)) => {
                 let __sym2 = (__loc1, (__tok0), __loc2);
-                __result = try!(__state10(__tokens, __sym2));
+                __result = try!(__state10(__tokens, __sym2, ::std::marker::PhantomData::<()>));
             }
             _ => {
                 return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -780,7 +794,7 @@ mod __parse__S {
             let (__lookahead, __nt) = __result;
             match __nt {
                 __Nonterminal::T(__sym2) => {
-                    __result = try!(__state15(__tokens, __lookahead, __sym0, __sym1, __sym2));
+                    __result = try!(__state15(__tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                     return Ok(__result);
                 }
                 _ => {
@@ -811,6 +825,7 @@ mod __parse__S {
         __lookahead: Option<((), Tok, ())>,
         __sym0: &mut Option<((), Tok, ())>,
         __sym1: ((), i32, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -818,12 +833,12 @@ mod __parse__S {
             Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
                 let __sym0 = __sym0.take().unwrap();
-                __result = try!(__state16(__tokens, __sym0, __sym1, __sym2));
+                __result = try!(__state16(__tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                 return Ok(__result);
             }
             Some((__loc1, __tok @ Tok::Minus, __loc2)) => {
                 let __sym2 = (__loc1, (__tok), __loc2);
-                __result = try!(__state13(__tokens, __sym1, __sym2));
+                __result = try!(__state13(__tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                 return Ok(__result);
             }
             _ => {
@@ -855,6 +870,7 @@ mod __parse__S {
         __sym0: ((), i32, ()),
         __sym1: ((), Tok, ()),
         __sym2: ((), i32, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -863,7 +879,7 @@ mod __parse__S {
             Some((_, Tok::Minus, _)) => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
-                let __nt = super::__action2(__sym0, __sym1, __sym2);
+                let __nt = super::__action2::<>(__sym0, __sym1, __sym2);
                 let __nt = __Nonterminal::E((
                     __start,
                     __nt,
@@ -900,6 +916,7 @@ mod __parse__S {
         __sym0: ((), Tok, ()),
         __sym1: ((), i32, ()),
         __sym2: ((), Tok, ()),
+        _: ::std::marker::PhantomData<()>,
     ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
     {
         let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -913,7 +930,7 @@ mod __parse__S {
             Some((_, Tok::Minus, _)) => {
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
-                let __nt = super::__action5(__sym0, __sym1, __sym2);
+                let __nt = super::__action5::<>(__sym0, __sym1, __sym2);
                 let __nt = __Nonterminal::T((
                     __start,
                     __nt,

--- a/lalrpop-test/src/sub_table.rs
+++ b/lalrpop-test/src/sub_table.rs
@@ -316,7 +316,7 @@ mod __parse__S {
                     __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                     continue '__shift;
                 } else if __action < 0 {
-                    if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                    if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                         return r;
                     }
                 } else {
@@ -331,7 +331,7 @@ mod __parse__S {
             let __state = *__states.last().unwrap() as usize;
             let __action = __EOF_ACTION[__state];
             if __action < 0 {
-                if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols) {
+                if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                     return r;
                 }
             } else {
@@ -348,6 +348,7 @@ mod __parse__S {
         __lookahead_start: Option<&()>,
         __states: &mut ::std::vec::Vec<i32>,
         __symbols: &mut ::std::vec::Vec<((),__Symbol<>,())>,
+        _: ::std::marker::PhantomData<()>,
     ) -> Option<Result<i32,__lalrpop_util::ParseError<(),Tok,()>>>
     {
         let __nonterminal = match -__action {
@@ -358,7 +359,7 @@ mod __parse__S {
                 let __sym0 = __pop_NtE(__symbols);
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
-                let __nt = super::__action2(__sym0, __sym1, __sym2);
+                let __nt = super::__action2::<>(__sym0, __sym1, __sym2);
                 let __states_len = __states.len();
                 __states.truncate(__states_len - 3);
                 __symbols.push((__start, __Symbol::NtE(__nt), __end));
@@ -369,7 +370,7 @@ mod __parse__S {
                 let __sym0 = __pop_NtT(__symbols);
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
-                let __nt = super::__action3(__sym0);
+                let __nt = super::__action3::<>(__sym0);
                 let __states_len = __states.len();
                 __states.truncate(__states_len - 1);
                 __symbols.push((__start, __Symbol::NtE(__nt), __end));
@@ -380,7 +381,7 @@ mod __parse__S {
                 let __sym0 = __pop_NtE(__symbols);
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
-                let __nt = super::__action1(__sym0);
+                let __nt = super::__action1::<>(__sym0);
                 let __states_len = __states.len();
                 __states.truncate(__states_len - 1);
                 __symbols.push((__start, __Symbol::NtS(__nt), __end));
@@ -391,7 +392,7 @@ mod __parse__S {
                 let __sym0 = __pop_TermNum(__symbols);
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
-                let __nt = super::__action4(__sym0);
+                let __nt = super::__action4::<>(__sym0);
                 let __states_len = __states.len();
                 __states.truncate(__states_len - 1);
                 __symbols.push((__start, __Symbol::NtT(__nt), __end));
@@ -404,7 +405,7 @@ mod __parse__S {
                 let __sym0 = __pop_Term_22_28_22(__symbols);
                 let __start = __sym0.0.clone();
                 let __end = __sym2.2.clone();
-                let __nt = super::__action5(__sym0, __sym1, __sym2);
+                let __nt = super::__action5::<>(__sym0, __sym1, __sym2);
                 let __states_len = __states.len();
                 __states.truncate(__states_len - 3);
                 __symbols.push((__start, __Symbol::NtT(__nt), __end));
@@ -415,7 +416,7 @@ mod __parse__S {
                 let __sym0 = __pop_NtS(__symbols);
                 let __start = __sym0.0.clone();
                 let __end = __sym0.2.clone();
-                let __nt = super::__action0(__sym0);
+                let __nt = super::__action0::<>(__sym0);
                 return Some(Ok(__nt));
             }
             _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/unit.rs
+++ b/lalrpop-test/src/unit.rs
@@ -37,7 +37,7 @@ mod __parse__Expr {
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
-                match try!(__state0(input, &mut __tokens, __lookahead)) {
+                match try!(__state0(input, &mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -113,17 +113,18 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym0));
+                        __result = try!(__state4(input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym0));
+                        __result = try!(__state5(input, __tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -136,13 +137,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym0) => {
-                            __result = try!(__state1(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state1(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym0) => {
-                            __result = try!(__state2(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state2(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym0) => {
-                            __result = try!(__state3(input, __tokens, __lookahead, __sym0));
+                            __result = try!(__state3(input, __tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -175,24 +176,25 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state6(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state6(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state7(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state7(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(input, __sym0);
+                        let __nt = super::super::super::__action0::<>(input, __sym0);
                         let __nt = __Nonterminal::____Expr((
                             __start,
                             __nt,
@@ -234,18 +236,19 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state8(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state8(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state9(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state9(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (3, _), _)) |
@@ -253,7 +256,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(input, __sym0);
+                        let __nt = super::super::super::__action3::<>(input, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -291,6 +294,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -302,7 +306,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(input, __sym0);
+                        let __nt = super::super::super::__action6::<>(input, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -377,6 +381,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -389,11 +394,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym1));
+                        __result = try!(__state13(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym1));
+                        __result = try!(__state14(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -409,13 +414,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state10(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state10(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state11(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state11(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state12(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -443,6 +448,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -459,7 +465,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0);
+                        let __nt = super::super::super::__action7::<>(input, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -515,6 +521,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -528,11 +535,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym2));
+                        __result = try!(__state4(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym2));
+                        __result = try!(__state5(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -548,10 +555,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state15(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state15(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state3(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -598,6 +605,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -611,11 +619,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym2));
+                        __result = try!(__state4(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym2));
+                        __result = try!(__state5(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -631,10 +639,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state16(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state16(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state3(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state3(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -667,6 +675,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -678,11 +687,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym2));
+                        __result = try!(__state4(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym2));
+                        __result = try!(__state5(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -695,7 +704,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state17(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state17(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -729,6 +738,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -740,11 +750,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state4(input, __tokens, __sym2));
+                        __result = try!(__state4(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state5(input, __tokens, __sym2));
+                        __result = try!(__state5(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -757,7 +767,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state18(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state18(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -792,6 +802,7 @@ mod __parse__Expr {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: &mut Option<(usize, &'input str, usize)>,
                 __sym1: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -799,17 +810,17 @@ mod __parse__Expr {
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state19(input, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state19(input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state20(input, __tokens, __sym1, __sym2));
+                        __result = try!(__state20(input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state21(input, __tokens, __sym1, __sym2));
+                        __result = try!(__state21(input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -845,18 +856,19 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state22(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state22(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state23(input, __tokens, __sym0, __sym1));
+                        __result = try!(__state23(input, __tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (1, _), _)) |
@@ -864,7 +876,7 @@ mod __parse__Expr {
                     Some((_, (4, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(input, __sym0);
+                        let __nt = super::super::super::__action3::<>(input, __sym0);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -902,6 +914,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -913,7 +926,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(input, __sym0);
+                        let __nt = super::super::super::__action6::<>(input, __sym0);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -988,6 +1001,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1000,11 +1014,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym1));
+                        __result = try!(__state13(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym1));
+                        __result = try!(__state14(input, __tokens, __sym1, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1020,13 +1034,13 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Expr(__sym1) => {
-                            __result = try!(__state24(input, __tokens, __lookahead, __sym0, __sym1));
+                            __result = try!(__state24(input, __tokens, __lookahead, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Factor(__sym1) => {
-                            __result = try!(__state11(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state11(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym1) => {
-                            __result = try!(__state12(input, __tokens, __lookahead, __sym1));
+                            __result = try!(__state12(input, __tokens, __lookahead, __sym1, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1054,6 +1068,7 @@ mod __parse__Expr {
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1070,7 +1085,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0);
+                        let __nt = super::super::super::__action7::<>(input, __sym0);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1114,18 +1129,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, (), usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state8(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state8(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state9(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (3, _), _)) |
@@ -1135,7 +1151,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1179,18 +1195,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, (), usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state8(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state8(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state9(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state9(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (3, _), _)) |
@@ -1200,7 +1217,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1240,6 +1257,7 @@ mod __parse__Expr {
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1251,7 +1269,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1291,6 +1309,7 @@ mod __parse__Expr {
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1302,7 +1321,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1341,6 +1360,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, (), usize),
                 __sym2: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1357,7 +1377,7 @@ mod __parse__Expr {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -1413,6 +1433,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1426,11 +1447,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym2));
+                        __result = try!(__state13(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym2));
+                        __result = try!(__state14(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1446,10 +1467,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state25(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state25(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state12(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state12(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1496,6 +1517,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1509,11 +1531,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym2));
+                        __result = try!(__state13(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym2));
+                        __result = try!(__state14(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1529,10 +1551,10 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Factor(__sym2) => {
-                            __result = try!(__state26(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state26(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state12(input, __tokens, __lookahead, __sym2));
+                            __result = try!(__state12(input, __tokens, __lookahead, __sym2, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -1565,6 +1587,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1576,11 +1599,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym2));
+                        __result = try!(__state13(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym2));
+                        __result = try!(__state14(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1593,7 +1616,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state27(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state27(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1627,6 +1650,7 @@ mod __parse__Expr {
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1638,11 +1662,11 @@ mod __parse__Expr {
                 match __lookahead {
                     Some((__loc1, (0, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state13(input, __tokens, __sym2));
+                        __result = try!(__state13(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     Some((__loc1, (6, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state14(input, __tokens, __sym2));
+                        __result = try!(__state14(input, __tokens, __sym2, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -1655,7 +1679,7 @@ mod __parse__Expr {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::Term(__sym2) => {
-                            __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1, __sym2));
+                            __result = try!(__state28(input, __tokens, __lookahead, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                             return Ok(__result);
                         }
                         _ => {
@@ -1690,6 +1714,7 @@ mod __parse__Expr {
                 __lookahead: Option<(usize, (usize, &'input str), usize)>,
                 __sym0: &mut Option<(usize, &'input str, usize)>,
                 __sym1: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1697,17 +1722,17 @@ mod __parse__Expr {
                     Some((__loc1, (1, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
                         let __sym0 = __sym0.take().unwrap();
-                        __result = try!(__state29(input, __tokens, __sym0, __sym1, __sym2));
+                        __result = try!(__state29(input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (3, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state20(input, __tokens, __sym1, __sym2));
+                        __result = try!(__state20(input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (4, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state21(input, __tokens, __sym1, __sym2));
+                        __result = try!(__state21(input, __tokens, __sym1, __sym2, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -1745,18 +1770,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, (), usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state22(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state22(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state23(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state23(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (1, _), _)) |
@@ -1766,7 +1792,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1810,18 +1836,19 @@ mod __parse__Expr {
                 __sym0: &mut Option<(usize, (), usize)>,
                 __sym1: &mut Option<(usize, &'input str, usize)>,
                 __sym2: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, (2, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state22(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state22(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((__loc1, (5, __tok0), __loc2)) => {
                         let __sym3 = (__loc1, (__tok0), __loc2);
-                        __result = try!(__state23(input, __tokens, __sym2, __sym3));
+                        __result = try!(__state23(input, __tokens, __sym2, __sym3, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     Some((_, (1, _), _)) |
@@ -1831,7 +1858,7 @@ mod __parse__Expr {
                         let __sym1 = __sym1.take().unwrap();
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Expr((
                             __start,
                             __nt,
@@ -1871,6 +1898,7 @@ mod __parse__Expr {
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1882,7 +1910,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1922,6 +1950,7 @@ mod __parse__Expr {
                 __sym0: (usize, (), usize),
                 __sym1: (usize, &'input str, usize),
                 __sym2: (usize, (), usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1933,7 +1962,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Factor((
                             __start,
                             __nt,
@@ -1972,6 +2001,7 @@ mod __parse__Expr {
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, (), usize),
                 __sym2: (usize, &'input str, usize),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>
             {
                 let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
@@ -1988,7 +2018,7 @@ mod __parse__Expr {
                     Some((_, (5, _), _)) => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(input, __sym0, __sym1, __sym2);
                         let __nt = __Nonterminal::Term((
                             __start,
                             __nt,
@@ -2741,7 +2771,7 @@ mod __parse__Expr {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(input, __action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -2756,7 +2786,7 @@ mod __parse__Expr {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(input, __action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -2775,6 +2805,7 @@ mod __parse__Expr {
                 __lookahead_start: Option<&usize>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<(),__lalrpop_util::ParseError<usize,(usize, &'input str),()>>>
             {
                 let __nonterminal = match -__action {
@@ -2785,7 +2816,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action1(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action1::<>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -2798,7 +2829,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action2(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action2::<>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -2809,7 +2840,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action3(input, __sym0);
+                        let __nt = super::super::super::__action3::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtExpr(__nt), __end));
@@ -2822,7 +2853,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action4(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action4::<>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -2835,7 +2866,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtFactor(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action5(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action5::<>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -2846,7 +2877,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtTerm(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action6(input, __sym0);
+                        let __nt = super::super::super::__action6::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtFactor(__nt), __end));
@@ -2857,7 +2888,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Termr_23_22_5c_5cd_2b_22_23(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action7(input, __sym0);
+                        let __nt = super::super::super::__action7::<>(input, __sym0);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 1);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -2870,7 +2901,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_Term_22_28_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
-                        let __nt = super::super::super::__action8(input, __sym0, __sym1, __sym2);
+                        let __nt = super::super::super::__action8::<>(input, __sym0, __sym1, __sym2);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 3);
                         __symbols.push((__start, __Symbol::NtTerm(__nt), __end));
@@ -2881,7 +2912,7 @@ mod __parse__Expr {
                         let __sym0 = __pop_NtExpr(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(input, __sym0);
+                        let __nt = super::super::super::__action0::<>(input, __sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-test/src/use_super.rs
+++ b/lalrpop-test/src/use_super.rs
@@ -46,7 +46,7 @@ mod __parse__S {
                     None => None,
                     Some(Err(e)) => return Err(__lalrpop_util::ParseError::User { error: e }),
                 };
-                match try!(__state0(&mut __tokens, __lookahead)) {
+                match try!(__state0(&mut __tokens, __lookahead, ::std::marker::PhantomData::<()>)) {
                     (Some(__lookahead), _) => {
                         Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead })
                     }
@@ -82,13 +82,14 @@ mod __parse__S {
             >(
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::LParen, __loc2)) => {
                         let __sym0 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state2(__tokens, __sym0));
+                        __result = try!(__state2(__tokens, __sym0, ::std::marker::PhantomData::<()>));
                     }
                     _ => {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
@@ -101,7 +102,7 @@ mod __parse__S {
                     let (__lookahead, __nt) = __result;
                     match __nt {
                         __Nonterminal::S(__sym0) => {
-                            __result = try!(__state1(__tokens, __lookahead, __sym0));
+                            __result = try!(__state1(__tokens, __lookahead, __sym0, ::std::marker::PhantomData::<()>));
                         }
                         _ => {
                             return Ok((__lookahead, __nt));
@@ -128,6 +129,7 @@ mod __parse__S {
                 __tokens: &mut __TOKENS,
                 __lookahead: Option<((), Tok, ())>,
                 __sym0: ((), i32, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -135,7 +137,7 @@ mod __parse__S {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(__sym0);
+                        let __nt = super::super::super::__action0::<>(__sym0);
                         let __nt = __Nonterminal::____S((
                             __start,
                             __nt,
@@ -170,6 +172,7 @@ mod __parse__S {
             >(
                 __tokens: &mut __TOKENS,
                 __sym0: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -181,7 +184,7 @@ mod __parse__S {
                 match __lookahead {
                     Some((__loc1, __tok @ Tok::RParen, __loc2)) => {
                         let __sym1 = (__loc1, (__tok), __loc2);
-                        __result = try!(__state3(__tokens, __sym0, __sym1));
+                        __result = try!(__state3(__tokens, __sym0, __sym1, ::std::marker::PhantomData::<()>));
                         return Ok(__result);
                     }
                     _ => {
@@ -211,6 +214,7 @@ mod __parse__S {
                 __tokens: &mut __TOKENS,
                 __sym0: ((), Tok, ()),
                 __sym1: ((), Tok, ()),
+                _: ::std::marker::PhantomData<()>,
             ) -> Result<(Option<((), Tok, ())>, __Nonterminal<>), __lalrpop_util::ParseError<(),Tok,()>>
             {
                 let mut __result: (Option<((), Tok, ())>, __Nonterminal<>);
@@ -223,7 +227,7 @@ mod __parse__S {
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action1(__sym0, __sym1);
+                        let __nt = super::super::super::__action1::<>(__sym0, __sym1);
                         let __nt = __Nonterminal::S((
                             __start,
                             __nt,
@@ -343,7 +347,7 @@ mod __parse__S {
                             __symbols.push((__lookahead.0, __symbol, __lookahead.2));
                             continue '__shift;
                         } else if __action < 0 {
-                            if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols) {
+                            if let Some(r) = __reduce(__action, Some(&__lookahead.0), &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                                 return r;
                             }
                         } else {
@@ -358,7 +362,7 @@ mod __parse__S {
                     let __state = *__states.last().unwrap() as usize;
                     let __action = __EOF_ACTION[__state];
                     if __action < 0 {
-                        if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols) {
+                        if let Some(r) = __reduce(__action, None, &mut __states, &mut __symbols, ::std::marker::PhantomData::<()>) {
                             return r;
                         }
                     } else {
@@ -375,6 +379,7 @@ mod __parse__S {
                 __lookahead_start: Option<&()>,
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<((),__Symbol<>,())>,
+                _: ::std::marker::PhantomData<()>,
             ) -> Option<Result<i32,__lalrpop_util::ParseError<(),Tok,()>>>
             {
                 let __nonterminal = match -__action {
@@ -384,7 +389,7 @@ mod __parse__S {
                         let __sym0 = __pop_Term_22_28_22(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym1.2.clone();
-                        let __nt = super::super::super::__action1(__sym0, __sym1);
+                        let __nt = super::super::super::__action1::<>(__sym0, __sym1);
                         let __states_len = __states.len();
                         __states.truncate(__states_len - 2);
                         __symbols.push((__start, __Symbol::NtS(__nt), __end));
@@ -395,7 +400,7 @@ mod __parse__S {
                         let __sym0 = __pop_NtS(__symbols);
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
-                        let __nt = super::super::super::__action0(__sym0);
+                        let __nt = super::super::super::__action0::<>(__sym0);
                         return Some(Ok(__nt));
                     }
                     _ => panic!("invalid action code {}", __action)

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -5,3 +5,4 @@ repository = "https://github.com/nikomatsakis/lalrpop"
 license = "Apache-2.0/MIT"
 version = "0.12.0" # LALRPOP
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+workspace = ".."

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["parser", "generator", "LR", "yacc", "grammar"]
 license = "Apache-2.0/MIT"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 build = "build.rs"
+workspace = ".."
 
 [lib]
 doctest = false

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -321,6 +321,8 @@ fn emit_recursive_ascent(session: &Session, grammar: &r::Grammar) -> io::Result<
              "Building states for public nonterminal `{}`",
              user_nt);
 
+        let _lr1_tls = lr1::Lr1Tls::install(grammar.terminals.clone());
+
         let states = match lr1::build_states(&grammar, start_nt) {
             Ok(states) => states,
             Err(error) => {

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -125,6 +125,15 @@ pub enum TypeParameter {
     Id(InternedString),
 }
 
+impl TypeParameter {
+    pub fn is_lifetime(&self) -> bool {
+        match *self {
+            TypeParameter::Lifetime(_) => true,
+            _ => false
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Parameter {
     pub name: InternedString,

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -498,6 +498,16 @@ impl Grammar {
     pub fn action_is_fallible(&self, f: ActionFn) -> bool {
         self.action_fn_defns[f.index()].fallible
     }
+
+    pub fn non_lifetime_type_parameters(&self) -> Vec<&TypeParameter> {
+        self.type_parameters
+            .iter()
+            .filter(|&tp| match *tp {
+                TypeParameter::Lifetime(_) => false,
+                TypeParameter::Id(_) => true,
+            })
+            .collect()
+    }
 }
 
 impl Default for Algorithm {

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -202,16 +202,18 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent,
     // input as `Foo`. An error is reported if the entire input is not
     // consumed.
     fn write_start_fn(&mut self) -> io::Result<()> {
+        let phantom_data = self.phantom_data_expr();
         try!(self.start_parser_fn());
         try!(self.define_tokens());
 
         try!(self.next_token("lookahead", "tokens"));
         rust!(self.out,
-              "match try!({}state0({}&mut {}tokens, {}lookahead)) {{",
+              "match try!({}state0({}&mut {}tokens, {}lookahead, {})) {{",
               self.prefix,
               self.grammar.user_parameter_refs(),
               self.prefix,
-              self.prefix);
+              self.prefix,
+              phantom_data);
 
         // extra tokens?
         rust!(self.out, "(Some({}lookahead), _) => {{", self.prefix);
@@ -541,6 +543,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent,
         let all_args = base_args.into_iter()
                                 .chain(optional_args)
                                 .chain(fixed_args)
+                                .chain(Some(format!("_: {}", self.phantom_data_type())))
                                 .collect();
 
         (all_args, starts_with_terminal)
@@ -677,14 +680,16 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent,
         let fn_name = format!("{}state{}", self.prefix, next_index.0);
 
         // invoke next state, transferring the top `m` tokens
+        let phantom_data_expr = self.phantom_data_expr();
         rust!(self.out,
-              "{}{} = try!({}({}{}, {}));",
+              "{}{} = try!({}({}{}, {}, {}));",
               self.prefix,
               into_result,
               fn_name,
               self.grammar.user_parameter_refs(),
               Sep(", ", &other_args),
-              Sep(", ", &transfer_syms));
+              Sep(", ", &transfer_syms),
+              phantom_data_expr);
 
         // if the target state takes at least **two** fixed tokens,
         // then it will have consumed the top of **our** stack frame,
@@ -776,20 +781,22 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent,
         let is_fallible = self.grammar.action_is_fallible(production.action);
         if is_fallible {
             rust!(self.out,
-                  "let {}nt = try!({}::{}action{}({}{}));",
+                  "let {}nt = try!({}::{}action{}::<{}>({}{}));",
                   self.prefix,
                   self.action_module,
                   self.prefix,
                   production.action.index(),
+                  Sep(", ", &self.grammar.non_lifetime_type_parameters()),
                   self.grammar.user_parameter_refs(),
                   Sep(", ", &args))
         } else {
             rust!(self.out,
-                  "let {}nt = {}::{}action{}({}{});",
+                  "let {}nt = {}::{}action{}::<{}>({}{});",
                   self.prefix,
                   self.action_module,
                   self.prefix,
                   production.action.index(),
+                  Sep(", ", &self.grammar.non_lifetime_type_parameters()),
                   self.grammar.user_parameter_refs(),
                   Sep(", ", &args))
         }

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -8,7 +8,6 @@ use grammar::repr::{Grammar, NonterminalString, Production, Symbol, TerminalStri
 use lr1::core::*;
 use lr1::lookahead::Token;
 use lr1::state_graph::StateGraph;
-use lr1::tls::Lr1Tls;
 use rust::RustWrite;
 use std::io::{self, Write};
 use tls::Tls;
@@ -23,7 +22,6 @@ pub fn compile<'grammar, W: Write>(grammar: &'grammar Grammar,
                                    action_module: &str,
                                    out: &mut RustWrite<W>)
                                    -> io::Result<()> {
-    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let graph = StateGraph::new(&states);
     let mut ascent = CodeGenerator::new_ascent(grammar,
                                                user_start_symbol,

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -4,6 +4,7 @@ use grammar::repr::*;
 use lr1::core::*;
 use rust::RustWrite;
 use std::io::{self, Write};
+use util::Sep;
 
 /// Base struct for various kinds of code generator. The flavor of
 /// code generator is customized by supplying distinct types for `C`
@@ -184,5 +185,23 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
                 self.types.terminal_loc_type(),
                 self.types.terminal_token_type(),
                 self.types.error_type())
+    }
+
+    /// Returns phantom data type that captures the user-declared type
+    /// parameters in a phantom-data. This helps with ensuring that
+    /// all type parameters are constrained, even if they are not
+    /// used.
+    pub fn phantom_data_type(&self) -> String {
+        format!("::std::marker::PhantomData<({})>",
+                Sep(", ", &self.grammar.non_lifetime_type_parameters()))
+    }
+
+    /// Returns expression that captures the user-declared type
+    /// parameters in a phantom-data. This helps with ensuring that
+    /// all type parameters are constrained, even if they are not
+    /// used.
+    pub fn phantom_data_expr(&self) -> String {
+        format!("::std::marker::PhantomData::<({})>",
+                Sep(", ", &self.grammar.non_lifetime_type_parameters()))
     }
 }

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -4,7 +4,6 @@ use collections::{Map, Set};
 use grammar::repr::*;
 use lr1::core::*;
 use lr1::lookahead::Token;
-use lr1::tls::Lr1Tls;
 use rust::RustWrite;
 use std::io::{self, Write};
 use tls::Tls;
@@ -21,7 +20,6 @@ pub fn compile<'grammar, W: Write>(grammar: &'grammar Grammar,
                                    action_module: &str,
                                    out: &mut RustWrite<W>)
                                    -> io::Result<()> {
-    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let mut table_driven = CodeGenerator::new_table_driven(grammar,
                                                            user_start_symbol,
                                                            start_symbol,

--- a/lalrpop/src/lr1/codegen/test_all.rs
+++ b/lalrpop/src/lr1/codegen/test_all.rs
@@ -4,7 +4,6 @@
 
 use grammar::repr::{Grammar, NonterminalString, TypeParameter};
 use lr1::core::*;
-use lr1::tls::Lr1Tls;
 use rust::RustWrite;
 use std::io::{self, Write};
 use util::Sep;
@@ -17,7 +16,6 @@ pub fn compile<'grammar, W: Write>(grammar: &'grammar Grammar,
                                    states: &[LR1State<'grammar>],
                                    out: &mut RustWrite<W>)
                                    -> io::Result<()> {
-    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
     let mut ascent = CodeGenerator::new_test_all(grammar,
                                                  user_start_symbol,
                                                  start_symbol,

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -1,7 +1,6 @@
 //! Naive LR(1) generation algorithm.
 
 use grammar::repr::*;
-use self::tls::Lr1Tls;
 
 pub mod codegen;
 mod build;
@@ -20,12 +19,11 @@ mod trace;
 
 pub use self::core::{LR1Result, LR1TableConstructionError};
 pub use self::error::report_error;
+pub use self::tls::Lr1Tls;
 
 pub fn build_states<'grammar>(grammar: &'grammar Grammar,
                               start: NonterminalString)
                               -> LR1Result<'grammar> {
-    let _lr1_tls = Lr1Tls::install(grammar.terminals.clone());
-
     if !grammar.algorithm.lalr {
         build::build_lr1_states(grammar, start)
     } else {


### PR DESCRIPTION
In the older code, type parameters that were not constrained by some
argument would fail to be threaded through. We now pass `PhantomData`
arguments and/or specify the type parameters manually so that this all
works out fine.

Fixes #104.