### PR TITLE
Report generation

### DIFF
--- a/lalrpop-intern/src/lib.rs
+++ b/lalrpop-intern/src/lib.rs
@@ -62,6 +62,10 @@ impl InternedString {
     fn index(&self) -> usize {
         self.index as usize
     }
+
+    pub fn len(&self) -> usize {
+        read(|interner| interner.data(*self).len())
+    }
 }
 
 impl Debug for InternedString {

--- a/lalrpop/src/api/mod.rs
+++ b/lalrpop/src/api/mod.rs
@@ -83,6 +83,12 @@ impl Configuration {
         self
     }
 
+    /// If true, emit report file about generated code.
+    pub fn emit_report(&mut self, val: bool) -> &mut Configuration {
+        self.session.emit_report = val;
+        self
+    }
+
     /// Minimal logs: only for errors that halt progress.
     pub fn log_quiet(&mut self) -> &mut Configuration {
         self.session.log.set_level(Level::Taciturn);

--- a/lalrpop/src/grammar/parse_tree.rs
+++ b/lalrpop/src/grammar/parse_tree.rs
@@ -359,6 +359,14 @@ impl TerminalString {
             _ => None
         }
     }
+
+    pub fn display_len(&self) -> usize {
+        match *self {
+            TerminalString::Literal(x) => x.display_len(),
+            TerminalString::Bare(x) => x.len(),
+            TerminalString::Error => "error".len()
+        }
+    }
 }
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -377,10 +385,24 @@ impl TerminalLiteral {
             TerminalLiteral::Regex(_) => 0,
         }
     }
+
+    pub fn display_len(&self) -> usize {
+        match *self {
+            TerminalLiteral::Quoted(x) => x.len(),
+            TerminalLiteral::Regex(x) => x.len() + "####r".len(),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NonterminalString(pub InternedString);
+
+impl NonterminalString
+{
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
 
 impl Into<Box<Content>> for NonterminalString {
     fn into(self) -> Box<Content> {

--- a/lalrpop/src/lr1/core/mod.rs
+++ b/lalrpop/src/lr1/core/mod.rs
@@ -167,8 +167,8 @@ pub struct TableConstructionError<'grammar, L: Lookahead> {
 
 pub type LR0TableConstructionError<'grammar> = TableConstructionError<'grammar, Nil>;
 pub type LR1TableConstructionError<'grammar> = TableConstructionError<'grammar, TokenSet>;
-pub type LR1Result<'grammar> = Result<Vec<LR1State<'grammar>>,
-                                      LR1TableConstructionError<'grammar>>;
+pub type LRResult<'grammar, L> = Result<Vec<State<'grammar, L>>, TableConstructionError<'grammar, L>>;
+pub type LR1Result<'grammar> = LRResult<'grammar, TokenSet>;
 
 impl<'grammar, L: Lookahead> Debug for Item<'grammar, L> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
@@ -200,6 +200,12 @@ impl Debug for Token {
 impl Debug for StateIndex {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(fmt, "S{}", self.0)
+    }
+}
+
+impl Display for StateIndex {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        write!(fmt, "{}", self.0)
     }
 }
 

--- a/lalrpop/src/lr1/mod.rs
+++ b/lalrpop/src/lr1/mod.rs
@@ -14,6 +14,8 @@ mod lookahead;
 mod state_graph;
 mod tls;
 mod trace;
+mod report;
+use std::io::{self, Write};
 
 #[cfg(test)] mod interpret;
 
@@ -31,3 +33,10 @@ pub fn build_states<'grammar>(grammar: &'grammar Grammar,
     }
 }
 
+pub fn generate_report<'grammar, W : Write + 'grammar>
+    ( out:          &'grammar mut W
+    , lr1result:    &LR1Result<'grammar>
+    ) -> io::Result<()>
+{
+    report::generate_report(out, lr1result)
+}

--- a/lalrpop/src/lr1/report/mod.rs
+++ b/lalrpop/src/lr1/report/mod.rs
@@ -1,0 +1,337 @@
+use grammar::repr::*;
+use lr1::core::*;
+use std::io::{self, Write};
+use std::cmp::max;
+use collections::*;
+
+use super::lookahead::*;
+
+pub fn generate_report<'grammar, W : Write + 'grammar>
+    ( out:                  &'grammar mut W
+    , lr1result:            &LR1Result<'grammar>
+    ) -> io::Result<()>
+{
+    let mut generator = ReportGenerator::new(out);
+    generator.report_lr_table_construction(lr1result)
+}
+
+static INDENT_STRING : &'static str = "    ";
+
+struct ReportGenerator<'report, W>
+    where W: Write + 'report
+{
+    pub out: &'report mut W,
+}
+
+type ConflictStateMap<'report, 'grammar,  L> = Map<StateIndex, Vec<&'report Conflict<'grammar, L>>>;
+
+impl <'report, W> ReportGenerator<'report, W>
+    where W: Write + 'report
+{
+    pub fn new
+        ( out:                  &'report mut W
+        ) -> Self 
+    {
+        ReportGenerator
+        { out:                  out
+        }
+    }
+
+    pub fn report_lr_table_construction<'grammar : 'report, L>
+        ( &mut self
+        , lr1result : &'report LRResult<'grammar, L>
+        ) -> io::Result<()>
+        where L : Lookahead + LookaheadPrinter<W>
+    {
+        try!(self.write_header());
+        try!(self.write_section_header("Summary"));
+        try!(writeln!(self.out, ""));
+        match lr1result {
+            &Ok(ref states) => {
+                try!(writeln!(self.out, "Constructed {} states", states.len()));
+                try!(self.report_states(&states, &Map::new()));
+            }
+            &Err(ref table_construction_error) => {
+                try!(writeln!(self.out, "Failure"));
+                try!(writeln!(self.out, "Constructed {} states", table_construction_error.states.len()));
+                try!(writeln!(self.out, "Has {} conflicts", table_construction_error.conflicts.len()));
+                let (sr, rr, conflict_map) = self.process_conflicts(&table_construction_error.conflicts);
+                if (sr > 0) {
+                    try!(writeln!(self.out, "{}shift/reduce:  {}", INDENT_STRING, sr));
+                }
+                if (rr > 0) {
+                    try!(writeln!(self.out, "{}reduce/reduce: {}", INDENT_STRING, rr));
+                }
+                try!(write!(self.out, "States with conflicts: "));
+                for state in conflict_map.keys() {
+                    try!(write!(self.out, " {}", state));
+                }
+                try!(writeln!(self.out, ""));
+                try!(self.report_states(&table_construction_error.states, &conflict_map));
+            }
+        };
+        Ok(())
+    }
+
+    fn process_conflicts<'grammar, L>(&mut self, conflicts : &'report Vec<Conflict<'grammar, L>>)
+        -> (usize, usize, ConflictStateMap<'report, 'grammar, L>) 
+        where L : Lookahead
+    {
+        let mut sr : usize = 0;
+        let mut rr : usize = 0;
+        let mut conflict_map  = Map::new();
+        for conflict in conflicts.iter() {
+            match conflict.action {
+                Action::Shift(_, _) => sr = sr + 1,
+                Action::Reduce(_)   => rr = rr + 1,
+            }
+            conflict_map.entry(conflict.state).or_insert(vec![]).push(conflict);
+        }
+        (sr, rr, conflict_map)
+    }
+
+    fn report_states<'grammar, L>(&mut self, states: &Vec<State<'grammar, L>>, conflict_map: &ConflictStateMap<'report, 'grammar, L>) -> io::Result<()> 
+        where L : Lookahead + LookaheadPrinter<W>
+    {
+        try!(self.write_section_header("State Table"));
+        for ref state in states {
+            try!(writeln!(self.out, ""));
+            try!(self.report_state(&state, conflict_map.get(&state.index)));
+        }
+        Ok(())
+    }
+
+    fn report_state<'grammar, L>(&mut self, state : &State<'grammar, L>, conflicts_opt: Option<&Vec<&'report Conflict<'grammar, L>>>) -> io::Result<()>
+        where L : Lookahead + LookaheadPrinter<W>
+    {
+        try!(writeln!(self.out, "State {} {{", state.index));
+        try!(self.write_items(&state.items));
+        if (state.reductions.len() > 0) {
+            try!(writeln!(self.out, ""));
+            try!(self.write_reductions(&state.reductions));
+        }
+
+        let max_width = get_width_for_gotos(state);
+
+        if (!state.shifts.len() > 0) {
+            try!(writeln!(self.out, ""));
+            try!(self.write_shifts(&state.shifts, max_width));
+        }
+
+        if (!state.gotos.len() > 0) {
+            try!(writeln!(self.out, ""));
+            try!(self.write_gotos(&state.gotos, max_width));
+        }
+
+        if let Some(conflicts) = conflicts_opt {
+            for conflict in conflicts.iter() {
+                try!(self.write_conflict(conflict));
+            }
+        }
+
+        try!(writeln!(self.out, "}}"));
+        Ok(())
+    }
+
+    fn write_conflict<'grammar, L>(&mut self, conflict: &Conflict<'grammar, L>) -> io::Result<()> 
+        where L : Lookahead + LookaheadPrinter<W>
+    {
+        try!(writeln!(self.out, ""));
+        match conflict.action {
+            Action::Shift(terminal, state) => {
+                let max_width = max(terminal.display_len(), conflict.production.nonterminal.len());
+                try!(writeln!(self.out, "{}shift/reduce conflict", INDENT_STRING));
+                try!(write!(self.out, "{}{}reduction ", INDENT_STRING, INDENT_STRING));
+                try!(self.write_production(conflict.production, max_width));
+                let sterminal = format!("{}", terminal);
+                try!(writeln!(self.out, "{}{}shift     {:width$}    shift and goto {}", INDENT_STRING, INDENT_STRING, sterminal, state, width = max_width));
+            }
+            Action::Reduce(other_production) => {
+                let max_width = max(other_production.nonterminal.len(), conflict.production.nonterminal.len());
+                try!(writeln!(self.out, "{}reduce/reduce conflict", INDENT_STRING));
+                try!(write!(self.out, "{}{}reduction ", INDENT_STRING, INDENT_STRING));
+                try!(self.write_production(conflict.production, max_width));
+                try!(write!(self.out, "{}{}reduction ", INDENT_STRING, INDENT_STRING));
+                try!(self.write_production(other_production, max_width));
+            }
+        }
+        try!(self.write_lookahead(&conflict.lookahead));
+        Ok(())
+    }
+
+    fn write_items<'grammar, L>(&mut self, items: &Items<'grammar, L>) -> io::Result<()>
+        where L : Lookahead + LookaheadPrinter<W>
+    {
+        let max_width = get_max_length(items.vec.iter().map(|item| &item.production.nonterminal));
+
+        for item in items.vec.iter() {
+            try!(writeln!(self.out, ""));
+            try!(self.write_item(item, max_width));
+        }
+        Ok(())
+    }
+
+    fn write_item<'grammar, L>(&mut self, item: &Item<'grammar, L>, max_width : usize) -> io::Result<()> 
+        where L : Lookahead + LookaheadPrinter<W>
+    {
+        try!(write!(self.out, "{}", INDENT_STRING));
+        let s = format!("{}", item.production.nonterminal); // stringize it first to allow handle :width by Display for string
+        try!(write!(self.out, "{:width$} ->", s, width=max_width));
+        for i in 0..item.index {
+            try!(write!(self.out, " {}", item.production.symbols[i]));
+        }
+        try!(write!(self.out, " ."));
+        for i in item.index..item.production.symbols.len() {
+            try!(write!(self.out, " {}", item.production.symbols[i]));
+        }
+        try!(writeln!(self.out, ""));
+        try!(self.write_lookahead(&item.lookahead));
+        Ok(())
+    }
+
+    fn write_shifts(&mut self, shifts: &Map<TerminalString, StateIndex>, max_width: usize) -> io::Result<()>
+    {
+        for entry in shifts {
+            try!(write!(self.out, "{}", INDENT_STRING));
+            let s = format!("{}", entry.0); // stringize it first to allow handle :width by Display for string
+            try!(writeln!(self.out, "{:width$} shift and goto {}", s, entry.1, width = max_width));
+        }
+        Ok(())
+    }
+
+    fn write_reductions<'grammar, L>(&mut self, reductions: &Vec<(L, &'grammar Production)>) -> io::Result<()>
+        where L : Lookahead + LookaheadPrinter<W>
+    {
+        let max_width = get_max_length(reductions.into_iter().map(|p| &p.1.nonterminal));
+        for reduction in reductions.iter() {
+            try!(writeln!(self.out, ""));
+            try!(self.write_reduction(reduction, max_width));
+        }
+        Ok(())
+    }
+
+    fn write_production<'grammar>(&mut self, production : &'grammar Production, max_width : usize) -> io::Result<()>
+    {
+        try!(write!(self.out, "{:width$} ->", production.nonterminal, width = max_width));
+        for symbol in production.symbols.iter() {
+            try!(write!(self.out, " {}", symbol));
+        }
+        try!(writeln!(self.out, ""));
+        Ok(())
+    }
+
+    fn write_reduction<'grammar, L>(&mut self, reduction: &(L, &'grammar Production), max_width: usize) -> io::Result<()>
+        where L : Lookahead + LookaheadPrinter<W>
+    {
+        let ref production = reduction.1;
+        try!(write!(self.out, "{}reduction ", INDENT_STRING));
+        try!(self.write_production(production, max_width));
+        try!(self.write_lookahead(&reduction.0));
+        Ok(())
+    }
+
+    fn write_lookahead<L>(&mut self, lookahead : &L) -> io::Result<()> 
+        where L : Lookahead + LookaheadPrinter<W>
+    {
+        if (lookahead.has_anything_to_print()) {
+            try!(write!(self.out, "{}{}lookahead", INDENT_STRING, INDENT_STRING));
+            try!(lookahead.print(self.out));
+            try!(writeln!(self.out, ""));
+        }
+        Ok(())
+    }
+
+    fn write_gotos(&mut self, gotos: &Map<NonterminalString, StateIndex>, max_width : usize) -> io::Result<()>
+    {
+        for entry in gotos {
+            try!(write!(self.out, "{}", INDENT_STRING));
+            let s = format!("{}", entry.0); // stringize it first to allow handle :width by Display for string
+            try!(writeln!(self.out, "{:width$} goto {}", s, entry.1, width = max_width));
+        }
+        Ok(())
+    }
+
+    fn write_section_header(&mut self, title: &str) -> io::Result<()>
+    {
+        try!(writeln!(self.out, "\n{}", title));
+        try!(writeln!(self.out, "----------------------------------------"));
+        Ok(())
+    }
+
+    fn write_header(&mut self) -> io::Result<()>
+    {
+        try!(writeln!(self.out, "Lalrpop Report File"));
+        try!(writeln!(self.out, "========================================"));
+        Ok(())
+    }
+}
+
+// helpers
+
+trait LookaheadPrinter<W>
+    where W: Write
+{
+    fn print<'report, 'grammar>(self : &Self, out: &'report mut W) -> io::Result<()> ;
+
+    fn has_anything_to_print<'report>(self : &Self) -> bool;
+}
+
+impl<W> LookaheadPrinter<W> for Nil 
+    where W: Write
+{
+    fn print<'report, 'grammar>(self : &Self, _: &'report mut W) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn has_anything_to_print<'report>(self : &Self) -> bool {
+        false
+    }
+}
+
+impl<W> LookaheadPrinter<W> for TokenSet
+    where W: Write
+{
+    fn print<'report, 'grammar>(self : &Self, out: &'report mut W) -> io::Result<()> {
+        for i in self.iter() {
+            try!(write!(out, " {}", i))
+        }
+        Ok(())
+    }
+
+    fn has_anything_to_print<'report>(self : &Self) -> bool {
+        self.len() > 0
+    }
+}
+
+trait HasDisplayLen
+{
+    fn display_len(&self) -> usize;
+}
+
+impl<'a> HasDisplayLen for &'a TerminalString {
+    fn display_len(&self) -> usize {
+        TerminalString::display_len(self)
+    }
+}
+
+impl<'a> HasDisplayLen for &'a NonterminalString {
+    fn display_len(&self) -> usize {
+        self.len()
+    }
+}
+
+fn get_max_length<I>(m : I) -> usize 
+    where I : Iterator, I::Item : HasDisplayLen
+{
+    m
+        .map(|k| k.display_len())
+        .fold(0, |acc, x| max(acc,x))
+}
+
+fn get_width_for_gotos<'grammar, L>(state : &State<'grammar, L>) -> usize
+    where L : Lookahead
+{
+    let shifts_max_width = get_max_length(state.shifts.keys());
+    let gotos_max_width  = get_max_length(state.gotos.keys());
+    max(shifts_max_width, gotos_max_width)
+}

--- a/lalrpop/src/lr1/report/mod.rs
+++ b/lalrpop/src/lr1/report/mod.rs
@@ -6,16 +6,14 @@ use collections::*;
 
 use super::lookahead::*;
 
-pub fn generate_report<'grammar, W : Write + 'grammar>
-    ( out:                  &'grammar mut W
-    , lr1result:            &LR1Result<'grammar>
-    ) -> io::Result<()>
-{
+pub fn generate_report<'grammar, W: Write + 'grammar>(out: &'grammar mut W,
+                                                      lr1result: &LR1Result<'grammar>)
+                                                      -> io::Result<()> {
     let mut generator = ReportGenerator::new(out);
     generator.report_lr_table_construction(lr1result)
 }
 
-static INDENT_STRING : &'static str = "    ";
+static INDENT_STRING: &'static str = "    ";
 
 struct ReportGenerator<'report, W>
     where W: Write + 'report
@@ -23,18 +21,13 @@ struct ReportGenerator<'report, W>
     pub out: &'report mut W,
 }
 
-type ConflictStateMap<'report, 'grammar,  L> = Map<StateIndex, Vec<&'report Conflict<'grammar, L>>>;
+type ConflictStateMap<'report, 'grammar, L> = Map<StateIndex, Vec<&'report Conflict<'grammar, L>>>;
 
-impl <'report, W> ReportGenerator<'report, W>
+impl<'report, W> ReportGenerator<'report, W>
     where W: Write + 'report
 {
-    pub fn new
-        ( out:                  &'report mut W
-        ) -> Self 
-    {
-        ReportGenerator
-        { out:                  out
-        }
+    pub fn new(out: &'report mut W) -> Self {
+        ReportGenerator { out: out }
     }
 
     pub fn report_lr_table_construction<'grammar : 'report, L>
@@ -53,9 +46,14 @@ impl <'report, W> ReportGenerator<'report, W>
             }
             &Err(ref table_construction_error) => {
                 try!(writeln!(self.out, "Failure"));
-                try!(writeln!(self.out, "Constructed {} states", table_construction_error.states.len()));
-                try!(writeln!(self.out, "Has {} conflicts", table_construction_error.conflicts.len()));
-                let (sr, rr, conflict_map) = self.process_conflicts(&table_construction_error.conflicts);
+                try!(writeln!(self.out,
+                              "Constructed {} states",
+                              table_construction_error.states.len()));
+                try!(writeln!(self.out,
+                              "Has {} conflicts",
+                              table_construction_error.conflicts.len()));
+                let (sr, rr, conflict_map) =
+                    self.process_conflicts(&table_construction_error.conflicts);
                 if (sr > 0) {
                     try!(writeln!(self.out, "{}shift/reduce:  {}", INDENT_STRING, sr));
                 }
@@ -73,25 +71,32 @@ impl <'report, W> ReportGenerator<'report, W>
         Ok(())
     }
 
-    fn process_conflicts<'grammar, L>(&mut self, conflicts : &'report Vec<Conflict<'grammar, L>>)
-        -> (usize, usize, ConflictStateMap<'report, 'grammar, L>) 
-        where L : Lookahead
+    fn process_conflicts<'grammar, L>(&mut self,
+                                      conflicts: &'report Vec<Conflict<'grammar, L>>)
+                                      -> (usize, usize, ConflictStateMap<'report, 'grammar, L>)
+        where L: Lookahead
     {
-        let mut sr : usize = 0;
-        let mut rr : usize = 0;
-        let mut conflict_map  = Map::new();
+        let mut sr: usize = 0;
+        let mut rr: usize = 0;
+        let mut conflict_map = Map::new();
         for conflict in conflicts.iter() {
             match conflict.action {
                 Action::Shift(_, _) => sr = sr + 1,
-                Action::Reduce(_)   => rr = rr + 1,
+                Action::Reduce(_) => rr = rr + 1,
             }
-            conflict_map.entry(conflict.state).or_insert(vec![]).push(conflict);
+            conflict_map
+                .entry(conflict.state)
+                .or_insert(vec![])
+                .push(conflict);
         }
         (sr, rr, conflict_map)
     }
 
-    fn report_states<'grammar, L>(&mut self, states: &Vec<State<'grammar, L>>, conflict_map: &ConflictStateMap<'report, 'grammar, L>) -> io::Result<()> 
-        where L : Lookahead + LookaheadPrinter<W>
+    fn report_states<'grammar, L>(&mut self,
+                                  states: &Vec<State<'grammar, L>>,
+                                  conflict_map: &ConflictStateMap<'report, 'grammar, L>)
+                                  -> io::Result<()>
+        where L: Lookahead + LookaheadPrinter<W>
     {
         try!(self.write_section_header("State Table"));
         for ref state in states {
@@ -101,8 +106,11 @@ impl <'report, W> ReportGenerator<'report, W>
         Ok(())
     }
 
-    fn report_state<'grammar, L>(&mut self, state : &State<'grammar, L>, conflicts_opt: Option<&Vec<&'report Conflict<'grammar, L>>>) -> io::Result<()>
-        where L : Lookahead + LookaheadPrinter<W>
+    fn report_state<'grammar, L>(&mut self,
+                                 state: &State<'grammar, L>,
+                                 conflicts_opt: Option<&Vec<&'report Conflict<'grammar, L>>>)
+                                 -> io::Result<()>
+        where L: Lookahead + LookaheadPrinter<W>
     {
         try!(writeln!(self.out, "State {} {{", state.index));
         try!(self.write_items(&state.items));
@@ -133,21 +141,29 @@ impl <'report, W> ReportGenerator<'report, W>
         Ok(())
     }
 
-    fn write_conflict<'grammar, L>(&mut self, conflict: &Conflict<'grammar, L>) -> io::Result<()> 
-        where L : Lookahead + LookaheadPrinter<W>
+    fn write_conflict<'grammar, L>(&mut self, conflict: &Conflict<'grammar, L>) -> io::Result<()>
+        where L: Lookahead + LookaheadPrinter<W>
     {
         try!(writeln!(self.out, ""));
         match conflict.action {
             Action::Shift(terminal, state) => {
-                let max_width = max(terminal.display_len(), conflict.production.nonterminal.len());
+                let max_width = max(terminal.display_len(),
+                                    conflict.production.nonterminal.len());
                 try!(writeln!(self.out, "{}shift/reduce conflict", INDENT_STRING));
                 try!(write!(self.out, "{}{}reduction ", INDENT_STRING, INDENT_STRING));
                 try!(self.write_production(conflict.production, max_width));
                 let sterminal = format!("{}", terminal);
-                try!(writeln!(self.out, "{}{}shift     {:width$}    shift and goto {}", INDENT_STRING, INDENT_STRING, sterminal, state, width = max_width));
+                try!(writeln!(self.out,
+                              "{}{}shift     {:width$}    shift and goto {}",
+                              INDENT_STRING,
+                              INDENT_STRING,
+                              sterminal,
+                              state,
+                              width = max_width));
             }
             Action::Reduce(other_production) => {
-                let max_width = max(other_production.nonterminal.len(), conflict.production.nonterminal.len());
+                let max_width = max(other_production.nonterminal.len(),
+                                    conflict.production.nonterminal.len());
                 try!(writeln!(self.out, "{}reduce/reduce conflict", INDENT_STRING));
                 try!(write!(self.out, "{}{}reduction ", INDENT_STRING, INDENT_STRING));
                 try!(self.write_production(conflict.production, max_width));
@@ -160,9 +176,12 @@ impl <'report, W> ReportGenerator<'report, W>
     }
 
     fn write_items<'grammar, L>(&mut self, items: &Items<'grammar, L>) -> io::Result<()>
-        where L : Lookahead + LookaheadPrinter<W>
+        where L: Lookahead + LookaheadPrinter<W>
     {
-        let max_width = get_max_length(items.vec.iter().map(|item| &item.production.nonterminal));
+        let max_width = get_max_length(items
+                                           .vec
+                                           .iter()
+                                           .map(|item| &item.production.nonterminal));
 
         for item in items.vec.iter() {
             try!(writeln!(self.out, ""));
@@ -171,12 +190,16 @@ impl <'report, W> ReportGenerator<'report, W>
         Ok(())
     }
 
-    fn write_item<'grammar, L>(&mut self, item: &Item<'grammar, L>, max_width : usize) -> io::Result<()> 
-        where L : Lookahead + LookaheadPrinter<W>
+    fn write_item<'grammar, L>(&mut self,
+                               item: &Item<'grammar, L>,
+                               max_width: usize)
+                               -> io::Result<()>
+        where L: Lookahead + LookaheadPrinter<W>
     {
         try!(write!(self.out, "{}", INDENT_STRING));
-        let s = format!("{}", item.production.nonterminal); // stringize it first to allow handle :width by Display for string
-        try!(write!(self.out, "{:width$} ->", s, width=max_width));
+        // stringize it first to allow handle :width by Display for string
+        let s = format!("{}", item.production.nonterminal);
+        try!(write!(self.out, "{:width$} ->", s, width = max_width));
         for i in 0..item.index {
             try!(write!(self.out, " {}", item.production.symbols[i]));
         }
@@ -189,18 +212,27 @@ impl <'report, W> ReportGenerator<'report, W>
         Ok(())
     }
 
-    fn write_shifts(&mut self, shifts: &Map<TerminalString, StateIndex>, max_width: usize) -> io::Result<()>
-    {
+    fn write_shifts(&mut self,
+                    shifts: &Map<TerminalString, StateIndex>,
+                    max_width: usize)
+                    -> io::Result<()> {
         for entry in shifts {
             try!(write!(self.out, "{}", INDENT_STRING));
-            let s = format!("{}", entry.0); // stringize it first to allow handle :width by Display for string
-            try!(writeln!(self.out, "{:width$} shift and goto {}", s, entry.1, width = max_width));
+            // stringize it first to allow handle :width by Display for string
+            let s = format!("{}", entry.0);
+            try!(writeln!(self.out,
+                          "{:width$} shift and goto {}",
+                          s,
+                          entry.1,
+                          width = max_width));
         }
         Ok(())
     }
 
-    fn write_reductions<'grammar, L>(&mut self, reductions: &Vec<(L, &'grammar Production)>) -> io::Result<()>
-        where L : Lookahead + LookaheadPrinter<W>
+    fn write_reductions<'grammar, L>(&mut self,
+                                     reductions: &Vec<(L, &'grammar Production)>)
+                                     -> io::Result<()>
+        where L: Lookahead + LookaheadPrinter<W>
     {
         let max_width = get_max_length(reductions.into_iter().map(|p| &p.1.nonterminal));
         for reduction in reductions.iter() {
@@ -210,9 +242,14 @@ impl <'report, W> ReportGenerator<'report, W>
         Ok(())
     }
 
-    fn write_production<'grammar>(&mut self, production : &'grammar Production, max_width : usize) -> io::Result<()>
-    {
-        try!(write!(self.out, "{:width$} ->", production.nonterminal, width = max_width));
+    fn write_production<'grammar>(&mut self,
+                                  production: &'grammar Production,
+                                  max_width: usize)
+                                  -> io::Result<()> {
+        try!(write!(self.out,
+                    "{:width$} ->",
+                    production.nonterminal,
+                    width = max_width));
         for symbol in production.symbols.iter() {
             try!(write!(self.out, " {}", symbol));
         }
@@ -220,8 +257,11 @@ impl <'report, W> ReportGenerator<'report, W>
         Ok(())
     }
 
-    fn write_reduction<'grammar, L>(&mut self, reduction: &(L, &'grammar Production), max_width: usize) -> io::Result<()>
-        where L : Lookahead + LookaheadPrinter<W>
+    fn write_reduction<'grammar, L>(&mut self,
+                                    reduction: &(L, &'grammar Production),
+                                    max_width: usize)
+                                    -> io::Result<()>
+        where L: Lookahead + LookaheadPrinter<W>
     {
         let ref production = reduction.1;
         try!(write!(self.out, "{}reduction ", INDENT_STRING));
@@ -230,8 +270,8 @@ impl <'report, W> ReportGenerator<'report, W>
         Ok(())
     }
 
-    fn write_lookahead<L>(&mut self, lookahead : &L) -> io::Result<()> 
-        where L : Lookahead + LookaheadPrinter<W>
+    fn write_lookahead<L>(&mut self, lookahead: &L) -> io::Result<()>
+        where L: Lookahead + LookaheadPrinter<W>
     {
         if (lookahead.has_anything_to_print()) {
             try!(write!(self.out, "{}{}lookahead", INDENT_STRING, INDENT_STRING));
@@ -241,25 +281,26 @@ impl <'report, W> ReportGenerator<'report, W>
         Ok(())
     }
 
-    fn write_gotos(&mut self, gotos: &Map<NonterminalString, StateIndex>, max_width : usize) -> io::Result<()>
-    {
+    fn write_gotos(&mut self,
+                   gotos: &Map<NonterminalString, StateIndex>,
+                   max_width: usize)
+                   -> io::Result<()> {
         for entry in gotos {
             try!(write!(self.out, "{}", INDENT_STRING));
-            let s = format!("{}", entry.0); // stringize it first to allow handle :width by Display for string
+            // stringize it first to allow handle :width by Display for string
+            let s = format!("{}", entry.0);
             try!(writeln!(self.out, "{:width$} goto {}", s, entry.1, width = max_width));
         }
         Ok(())
     }
 
-    fn write_section_header(&mut self, title: &str) -> io::Result<()>
-    {
+    fn write_section_header(&mut self, title: &str) -> io::Result<()> {
         try!(writeln!(self.out, "\n{}", title));
         try!(writeln!(self.out, "----------------------------------------"));
         Ok(())
     }
 
-    fn write_header(&mut self) -> io::Result<()>
-    {
+    fn write_header(&mut self) -> io::Result<()> {
         try!(writeln!(self.out, "Lalrpop Report File"));
         try!(writeln!(self.out, "========================================"));
         Ok(())
@@ -271,19 +312,19 @@ impl <'report, W> ReportGenerator<'report, W>
 trait LookaheadPrinter<W>
     where W: Write
 {
-    fn print<'report, 'grammar>(self : &Self, out: &'report mut W) -> io::Result<()> ;
+    fn print<'report, 'grammar>(self: &Self, out: &'report mut W) -> io::Result<()>;
 
-    fn has_anything_to_print<'report>(self : &Self) -> bool;
+    fn has_anything_to_print<'report>(self: &Self) -> bool;
 }
 
-impl<W> LookaheadPrinter<W> for Nil 
+impl<W> LookaheadPrinter<W> for Nil
     where W: Write
 {
-    fn print<'report, 'grammar>(self : &Self, _: &'report mut W) -> io::Result<()> {
+    fn print<'report, 'grammar>(self: &Self, _: &'report mut W) -> io::Result<()> {
         Ok(())
     }
 
-    fn has_anything_to_print<'report>(self : &Self) -> bool {
+    fn has_anything_to_print<'report>(self: &Self) -> bool {
         false
     }
 }
@@ -291,20 +332,19 @@ impl<W> LookaheadPrinter<W> for Nil
 impl<W> LookaheadPrinter<W> for TokenSet
     where W: Write
 {
-    fn print<'report, 'grammar>(self : &Self, out: &'report mut W) -> io::Result<()> {
+    fn print<'report, 'grammar>(self: &Self, out: &'report mut W) -> io::Result<()> {
         for i in self.iter() {
             try!(write!(out, " {}", i))
         }
         Ok(())
     }
 
-    fn has_anything_to_print<'report>(self : &Self) -> bool {
+    fn has_anything_to_print<'report>(self: &Self) -> bool {
         self.len() > 0
     }
 }
 
-trait HasDisplayLen
-{
+trait HasDisplayLen {
     fn display_len(&self) -> usize;
 }
 
@@ -320,18 +360,17 @@ impl<'a> HasDisplayLen for &'a NonterminalString {
     }
 }
 
-fn get_max_length<I>(m : I) -> usize 
-    where I : Iterator, I::Item : HasDisplayLen
+fn get_max_length<I>(m: I) -> usize
+    where I: Iterator,
+          I::Item: HasDisplayLen
 {
-    m
-        .map(|k| k.display_len())
-        .fold(0, |acc, x| max(acc,x))
+    m.map(|k| k.display_len()).fold(0, |acc, x| max(acc, x))
 }
 
-fn get_width_for_gotos<'grammar, L>(state : &State<'grammar, L>) -> usize
-    where L : Lookahead
+fn get_width_for_gotos<'grammar, L>(state: &State<'grammar, L>) -> usize
+    where L: Lookahead
 {
     let shifts_max_width = get_max_length(state.shifts.keys());
-    let gotos_max_width  = get_max_length(state.gotos.keys());
+    let gotos_max_width = get_max_length(state.gotos.keys());
     max(shifts_max_width, gotos_max_width)
 }

--- a/lalrpop/src/main.rs
+++ b/lalrpop/src/main.rs
@@ -41,6 +41,10 @@ fn main1() -> io::Result<()> {
         config.emit_comments(true);
     }
 
+    if args.flag_report {
+        config.emit_report(true);
+    }
+
     if args.arg_inputs.len() == 0 {
         try!(writeln!(stderr, "Error: no input files specified! Try --help for help."));
         process::exit(1);
@@ -70,6 +74,7 @@ Options:
     -f, --force          Force execution, even if the .lalrpop file is older than the .rs file.
     -c, --color          Force colorful output, even if this is not a TTY.
     --comments           Enable comments in the generated code.
+    --report             Generate report files.
 ";
 
 #[derive(Debug, RustcDecodable)]
@@ -79,6 +84,7 @@ struct Args {
     flag_force: bool,
     flag_color: bool,
     flag_comments: bool,
+    flag_report: bool
 }
 
 #[derive(Debug, RustcDecodable)]

--- a/lalrpop/src/session.rs
+++ b/lalrpop/src/session.rs
@@ -40,6 +40,9 @@ pub struct Session {
     /// forth.
     pub emit_comments: bool,
 
+    /// Emit report file about generated code
+    pub emit_report: bool,
+
     pub color_config: ColorConfig,
 
     /// Stop after you find `max_errors` errors. If this value is 0,
@@ -86,6 +89,7 @@ impl Session {
             out_dir: None,
             force_build: false,
             emit_comments: false,
+            emit_report: false,
             color_config: ColorConfig::default(),
             max_errors: 1,
             heading: style::FG_WHITE.with(style::BOLD),
@@ -109,6 +113,7 @@ impl Session {
             out_dir: None,
             force_build: false,
             emit_comments: false,
+            emit_report: false,
             color_config: ColorConfig::IfTty,
             max_errors: 1,
             heading: Style::new(),


### PR DESCRIPTION
Currently lalrpop is able to produce very nice high-level errors. They are very useful especially when someone is interested in assistance with resolving conflicts. I believe that I am not only one user who would prefer to have also a brief summary of produced automaton and encountered conflicts. After many years of using bison and menhir I am used to have such summary and solve conflicts using mainly such brief report.

In future we could include a high-level description of conflicts in report file as additional section.

Usage
---------

If lalrpop is executed with `--report` option, then report will be generated for each input file. The report is written in file with `.report` extension in same directory where `.rs` file has been generated.

Example
------------

https://pastebin.com/raw/whUKg7My

Report has been generated for `calculator6.lalrpop` where `Tier` macro has been modified to produce shift/reduce conflicts. 

```diff
 Tier<Op,NextTier>: Box<Expr> = {                                                                                                                                                           
-    Tier<Op,NextTier> Op NextTier => Box::new(Expr::Op(<>)),                                                                                                                               
+    Tier<Op,NextTier> Op Tier<Op, NextTier> => Box::new(Expr::Op(<>)),                                                                                                                     
     NextTier                                                                                                                                                                               
};
```

As a result you are able to see how report looks and how states are annotated in case of conflicts.
