### PR TITLE
Restore Rust 1.13 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - stable
+  - 1.16.0
   - beta
   - nightly
 script:

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -417,7 +417,7 @@ fn generics_issue_104_test1() {
 }
 
 #[test]
-fn match_section() {
+fn test_match_section() {
     assert!(match_section::parse_Query("SELECT foo").is_ok());
     assert!(match_section::parse_Query("select foo").is_ok());
     assert!(match_section::parse_Query("INSERT foo").is_ok());

--- a/lalrpop/src/lr1/lane_table/construct/merge.rs
+++ b/lalrpop/src/lr1/lane_table/construct/merge.rs
@@ -1,6 +1,8 @@
-use super::*;
-
-use collections::Multimap;
+use collections::{Map, Multimap, Set};
+use ena::unify::UnificationTable;
+use lr1::core::{Action, LR1State, StateIndex};
+use lr1::lane_table::construct::state_set::StateSet;
+use lr1::lane_table::table::LaneTable;
 use lr1::lane_table::table::context_set::ContextSet;
 
 /// The "merge" phase of the algorithm is described in "Step 3c" of

--- a/lalrpop/src/lr1/lane_table/construct/mod.rs
+++ b/lalrpop/src/lr1/lane_table/construct/mod.rs
@@ -28,7 +28,7 @@ pub struct LaneTableConstruct<'grammar> {
 impl<'grammar> LaneTableConstruct<'grammar> {
     pub fn new(grammar: &'grammar Grammar, start_nt: NonterminalString) -> Self {
         let first_sets = FirstSets::new(grammar);
-        Self {
+        LaneTableConstruct {
             grammar: grammar,
             start_nt: start_nt,
             first_sets: first_sets,


### PR DESCRIPTION
Lalrpop 0.13 regressed in Rust compatibility; 0.12.5 compiled fine on Rust 1.13 onwards, but 0.13 required at least Rust 1.16.

With a few small adjustments, Rust 1.13 compatibility can be restored.

It might also be a good idea to put the minimal supported Rust version in the CI configuration. That way breaking changes can be detected. If the advantages of using a newer Rust version outweigh breaking compatibility, then requiring a newer Rust version is fine, but at least breakages are explicit in this way, and they can be mentioned in the changelog.