### PR TITLE
Fixes typo in README.md for Configuration object

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ directory), and it will only do so if the `.lalrpop` file has actually
 changed. But you can also use the [`Configuration`][config] struct to
 get more detailed control.
 
-[config]: https://github.com/nikomatsakis/lalrpop/blob/master/lalrpop/src/apimod.rs
+[config]: https://github.com/nikomatsakis/lalrpop/blob/master/lalrpop/src/api/mod.rs
 
 #### Running manually
 


### PR DESCRIPTION
Very minor contribution, however this fixes a 404 in the README.md.