### PR TITLE
Add user uses in generated mod intern_token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ doc/pascal/lalrpop/src/pascal.rs
 doc/whitespace/src/parser.rs
 
 lalrpop-test/src/error.rs
+lalrpop-test/src/error_issue_113.rs
 lalrpop-test/src/error_recovery.rs
 lalrpop-test/src/error_recovery_pull_182.rs
 lalrpop-test/src/expr.rs

--- a/lalrpop-snap/src/lexer/intern_token/mod.rs
+++ b/lalrpop-snap/src/lexer/intern_token/mod.rs
@@ -34,7 +34,8 @@ pub fn compile<W: Write>(
     let prefix = &grammar.prefix;
 
     rust!(out, "mod {}intern_token {{", prefix);
-    try!(out.write_standard_uses(prefix));
+    rust!(out, "#![allow(unused_imports)]");
+    try!(out.write_uses("", &grammar));
     rust!(out, "pub struct {}Matcher<'input> {{", prefix);
     rust!(out, "text: &'input str,"); // remaining input
     rust!(out, "consumed: usize,"); // number of chars consumed thus far

--- a/lalrpop-test/src/error_issue_113.lalrpop
+++ b/lalrpop-test/src/error_issue_113.lalrpop
@@ -1,0 +1,20 @@
+use util::tok::Tok;
+use lalrpop_util::ParseError;
+use super::MyCustomError;
+
+grammar;
+
+extern {
+    type Error = MyCustomError;
+
+    enum Tok {
+        "-" => Tok::Minus,
+        "+" => Tok::Plus
+    }
+}
+
+pub Items: Vec<(usize, usize)> = {
+    => vec![],
+    Items "+" =>? Err(ParseError::User { error: MyCustomError('+') }),
+    <v:Items> "-" =>? Ok(v),
+};

--- a/lalrpop-test/src/error_issue_113.lalrpop
+++ b/lalrpop-test/src/error_issue_113.lalrpop
@@ -1,4 +1,3 @@
-use util::tok::Tok;
 use lalrpop_util::ParseError;
 use super::MyCustomError;
 
@@ -6,11 +5,6 @@ grammar;
 
 extern {
     type Error = MyCustomError;
-
-    enum Tok {
-        "-" => Tok::Minus,
-        "+" => Tok::Plus
-    }
 }
 
 pub Items: Vec<(usize, usize)> = {

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -59,8 +59,13 @@ mod loc_issue_90_lib;
 /// test that uses `super` in paths in various places
 mod use_super;
 
-/// test that exercises locations and spans
+/// Custom error type (issue #113)
+#[derive(Debug, PartialEq)]
+pub struct MyCustomError(char);
+
+/// test that exercises locations, spans, and custom errors
 mod error;
+mod error_issue_113;
 
 /// Test error recovery
 mod error_recovery;

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -44,6 +44,7 @@ pub fn compile<W: Write>(
     let prefix = &grammar.prefix;
 
     rust!(out, "mod {}intern_token {{", prefix);
+    rust!(out, "#![allow(unused_imports)]");
     try!(out.write_uses("", &grammar));
     rust!(out, "extern crate regex as {}regex;", prefix);
     rust!(out, "pub struct {}Matcher<'input> {{", prefix);

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -44,7 +44,7 @@ pub fn compile<W: Write>(
     let prefix = &grammar.prefix;
 
     rust!(out, "mod {}intern_token {{", prefix);
-    try!(out.write_standard_uses(prefix));
+    try!(out.write_uses("", &grammar));
     rust!(out, "extern crate regex as {}regex;", prefix);
     rust!(out, "pub struct {}Matcher<'input> {{", prefix);
     rust!(out, "text: &'input str,"); // remaining input


### PR DESCRIPTION
This allows custom error types to be used as User ParseError

This should fix #113 