### PR TITLE
parse table generator is now packing terminal parameters into tuple

### DIFF
--- a/lalrpop-test/src/expr.lalrpop
+++ b/lalrpop-test/src/expr.lalrpop
@@ -11,6 +11,7 @@ extern {
         "*" => Tok::Times,
         "/" => Tok::Div,
         Num => Tok::Num(<i32>),
+        Fraction => Tok::Fraction(<i32>, <i32>),
     }
 }
 

--- a/lalrpop-test/src/expr.lalrpop
+++ b/lalrpop-test/src/expr.lalrpop
@@ -11,7 +11,7 @@ extern {
         "*" => Tok::Times,
         "/" => Tok::Div,
         Num => Tok::Num(<i32>),
-        Fraction => Tok::Fraction(<i32>, <i32>),
+        Fraction => Tok::Fraction(<i32>, <i32>), // Regression test for #179
     }
 }
 

--- a/lalrpop-test/src/expr_lalr.lalrpop
+++ b/lalrpop-test/src/expr_lalr.lalrpop
@@ -12,7 +12,7 @@ extern {
         "*" => Tok::Times,
         "/" => Tok::Div,
         Num => Tok::Num(<i32>),
-        Fraction => Tok::Fraction(<i32>, <i32>),
+        Fraction => Tok::Fraction(<i32>, <i32>), // Regression test for #179
     }
 }
 

--- a/lalrpop-test/src/expr_lalr.lalrpop
+++ b/lalrpop-test/src/expr_lalr.lalrpop
@@ -11,7 +11,8 @@ extern {
         "+" => Tok::Plus,
         "*" => Tok::Times,
         "/" => Tok::Div,
-        Num => Tok::Num(<i32>)
+        Num => Tok::Num(<i32>),
+        Fraction => Tok::Fraction(<i32>, <i32>),
     }
 }
 

--- a/lalrpop-test/src/sub_ascent.lalrpop
+++ b/lalrpop-test/src/sub_ascent.lalrpop
@@ -11,7 +11,7 @@ extern {
         ")" => Tok::RParen,
         "-" => Tok::Minus,
         Num => Tok::Num(<i32>),
-        Fraction => Tok::Fraction(<i32>, <i32>),
+        Fraction => Tok::Fraction(<i32>, <i32>), // Regression test for #179
     }
 }
 

--- a/lalrpop-test/src/sub_ascent.lalrpop
+++ b/lalrpop-test/src/sub_ascent.lalrpop
@@ -11,6 +11,7 @@ extern {
         ")" => Tok::RParen,
         "-" => Tok::Minus,
         Num => Tok::Num(<i32>),
+        Fraction => Tok::Fraction(<i32>, <i32>),
     }
 }
 

--- a/lalrpop-test/src/util/tok.rs
+++ b/lalrpop-test/src/util/tok.rs
@@ -13,6 +13,7 @@ pub enum Tok {
     Times,
     Div,
     Comma,
+    Fraction(i32, i32),
 }
 
 // simplest and stupidest possible tokenizer
@@ -48,13 +49,14 @@ pub fn tokenize(s: &str) -> Vec<(usize, Tok, usize)> {
     }
 
     tokens.into_iter()
-          .enumerate()
-          .map(|(i, tok)| (i*2, tok, i*2+1))
-          .collect()
+        .enumerate()
+        .map(|(i, tok)| (i * 2, tok, i * 2 + 1))
+        .collect()
 }
 
-fn take_while<C,F>(c0: char, chars: &mut C, f: F) -> (String, Option<char>)
-    where C: Iterator<Item=char>, F: Fn(char) -> bool
+fn take_while<C, F>(c0: char, chars: &mut C, f: F) -> (String, Option<char>)
+    where C: Iterator<Item = char>,
+          F: Fn(char) -> bool
 {
     let mut buf = String::new();
 

--- a/lalrpop-test/src/util/tok.rs
+++ b/lalrpop-test/src/util/tok.rs
@@ -13,7 +13,7 @@ pub enum Tok {
     Times,
     Div,
     Comma,
-    Fraction(i32, i32),
+    Fraction(i32, i32), // Not produced by tokenizer, used only in regression tests for #179
 }
 
 // simplest and stupidest possible tokenizer

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -734,7 +734,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
 
             let variant_name = self.variant_name_for_symbol(Symbol::Terminal(terminal));
             rust!(self.out,
-                  "{} => {}Symbol::{}({}),",
+                  "{} => {}Symbol::{}(({})),",
                   pattern,
                   self.prefix,
                   variant_name,


### PR DESCRIPTION
Fix for #179.