### PR TITLE
fix: Don't accidentally cast a reduce action to usize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,12 @@ TAGS
 Cargo.lock
 lalrpop/src/parser/lrgrammar.rs
 
+doc/calculator/src/calculator6.rs
+doc/whitespace/src/parser.rs
+
 lalrpop-test/src/error.rs
 lalrpop-test/src/error_recovery.rs
+lalrpop-test/src/error_recovery_pull_182.rs
 lalrpop-test/src/expr.rs
 lalrpop-test/src/expr_arena.rs
 lalrpop-test/src/expr_generic.rs

--- a/lalrpop-test/src/error_recovery_pull_182.lalrpop
+++ b/lalrpop-test/src/error_recovery_pull_182.lalrpop
@@ -1,0 +1,29 @@
+
+use util::tok::Tok;
+use lalrpop_util::ErrorRecovery;
+
+grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<(), Tok, ()>>);
+
+extern {
+    enum Tok {
+        "+" => Tok::Plus,
+        "/" => Tok::Div,
+        Num => Tok::Num(<i32>)
+    }
+}
+
+SkipExtraTokens: () = {
+    => (),
+    <!> => errors.push(<>),
+};
+
+Expr: () = {
+    Num => (),
+
+    <lhs: Num> "+" <rhs: Num> => (),
+};
+
+pub Item: ()  = {
+    Expr SkipExtraTokens "/" => (),
+    <!> => errors.push(<>)
+};

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -64,6 +64,7 @@ mod error;
 
 /// Test error recovery
 mod error_recovery;
+mod error_recovery_pull_182;
 
 /// test for inlining expansion issue #55
 mod issue_55;
@@ -359,6 +360,22 @@ fn error_recovery_multiple_extra_tokens() {
         },
         dropped_tokens: vec![((), Tok::Plus, ()), ((), Tok::Plus, ())],
     });
+}
+
+#[test]
+fn error_recovery_dont_panic_on_reduce_normal() {
+    let mut errors = vec![];
+    util::test(|v| error_recovery_pull_182::parse_Item(&mut errors, v), "1+/", ());
+
+    assert_eq!(errors.len(), 1);
+}
+
+#[test]
+fn error_recovery_dont_panic_on_reduce_at_eof() {
+    let mut errors = vec![];
+    util::test(|v| error_recovery_pull_182::parse_Item(&mut errors, v), "1+", ());
+
+    assert_eq!(errors.len(), 1);
 }
 
 #[test]

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -166,7 +166,7 @@ pub fn compile<'grammar, W: Write>(grammar: &'grammar Grammar,
 //         match states.last().cloned() {
 //             Some(state) => {
 //                 error_state = ACTION[(state as usize + 1) * NUM_STATES - 1];
-//                 if error_state != 0  {
+//                 if error_state > 0 {
 //                     break;
 //                 }
 //                 states.pop();
@@ -1065,7 +1065,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             self.prefix,
             self.grammar.terminals.all.len());
 
-        rust!(self.out, "if {}error_state != 0 {} {{", self.prefix, extra_test);
+        rust!(self.out, "if {}error_state > 0 {} {{", self.prefix, extra_test);
         rust!(self.out, "break;");
         rust!(self.out, "}}");
         rust!(self.out, "{}states.pop();", self.prefix);


### PR DESCRIPTION
This caused panics in certain error recovery scenarios as a reduce action represented by a negative number would get casted to `usize` which then caused an index out of bounds panic.

The added tests were extracted and minimized from [gluon's grammar](https://github.com/gluon-lang/gluon/blob/abd06a4f6efa24d5dc4800373f6dfbc066dd661d/parser/src/grammar.lalrpop) with the test case below being a minimal reproduction.

Panicking
```
type Test = a ->
```

Valid expression
```
type Test = a -> a
in 1
```