### PR TITLE
Issue226 ltgt construct should work with named input

### DIFF
--- a/doc/calculator/src/calculator2.lalrpop
+++ b/doc/calculator/src/calculator2.lalrpop
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+
 grammar;
 
 pub Term = { Num, "(" <Term> ")" };

--- a/doc/calculator/src/calculator2.lalrpop
+++ b/doc/calculator/src/calculator2.lalrpop
@@ -1,6 +1,5 @@
 use std::str::FromStr;
 
-
 grammar;
 
 pub Term = { Num, "(" <Term> ")" };

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -414,13 +414,9 @@ give you the idea:
 | `<p:A> B => Foo {<>}` | `<p:A> B => Foo {p:p}` |
 | `<p:A> <q:B> => Foo {<>} | `<p:A> <q:B> => Foo {p:p, q:q}` |
 
-The funky expression also works with struct constructors 
-(like `Foo {...}` in examples above). This works out well if the
-names of your parsed values match the names of your struct fields.
-
-In such case user had to explicitly
-assign names of structure's field to parsed values.
-
+The `<>` expressions also works with struct constructors (like `Foo
+{...}` in examples above). This works out well if the names of your
+parsed values match the names of your struct fields.
 
 <a id="calculator2b"></a>
 ### calculator2b: Controlling the lexer with `match` declarations

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -408,7 +408,16 @@ give you the idea:
 | `A => bar(<>)`       | `<a:A> => bar(a)`          |
 | `A B => bar(<>)`     | `<a:A> <b:B> => bar(a, b)` |
 | `<A> B => bar(<>)`   | `<a:A> B => bar(a)`        |
+| `<p:A> B => bar(<>)` | `<p:A> B => bar(p)`        |
 | `<A> <B> => bar(<>)` | `<a:A> <b:B> => bar(a, b)` |
+| `<p:A> <q:B> => bar(<>)` | `<p:A> <q:B> => bar(p, q)` |
+| `<p:A> B => Foo{<>}` | `<p:A> B => Foo{p:p}` |
+| `<p:A> <q:B> => Foo{<>} | `<p:A> <q:B> => Foo{p:p, q:q}` |
+
+The funky expression also works with struct constructors 
+(like `Foo{...}` in examples above). In such case user had to explicitly
+assign names of structure's field to parsed values.
+
 
 <a id="calculator2b"></a>
 ### calculator2b: Controlling the lexer with `match` declarations

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -411,11 +411,14 @@ give you the idea:
 | `<p:A> B => bar(<>)` | `<p:A> B => bar(p)`        |
 | `<A> <B> => bar(<>)` | `<a:A> <b:B> => bar(a, b)` |
 | `<p:A> <q:B> => bar(<>)` | `<p:A> <q:B> => bar(p, q)` |
-| `<p:A> B => Foo{<>}` | `<p:A> B => Foo{p:p}` |
-| `<p:A> <q:B> => Foo{<>} | `<p:A> <q:B> => Foo{p:p, q:q}` |
+| `<p:A> B => Foo {<>}` | `<p:A> B => Foo {p:p}` |
+| `<p:A> <q:B> => Foo {<>} | `<p:A> <q:B> => Foo {p:p, q:q}` |
 
 The funky expression also works with struct constructors 
-(like `Foo{...}` in examples above). In such case user had to explicitly
+(like `Foo {...}` in examples above). This works out well if the
+names of your parsed values match the names of your struct fields.
+
+In such case user had to explicitly
 assign names of structure's field to parsed values.
 
 

--- a/lalrpop-test/src/expr_arena.lalrpop
+++ b/lalrpop-test/src/expr_arena.lalrpop
@@ -19,9 +19,13 @@ extern {
 }
 
 pub Expr: &'ast Node<'ast> = {
-    <l:Expr> "-" <r:Factor> => arena.alloc(Node::Binary(Op::Sub, l, r)),
-    <l:Expr> "+" <r:Factor> => arena.alloc(Node::Binary(Op::Add, l, r)),
+    <l:Expr> <op:OpExpr> <r:Factor> => arena.alloc(Node::Binary { <> }),
     Factor,
+};
+
+OpExpr: Op = {
+    "-" => Op::Sub,
+    "+" => Op::Add,
 };
 
 Comma<T>: Vec<T> = {
@@ -30,10 +34,14 @@ Comma<T>: Vec<T> = {
 };
 
 Factor = {
-    <l:Factor> "*" <r:Term> => arena.alloc(Node::Binary(Op::Mul, l, r)),
-    <l:Factor> "/" <r:Term> => arena.alloc(Node::Binary(Op::Div, l, r)),
+    <l:Factor> <op:OpFactor> <r:Term> => arena.alloc(Node::Binary { <> }),
     "*" "(" <Comma<Expr>> ")" => arena.alloc(Node::Reduce(Op::Mul, <>)),
     Term,
+};
+
+OpFactor: Op = {
+    "*" => Op::Mul,
+    "/" => Op::Div,
 };
 
 Term: &'ast Node<'ast> = {

--- a/lalrpop-test/src/expr_arena_ast.rs
+++ b/lalrpop-test/src/expr_arena_ast.rs
@@ -8,7 +8,7 @@ pub enum Op {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Node<'ast> {
     Value(i32),
-    Binary(Op, &'ast Node<'ast>, &'ast Node<'ast>),
+    Binary { op: Op, l: &'ast Node<'ast>, r: &'ast Node<'ast>},
     Reduce(Op, Vec<&'ast Node<'ast>>),
     Paren(&'ast Node<'ast>),
 }

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -429,3 +429,8 @@ fn test_match_section() {
     assert!(match_section::parse_Query("UPDATE foo").is_ok());
     assert!(match_section::parse_Query("UPDATE update").is_err());
 }
+
+#[test]
+fn issue_113() {
+    assert!(error_issue_113::parse_Items("+").is_err());
+}

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -206,11 +206,11 @@ fn expr_arena_test1() {
     use expr_arena_ast::*;
     let arena = Arena::new();
     let expected =
-        arena.alloc(Node::Binary(Op::Sub,
-                                 arena.alloc(Node::Binary(Op::Mul,
-                                                          arena.alloc(Node::Value(22)),
-                                                          arena.alloc(Node::Value(3)))),
-                                 arena.alloc(Node::Value(6))));
+        arena.alloc(Node::Binary { op: Op::Sub,
+                                   l: arena.alloc(Node::Binary { op: Op::Mul,
+                                                                 l: arena.alloc(Node::Value(22)),
+                                                                 r: arena.alloc(Node::Value(3)) }),
+                                   r: arena.alloc(Node::Value(6)) });
     util::test_loc(|v| expr_arena::parse_Expr(&arena, v), "22 * 3 - 6", expected);
 }
 
@@ -233,13 +233,13 @@ fn expr_arena_test3() {
     let arena = Arena::new();
     let expected =
         arena.alloc(
-            Node::Binary(Op::Mul,
-                         arena.alloc(Node::Value(22)),
-                         arena.alloc(Node::Paren(
-                             arena.alloc(
-                                 Node::Binary(Op::Sub,
-                                              arena.alloc(Node::Value(3)),
-                                              arena.alloc(Node::Value(6))))))));
+            Node::Binary { op: Op::Mul,
+                           l: arena.alloc(Node::Value(22)),
+                           r: arena.alloc(Node::Paren(
+                               arena.alloc(
+                                   Node::Binary { op: Op::Sub,
+                                                  l: arena.alloc(Node::Value(3)),
+                                                  r: arena.alloc(Node::Value(6)) }))) });
     util::test_loc(|v| expr_arena::parse_Expr(&arena, v), "22 * (3 - 6)", expected);
 }
 

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -318,6 +318,30 @@ impl<'s> LowerState<'s> {
                 let arg_patterns = patterns(names.iter().map(|&(index, name, _)| (index, name)),
                                             symbols.len());
 
+
+                let action = {
+                    match norm_util::check_funky_expression(&action) {
+                        norm_util::FunkyExpressionPresence::None => {
+                            action
+                        } 
+                        norm_util::FunkyExpressionPresence::Normal => {
+                            let name_str : String = intern::read(|interner| {
+                                let name_strs: Vec<_> = names.iter().map(|&(_,name,_)| interner.data(name)).collect();
+                                name_strs.join(", ")
+                            });
+                            action.replace("<>", &name_str)
+                        }
+                        norm_util::FunkyExpressionPresence::InCurlyBrackets => {
+                            let name_str = intern::read(|interner| {
+                                let name_strs: Vec<_> = names.iter().map(|&(_,name,_)| format!("{0}:{0}", interner.data(name))).collect();
+                                name_strs.join(", ")
+                            });
+                            action.replace("<>", &name_str)
+                        }
+                    }
+                };
+
+
                 r::ActionFnDefn {
                     fallible: fallible,
                     ret_type: nt_type,

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -320,18 +320,18 @@ impl<'s> LowerState<'s> {
 
 
                 let action = {
-                    match norm_util::check_funky_expression(&action) {
-                        norm_util::FunkyExpressionPresence::None => {
+                    match norm_util::check_between_braces(&action) {
+                        norm_util::Presence::None => {
                             action
                         } 
-                        norm_util::FunkyExpressionPresence::Normal => {
+                        norm_util::Presence::Normal => {
                             let name_str : String = intern::read(|interner| {
                                 let name_strs: Vec<_> = names.iter().map(|&(_,name,_)| interner.data(name)).collect();
                                 name_strs.join(", ")
                             });
                             action.replace("<>", &name_str)
                         }
-                        norm_util::FunkyExpressionPresence::InCurlyBrackets => {
+                        norm_util::Presence::InCurlyBrackets => {
                             let name_str = intern::read(|interner| {
                                 let name_strs: Vec<_> = names.iter().map(|&(_,name,_)| format!("{0}:{0}", interner.data(name))).collect();
                                 name_strs.join(", ")

--- a/lalrpop/src/normalize/norm_util.rs
+++ b/lalrpop/src/normalize/norm_util.rs
@@ -55,13 +55,18 @@ pub fn analyze_expr<'a>(expr: &'a ExprSymbol) -> Symbols<'a> {
     Symbols::Anon(expr.symbols.iter().enumerate().collect())
 }
 
-// @TODO: When 'struct field shorthands' become stable then curly-brackets detection mechanism will be not-needed
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum FunkyExpressionPresence
 {
     None,
     InCurlyBrackets,
     Normal
+}
+
+impl FunkyExpressionPresence {
+    pub fn is_in_curly_brackets(&self) -> bool {
+        *self == FunkyExpressionPresence::InCurlyBrackets
+    }
 }
 
 pub fn check_funky_expression(action: &str) -> FunkyExpressionPresence

--- a/lalrpop/src/normalize/norm_util.rs
+++ b/lalrpop/src/normalize/norm_util.rs
@@ -54,3 +54,68 @@ pub fn analyze_expr<'a>(expr: &'a ExprSymbol) -> Symbols<'a> {
     // If they didn't choose anything with `<>`, make a tuple of everything.
     Symbols::Anon(expr.symbols.iter().enumerate().collect())
 }
+
+// @TODO: When 'struct field shorthands' become stable then curly-brackets detection mechanism will be not-needed
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum FunkyExpressionPresence
+{
+    None,
+    InCurlyBrackets,
+    Normal
+}
+
+pub fn check_funky_expression(action: &str) -> FunkyExpressionPresence
+{
+    if let Some(funky_index) = action.find("<>") {
+        let (before, after) = {
+            let (before, after) = action.split_at(funky_index);
+            (before.trim(), after[2..].trim())
+        };
+
+        let last_before = before.chars().last();
+        let next_after = after.chars().next();
+        if let (Some('{'), Some('}')) = (last_before, next_after) {
+            FunkyExpressionPresence::InCurlyBrackets
+        } else {
+            FunkyExpressionPresence::Normal
+        }
+    } else {
+        FunkyExpressionPresence::None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn detecting_normal_funky_expression() {
+        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("<>"));
+        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("ble <> blaa"));
+        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("ble <> } b"));
+        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{ e <> } b"));
+        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{ e <>} b"));
+        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{ e <> e } b"));
+        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{ <> e } b"));
+        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{<> e } b"));
+        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{<>"));
+        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("<>}"));
+    }
+
+    #[test]
+    fn detecting_nopresence_of_funky_expression() {
+        assert_eq!(FunkyExpressionPresence::None, check_funky_expression("< >"));
+        assert_eq!(FunkyExpressionPresence::None, check_funky_expression("ble <b> blaa"));
+    }
+
+    #[test]
+    fn detecting_incurlybrackets_funky_expression() {
+        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("{<>}"));
+        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("ble{<> }blaa"));
+        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("ble{ <> } b"));
+        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("bl{         <>} b"));
+        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("bl{<>} b"));
+        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("bl{<>         } b"));
+    }
+
+}

--- a/lalrpop/src/normalize/norm_util.rs
+++ b/lalrpop/src/normalize/norm_util.rs
@@ -56,20 +56,20 @@ pub fn analyze_expr<'a>(expr: &'a ExprSymbol) -> Symbols<'a> {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum FunkyExpressionPresence
+pub enum Presence
 {
     None,
     InCurlyBrackets,
     Normal
 }
 
-impl FunkyExpressionPresence {
+impl Presence {
     pub fn is_in_curly_brackets(&self) -> bool {
-        *self == FunkyExpressionPresence::InCurlyBrackets
+        *self == Presence::InCurlyBrackets
     }
 }
 
-pub fn check_funky_expression(action: &str) -> FunkyExpressionPresence
+pub fn check_between_braces(action: &str) -> Presence
 {
     if let Some(funky_index) = action.find("<>") {
         let (before, after) = {
@@ -80,12 +80,12 @@ pub fn check_funky_expression(action: &str) -> FunkyExpressionPresence
         let last_before = before.chars().last();
         let next_after = after.chars().next();
         if let (Some('{'), Some('}')) = (last_before, next_after) {
-            FunkyExpressionPresence::InCurlyBrackets
+            Presence::InCurlyBrackets
         } else {
-            FunkyExpressionPresence::Normal
+            Presence::Normal
         }
     } else {
-        FunkyExpressionPresence::None
+        Presence::None
     }
 }
 
@@ -95,32 +95,32 @@ mod test {
 
     #[test]
     fn detecting_normal_funky_expression() {
-        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("<>"));
-        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("ble <> blaa"));
-        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("ble <> } b"));
-        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{ e <> } b"));
-        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{ e <>} b"));
-        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{ e <> e } b"));
-        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{ <> e } b"));
-        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{<> e } b"));
-        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("bl{<>"));
-        assert_eq!(FunkyExpressionPresence::Normal, check_funky_expression("<>}"));
+        assert_eq!(Presence::Normal, check_between_braces("<>"));
+        assert_eq!(Presence::Normal, check_between_braces("ble <> blaa"));
+        assert_eq!(Presence::Normal, check_between_braces("ble <> } b"));
+        assert_eq!(Presence::Normal, check_between_braces("bl{ e <> } b"));
+        assert_eq!(Presence::Normal, check_between_braces("bl{ e <>} b"));
+        assert_eq!(Presence::Normal, check_between_braces("bl{ e <> e } b"));
+        assert_eq!(Presence::Normal, check_between_braces("bl{ <> e } b"));
+        assert_eq!(Presence::Normal, check_between_braces("bl{<> e } b"));
+        assert_eq!(Presence::Normal, check_between_braces("bl{<>"));
+        assert_eq!(Presence::Normal, check_between_braces("<>}"));
     }
 
     #[test]
     fn detecting_nopresence_of_funky_expression() {
-        assert_eq!(FunkyExpressionPresence::None, check_funky_expression("< >"));
-        assert_eq!(FunkyExpressionPresence::None, check_funky_expression("ble <b> blaa"));
+        assert_eq!(Presence::None, check_between_braces("< >"));
+        assert_eq!(Presence::None, check_between_braces("ble <b> blaa"));
     }
 
     #[test]
     fn detecting_incurlybrackets_funky_expression() {
-        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("{<>}"));
-        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("ble{<> }blaa"));
-        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("ble{ <> } b"));
-        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("bl{         <>} b"));
-        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("bl{<>} b"));
-        assert_eq!(FunkyExpressionPresence::InCurlyBrackets, check_funky_expression("bl{<>         } b"));
+        assert_eq!(Presence::InCurlyBrackets, check_between_braces("{<>}"));
+        assert_eq!(Presence::InCurlyBrackets, check_between_braces("ble{<> }blaa"));
+        assert_eq!(Presence::InCurlyBrackets, check_between_braces("ble{ <> } b"));
+        assert_eq!(Presence::InCurlyBrackets, check_between_braces("bl{         <>} b"));
+        assert_eq!(Presence::InCurlyBrackets, check_between_braces("bl{<>} b"));
+        assert_eq!(Presence::InCurlyBrackets, check_between_braces("bl{<>         } b"));
     }
 
 }

--- a/lalrpop/src/normalize/norm_util.rs
+++ b/lalrpop/src/normalize/norm_util.rs
@@ -56,8 +56,7 @@ pub fn analyze_expr<'a>(expr: &'a ExprSymbol) -> Symbols<'a> {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum Presence
-{
+pub enum Presence {
     None,
     InCurlyBrackets,
     Normal
@@ -69,8 +68,7 @@ impl Presence {
     }
 }
 
-pub fn check_between_braces(action: &str) -> Presence
-{
+pub fn check_between_braces(action: &str) -> Presence {
     if let Some(funky_index) = action.find("<>") {
         let (before, after) = {
             let (before, after) = action.split_at(funky_index);

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -177,13 +177,8 @@ impl<'grammar> Validator<'grammar> {
                     }
                 };
                 if norm_util::check_funky_expression(action).is_in_curly_brackets() {
-                    let sym =
-                        syms.iter()
-                            .map(|&(_, sym)| sym)
-                            .next()
-                            .unwrap();
                     return_err!(
-                        sym.span,
+                        alternative.span,
                         "the `<>` expression requires to explicitly assign fields' names to values");
                 }
             }

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -167,7 +167,7 @@ impl<'grammar> Validator<'grammar> {
                         sym);
                 }
             }
-            Symbols::Anon(syms) => { 
+            Symbols::Anon(_) => { 
                 let empty_string = "".to_string();
                 let action = {
                     match alternative.action {
@@ -176,10 +176,10 @@ impl<'grammar> Validator<'grammar> {
                         _ => &empty_string
                     }
                 };
-                if norm_util::check_funky_expression(action).is_in_curly_brackets() {
+                if norm_util::check_between_braces(action).is_in_curly_brackets() {
                     return_err!(
                         alternative.span,
-                        "the `<>` expression requires to explicitly assign fields' names to values");
+                        "Using `<>` between curly braces (e.g., `{{<>}}`) only works when your parsed values have been given names (e.g., `<x:Foo>`, not just `<Foo>`)");
                 }
             }
         }

--- a/lalrpop/src/normalize/prevalidate/mod.rs
+++ b/lalrpop/src/normalize/prevalidate/mod.rs
@@ -167,7 +167,26 @@ impl<'grammar> Validator<'grammar> {
                         sym);
                 }
             }
-            Symbols::Anon(_) => { }
+            Symbols::Anon(syms) => { 
+                let empty_string = "".to_string();
+                let action = {
+                    match alternative.action {
+                        Some(ActionKind::User(ref action)) => action,
+                        Some(ActionKind::Fallible(ref action)) => action,
+                        _ => &empty_string
+                    }
+                };
+                if norm_util::check_funky_expression(action).is_in_curly_brackets() {
+                    let sym =
+                        syms.iter()
+                            .map(|&(_, sym)| sym)
+                            .next()
+                            .unwrap();
+                    return_err!(
+                        sym.span,
+                        "the `<>` expression requires to explicitly assign fields' names to values");
+                }
+            }
         }
 
         Ok(())

--- a/lalrpop/src/normalize/prevalidate/test.rs
+++ b/lalrpop/src/normalize/prevalidate/test.rs
@@ -110,3 +110,19 @@ fn match_catch_all_last_of_first() {
         r#"grammar; match { "abc", _ } else { "foo" }"#,
         r#"                        ~                 "#);
 }
+
+#[test]
+fn expandable_expression_requires_named_variables() {
+    check_err(
+        r#"Using `<>` between curly braces \(e.g., `\{<>\}`\) only works when your parsed values have been given names \(e.g., `<x:Foo>`, not just `<Foo>`\)"#,
+        r#"grammar; Term = { <A> => Foo {<>} };"#,
+        r#"                  ~~~~~~~~~~~~~~~~  "#);
+}
+
+#[test]
+fn mixing_names_and_anonymous_values() {
+    check_err(
+        r#"anonymous symbols like this one cannot be combined with named symbols like `b:B`"#,
+        r#"grammar; Term = { <A> <b:B> => Alien: Eighth passanger of Nostromo};"#,
+        r#"                  ~~~                                               "#);
+}


### PR DESCRIPTION
Solution to #226.

Lalrpop validates also usage of the `<>` expression with struct constructors -- it requires to assign field names to values.

* Example

```
pub Foo: Foo = {
    <Num> Num <Num> => Foo{<>}
};
```

Provokes error message:
```
wieczyk-> lalrpop -f src/example.lalrpop 
processing file `src/example.lalrpop`
src/example.lalrpop:7:5: 8:0 error: the `<>` expression requires to explicitly assign fields' names to values
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~+
|     <Num> Num <Num> => Foo{<>} |
| };
+~
```

