### PR TITLE
Ignore the possible expected token when we find an unrecognized token

### DIFF
--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -209,7 +209,7 @@ fn parse_and_normalize_grammar(session: &Session, file_text: &FileText) -> io::R
         }
 
         Err(ParseError::UnrecognizedToken { token: Some((lo, _, hi)), expected }) => {
-            assert!(expected.is_empty()); // didn't implement this yet :)
+            let _ = expected; // didn't implement this yet :)
             let text = &file_text.text()[lo..hi];
             report_error(&file_text,
                          pt::Span(lo, hi),


### PR DESCRIPTION
This will at least print an error message with the location, rather than
panicking, which is a lot more user-friendly :)

r? @nikomatsakis 