### PR TITLE
Make action and state functions private.

### DIFF
--- a/lalrpop/src/build/action.rs
+++ b/lalrpop/src/build/action.rs
@@ -5,7 +5,7 @@
 //! (which takes Y and Z as input), they have this form:
 //!
 //! ```
-//! pub fn __action17<
+//! fn __action17<
 //!     'input,                       // user-declared type parameters (*)
 //! >(
 //!     input: &'input str,           // user-declared parameters
@@ -18,7 +18,7 @@
 //! Otherwise, they have this form:
 //!
 //! ```
-//! pub fn __action17<
+//! fn __action17<
 //!     'input,                       // user-declared type parameters (*)
 //! >(
 //!     input: &'input str,           // user-declared parameters
@@ -108,12 +108,12 @@ fn emit_user_action_code<W: Write>(grammar: &r::Grammar,
                                       grammar.types.terminal_loc_type())]);
     }
 
-    try!(rust.write_pub_fn_header(grammar,
-                                  format!("{}action{}", grammar.prefix, index),
-                                  vec![],
-                                  arguments,
-                                  ret_type,
-                                  vec![]));
+    try!(rust.write_fn_header(grammar,
+                              format!("{}action{}", grammar.prefix, index),
+                              vec![],
+                              arguments,
+                              ret_type,
+                              vec![]));
     rust!(rust, "{{");
     rust!(rust, "{}", data.code);
     rust!(rust, "}}");
@@ -126,17 +126,17 @@ fn emit_lookaround_action_code<W: Write>(grammar: &r::Grammar,
                                          _defn: &r::ActionFnDefn,
                                          data: &r::LookaroundActionFnDefn)
                                          -> io::Result<()> {
-    try!(rust.write_pub_fn_header(grammar,
-                                  format!("{}action{}", grammar.prefix, index),
-                                  vec![],
-                                  vec![format!("{}lookbehind: &{}",
-                                               grammar.prefix,
-                                               grammar.types.terminal_loc_type()),
-                                       format!("{}lookahead: &{}",
-                                               grammar.prefix,
-                                               grammar.types.terminal_loc_type())],
-                                  format!("{}", grammar.types.terminal_loc_type()),
-                                  vec![]));
+    try!(rust.write_fn_header(grammar,
+                              format!("{}action{}", grammar.prefix, index),
+                              vec![],
+                              vec![format!("{}lookbehind: &{}",
+                                           grammar.prefix,
+                                           grammar.types.terminal_loc_type()),
+                                   format!("{}lookahead: &{}",
+                                           grammar.prefix,
+                                           grammar.types.terminal_loc_type())],
+                              format!("{}", grammar.types.terminal_loc_type()),
+                              vec![]));
 
     rust!(rust, "{{");
     match *data {
@@ -197,12 +197,12 @@ fn emit_inline_action_code<W: Write>(grammar: &r::Grammar,
                                       grammar.types.terminal_loc_type())]);
     }
 
-    try!(rust.write_pub_fn_header(grammar,
-                                  format!("{}action{}", grammar.prefix, index),
-                                  vec![],
-                                  arguments,
-                                  ret_type,
-                                  vec![]));
+    try!(rust.write_fn_header(grammar,
+                              format!("{}action{}", grammar.prefix, index),
+                              vec![],
+                              arguments,
+                              ret_type,
+                              vec![]));
     rust!(rust, "{{");
 
     // For each inlined thing, compute the start/end locations.

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -468,20 +468,20 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent,
 
         let (fn_args, starts_with_terminal) = self.fn_args(optional_prefix, fixed_prefix);
 
-        try!(self.out.write_pub_fn_header(self.grammar,
-                                          format!("{}{}{}", self.prefix, fn_kind, fn_index),
-                                          vec![format!("{}TOKENS: Iterator<Item=Result<{},{}>>",
-                                                       self.prefix,
-                                                       triple_type,
-                                                       iter_error_type)],
-                                          fn_args,
-                                          format!("Result<(Option<{}>, {}Nonterminal<{}>), {}>",
-                                                  triple_type,
-                                                  self.prefix,
-                                                  Sep(", ",
-                                                      &self.custom.nonterminal_type_params),
-                                                  parse_error_type),
-                                          vec![]));
+        try!(self.out.write_fn_header(self.grammar,
+                                      format!("{}{}{}", self.prefix, fn_kind, fn_index),
+                                      vec![format!("{}TOKENS: Iterator<Item=Result<{},{}>>",
+                                                   self.prefix,
+                                                   triple_type,
+                                                   iter_error_type)],
+                                      fn_args,
+                                      format!("Result<(Option<{}>, {}Nonterminal<{}>), {}>",
+                                              triple_type,
+                                              self.prefix,
+                                              Sep(", ",
+                                                  &self.custom.nonterminal_type_params),
+                                              parse_error_type),
+                                      vec![]));
 
         rust!(self.out, "{{");
 

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -117,6 +117,19 @@ impl<W:Write> RustWrite<W> {
                                     parameters, return_type, where_clauses)
     }
 
+    pub fn write_fn_header(&mut self,
+                               grammar: &Grammar,
+                               name: String,
+                               type_parameters: Vec<String>,
+                               parameters: Vec<String>,
+                               return_type: String,
+                               where_clauses: Vec<String>)
+                               -> io::Result<()>
+    {
+        self.write_fn_header_helper(grammar, "", name, type_parameters,
+                                    parameters, return_type, where_clauses)
+    }
+
     fn write_fn_header_helper(&mut self,
                               grammar: &Grammar,
                               qualifiers: &str,


### PR DESCRIPTION
Generated recursive ascent parser contains public functions
for every state and every action.
Only the top level state function(s) must be public.