### PR TITLE
Remove dependencies on rustc-serialize.

### DIFF
--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -9,7 +9,6 @@ path = "../../../lalrpop"
 
 [dependencies]
 docopt = "0.7"
-rustc-serialize = "0.3"
 regex = "0.2.1"
 
 [dependencies.lalrpop-util]

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -9,6 +9,7 @@ path = "../../../lalrpop"
 
 [dependencies]
 docopt = "0.7"
+rustc-serialize = "0.3"
 regex = "0.2.1"
 
 [dependencies.lalrpop-util]

--- a/lalrpop-snap/Cargo.toml
+++ b/lalrpop-snap/Cargo.toml
@@ -21,7 +21,6 @@ itertools = "0.5.9"
 regex = "0.2.1"
 regex-syntax = "0.2"
 petgraph = "0.3.2"
-rustc-serialize = "0.3"
 term = "0.4.5"
 unicode-xid = "0.0.4"
 


### PR DESCRIPTION
rustc-serialize is deprecated and is not actually used in lalrpop
right now anyway.