### PR TITLE
Make ParseError Displayable

### DIFF
--- a/doc/calculator/src/calculator6.lalrpop
+++ b/doc/calculator/src/calculator6.lalrpop
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 use ast::{Expr, Opcode};
-use lalrpop_util::ErrorRecovery;
+use lalrpop_util::{ErrorRecovery,InternalToken};
 
-grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, (usize, &'input str), &'static str>>);
+grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, InternalToken<'input>, &'static str>>);
 
 pub Exprs = Comma<Expr>;
 

--- a/doc/calculator/src/calculator6.lalrpop
+++ b/doc/calculator/src/calculator6.lalrpop
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 use ast::{Expr, Opcode};
-use lalrpop_util::{ErrorRecovery,InternalToken};
+use lalrpop_util::ErrorRecovery;
 
-grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, InternalToken<'input>, &'static str>>);
+grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, &'static str>>);
 
 pub Exprs = Comma<Expr>;
 

--- a/doc/calculator/src/calculator6.lalrpop
+++ b/doc/calculator/src/calculator6.lalrpop
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use ast::{Expr, Opcode};
 use lalrpop_util::ErrorRecovery;
 
-grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, (usize, &'input str), ()>>);
+grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, (usize, &'input str), &'static str>>);
 
 pub Exprs = Comma<Expr>;
 

--- a/lalrpop-test/src/error_recovery.lalrpop
+++ b/lalrpop-test/src/error_recovery.lalrpop
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
-grammar<'e>(errors: &'e RefCell<Vec<ErrorRecovery<(), Tok, ()>>>);
+grammar<'e>(errors: &'e RefCell<Vec<ErrorRecovery<(), Tok, &'static str>>>);
 
 extern {
     enum Tok {

--- a/lalrpop-test/src/error_recovery_pull_182.lalrpop
+++ b/lalrpop-test/src/error_recovery_pull_182.lalrpop
@@ -2,7 +2,7 @@
 use util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
-grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<(), Tok, ()>>);
+grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<(), Tok, &'static str>>);
 
 extern {
     enum Tok {

--- a/lalrpop-test/src/expr_module_attributes.lalrpop
+++ b/lalrpop-test/src/expr_module_attributes.lalrpop
@@ -1,4 +1,3 @@
-#![allow(clippy)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy))]
 grammar(scale: i32);
 

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -159,7 +159,7 @@ fn expr_intern_tok_display_err() {
     let expr = "(1+\n(2++3))";
     let result = expr_intern_tok::parse_Expr(1, expr);
     let err : lalrpop_util::ParseError<usize, (usize, &str),()>
-            = result.expect_err("expected a syntax error");
+            = result.unwrap_err();
 
     // The problem is that (usize,&str) and () do not implement fmt::Display,
     // so neither does the ParseError.

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -164,8 +164,9 @@ fn expr_intern_tok_display_err() {
     // The problem is that (usize,&str) and () do not implement fmt::Display,
     // so neither does the ParseError.
     // We can fix that by rewriting them to something that has fmt::Display
-    let disp = err.map_tok(|(_,t)|t).map_err(|_| "error");
-    assert!(disp.to_string().contains("Unrecognized token +"));
+    let disp = err.map_token(|(_,t)|t).map_err(|_| "error");
+    let message = disp.to_string();
+    assert!(message.contains("Unrecognized token `+`"));
 
     // We can even convert the locations to a line number
     let line_based = disp.map_loc(|offset| {

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -158,11 +158,11 @@ fn expr_intern_tok_test_err() {
 fn parse_error_map_token_and_location() {
     let expr = "(1+\n(2++3))";
     let result = expr_intern_tok::parse_Expr(1, expr);
-    let err : lalrpop_util::ParseError<usize, lalrpop_util::InternalToken,&'static str>
+    let err : lalrpop_util::ParseError<usize, expr_intern_tok::Token,&'static str>
             = result.unwrap_err();
 
     let message = err
-            .map_token(|lalrpop_util::InternalToken(_,t)| format!("TOKEN {}", t))
+            .map_token(|expr_intern_tok::Token(_,t)| format!("TOKEN {}", t))
             .map_location(|offset| format!("line {}", expr[0..offset].lines().count()))
             .to_string();
     assert!(message.contains("Unrecognized token `TOKEN +`"));

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -155,14 +155,14 @@ fn expr_intern_tok_test_err() {
 }
 
 #[test]
-fn parse_error_map() {
+fn parse_error_map_token_and_location() {
     let expr = "(1+\n(2++3))";
     let result = expr_intern_tok::parse_Expr(1, expr);
-    let err : lalrpop_util::ParseError<usize, (usize, &str),&'static str>
+    let err : lalrpop_util::ParseError<usize, lalrpop_util::InternalToken,&'static str>
             = result.unwrap_err();
 
     let message = err
-            .map_token(|(_,t)| format!("TOKEN {}", t))
+            .map_token(|lalrpop_util::InternalToken(_,t)| format!("TOKEN {}", t))
             .map_location(|offset| format!("line {}", expr[0..offset].lines().count()))
             .to_string();
     assert!(message.contains("Unrecognized token `TOKEN +`"));
@@ -179,6 +179,14 @@ fn parse_error_map_err() {
     } else {
         panic!("Expected a User error")
     }
+}
+
+#[test]
+fn display_parse_error() {
+    let expr = "(1+\n(2++3))";
+    let err = expr_intern_tok::parse_Expr(1, expr).unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("Unrecognized token `+`"));
 }
 
 #[test]

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -163,7 +163,7 @@ fn expr_intern_tok_display_err() {
 
     // The problem is that (usize,&str) and () do not implement fmt::Display,
     // so neither does the ParseError.
-    // We can fix that by rewriting them to something else, such as a string.
+    // We can fix that by rewriting them to something that has fmt::Display
     let disp = err.map_tok(|(_,t)|t).map_err(|_| "error");
     assert!(disp.to_string().contains("Unrecognized token +"));
 

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -164,12 +164,12 @@ fn expr_intern_tok_display_err() {
     // The problem is that (usize,&str) and () do not implement fmt::Display,
     // so neither does the ParseError.
     // We can fix that by rewriting them to something that has fmt::Display
-    let disp = err.map_token(|(_,t)|t).map_err(|_| "error");
+    let disp = err.map_token(|(_,t)|t).map_error(|_| "error");
     let message = disp.to_string();
     assert!(message.contains("Unrecognized token `+`"));
 
     // We can even convert the locations to a line number
-    let line_based = disp.map_loc(|offset| {
+    let line_based = disp.map_location(|offset| {
         format!("line {}", expr[0..offset].lines().count())
     });
     assert!(line_based.to_string().contains("line 2"));

--- a/lalrpop-test/src/util/mod.rs
+++ b/lalrpop-test/src/util/mod.rs
@@ -9,7 +9,7 @@ use util::tok::Tok;
 pub mod tok;
 
 pub fn test<R: Debug + Eq, F>(parse_fn: F, input: &str, expected: R)
-    where F: FnOnce(Vec<Tok>) -> Result<R, ParseError<(), Tok, ()>>
+    where F: FnOnce(Vec<Tok>) -> Result<R, ParseError<(), Tok, &'static str>>
 {
     // create tokens
     let tokens = tok::tokenize(input);
@@ -29,7 +29,7 @@ pub fn test<R: Debug + Eq, F>(parse_fn: F, input: &str, expected: R)
 }
 
 pub fn test_loc<R: Debug + Eq, F>(parse_fn: F, input: &str, expected: R)
-    where F: FnOnce(Vec<(usize, Tok, usize)>) -> Result<R, ParseError<usize, Tok, ()>>
+    where F: FnOnce(Vec<(usize, Tok, usize)>) -> Result<R, ParseError<usize, Tok, &'static str>>
 {
     // create tokens
     let tokens = tok::tokenize(input);

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -51,7 +51,7 @@ impl<L, T, E> ParseError<L, T, E> {
         }
     }
 
-    pub fn map_loc<F,LL>(self, op: F) -> ParseError<LL, T, E> where F: Fn(L) -> LL {
+    pub fn map_location<F,LL>(self, op: F) -> ParseError<LL, T, E> where F: Fn(L) -> LL {
         self.map_intern(op, |x|x, |x|x)
     }
 
@@ -59,7 +59,7 @@ impl<L, T, E> ParseError<L, T, E> {
         self.map_intern(|x|x, op, |x|x)
     }
 
-    pub fn map_err<F,EE>(self, op: F) -> ParseError<L, T, EE> where F: Fn(E) -> EE {
+    pub fn map_error<F,EE>(self, op: F) -> ParseError<L, T, EE> where F: Fn(E) -> EE {
         self.map_intern(|x|x, |x|x, op)
     }
 }

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -120,16 +120,6 @@ pub struct ErrorRecovery<L, T, E> {
     pub dropped_tokens: Vec<(L, T, L)>,
 }
 
-// Only used by the internal tokenizer
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct InternalToken<'a>(pub usize, pub &'a str);
-
-impl<'a> fmt::Display for InternalToken<'a> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        self.1.fmt(formatter)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -120,6 +120,16 @@ pub struct ErrorRecovery<L, T, E> {
     pub dropped_tokens: Vec<(L, T, L)>,
 }
 
+// Only used by the internal tokenizer
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InternalToken<'a>(pub usize, pub &'a str);
+
+impl<'a> fmt::Display for InternalToken<'a> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.1.fmt(formatter)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -55,7 +55,7 @@ impl<L, T, E> ParseError<L, T, E> {
         self.map_intern(op, |x|x, |x|x)
     }
 
-    pub fn map_tok<F,TT>(self, op: F) -> ParseError<L, TT, E> where F: Fn(T) -> TT {
+    pub fn map_token<F,TT>(self, op: F) -> ParseError<L, TT, E> where F: Fn(T) -> TT {
         self.map_intern(|x|x, op, |x|x)
     }
 
@@ -77,7 +77,7 @@ where L: fmt::Display,
             UnrecognizedToken { ref token, ref expected } => {
                 match *token {
                     Some((ref start, ref token, ref end)) =>
-                        try!(write!(f, "Unrecognized token {} found at {}:{}", token, start, end)),
+                        try!(write!(f, "Unrecognized token `{}` found at {}:{}", token, start, end)),
                     None =>
                         try!(write!(f, "Unrecognized EOF")),
                 }
@@ -133,7 +133,7 @@ mod tests {
                 .map(|s| s.to_string())
                 .collect()
         };
-        assert_eq!(format!("{}", err), "Unrecognized token t0 found at 1:2\n\
+        assert_eq!(format!("{}", err), "Unrecognized token `t0` found at 1:2\n\
                                         Expected one of t1, t2 or t3");
     }
 }

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -404,6 +404,7 @@ fn emit_recursive_ascent(session: &Session, grammar: &r::Grammar, report_file : 
 
     if let Some(ref intern_token) = grammar.intern_token {
         try!(intern_token::compile(&grammar, intern_token, &mut rust));
+        rust!(rust, "pub use self::{}intern_token::Token;", grammar.prefix);
     }
 
     try!(action::emit_action_code(grammar, &mut rust));

--- a/lalrpop/src/grammar/pattern.rs
+++ b/lalrpop/src/grammar/pattern.rs
@@ -30,6 +30,7 @@ pub enum PatternKind<T> {
     Struct(Path, Vec<FieldPattern<T>>, /* trailing ..? */ bool),
     Path(Path),
     Tuple(Vec<Pattern<T>>),
+    TupleStruct(Path, Vec<Pattern<T>>),
     Usize(usize),
     Underscore,
     DotDot,
@@ -68,6 +69,8 @@ impl<T> PatternKind<T> {
                     dotdot),
             PatternKind::Tuple(ref pats) =>
                 PatternKind::Tuple(pats.iter().map(|p| p.map(map_fn)).collect()),
+            PatternKind::TupleStruct(ref path, ref pats) =>
+                PatternKind::TupleStruct(path.clone(), pats.iter().map(|p| p.map(map_fn)).collect()),
             PatternKind::Underscore =>
                 PatternKind::Underscore,
             PatternKind::DotDot =>
@@ -113,6 +116,8 @@ impl<T:Display> Display for PatternKind<T> {
                 write!(fmt, "{} {{ {}, .. }}", path, Sep(", ", fields)),
             PatternKind::Tuple(ref paths) =>
                 write!(fmt, "({})", Sep(", ", paths)),
+            PatternKind::TupleStruct(ref path, ref paths) =>
+                write!(fmt, "{}({})", path, Sep(", ", paths)),
             PatternKind::Underscore =>
                 write!(fmt, "_"),
             PatternKind::DotDot =>

--- a/lalrpop/src/grammar/repr.rs
+++ b/lalrpop/src/grammar/repr.rs
@@ -263,6 +263,7 @@ impl Types {
                 terminal_token_type: terminal_token_type,
                 terminal_types: map(),
                 nonterminal_types: map(),
+                // the following two will be overwritten later
                 parse_error_type: TypeRepr::Tuple(vec![]),
                 error_recovery_type: TypeRepr::Tuple(vec![]) };
 
@@ -314,7 +315,11 @@ impl Types {
 
     pub fn error_type(&self) -> TypeRepr {
         self.error_type.clone()
-                       .unwrap_or_else(|| TypeRepr::Tuple(vec![]))
+                       .unwrap_or_else(|| TypeRepr::Ref {
+                               lifetime: Some(intern("'static")),
+                               mutable: false,
+                               referent: Box::new(TypeRepr::str()),
+                       })
     }
 
     pub fn terminal_type(&self, id: TerminalString) -> &TypeRepr {

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -6,6 +6,15 @@ Generates an iterator type `__Matcher` that looks roughly like
 mod __intern_token {
     extern crate regex as __regex;
 
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Token<'input>(pub usize, pub &'input str);
+    //                           ~~~~~~     ~~~~~~~~~~~
+    //                           token      token
+    //                           index      text
+    //                           (type)
+
+    impl<'a> fmt::Display for Token<'a> { ... }
+
     pub struct __Matcher<'input> {
         text: &'input str,
         consumed: usize,
@@ -18,10 +27,9 @@ mod __intern_token {
     }
 
     impl<'input> Iterator for __Matcher<'input> {
-        type Item = Result<(usize, (usize, &'input str), usize), ParseError>;
-        //                  ~~~~~   ~~~~~  ~~~~~~~~~~~   ~~~~~
-        //                  start   token  token         end
-        //                          index  text
+        type Item = Result<(usize, Token<'input>, usize), ParseError>;
+        //                  ~~~~~  ~~~~~~~~~~~~~  ~~~~~
+        //                  start  token          end
     }
 }
 ```
@@ -47,6 +55,16 @@ pub fn compile<W: Write>(
     rust!(out, "#![allow(unused_imports)]");
     try!(out.write_uses("", &grammar));
     rust!(out, "extern crate regex as {}regex;", prefix);
+    rust!(out, "use std::fmt as {}fmt;", prefix);
+    rust!(out, "");
+    rust!(out, "#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]");
+    rust!(out, "pub struct Token<'input>(pub usize, pub &'input str);");
+    rust!(out, "impl<'a> {}fmt::Display for Token<'a> {{", prefix);
+    rust!(out, "fn fmt(&self, formatter: &mut {}fmt::Formatter) -> Result<(), {}fmt::Error> {{", prefix, prefix);
+    rust!(out, "{}fmt::Display::fmt(self.1, formatter)", prefix);
+    rust!(out, "}}");
+    rust!(out, "}}");
+    rust!(out, "");
     rust!(out, "pub struct {}Matcher<'input> {{", prefix);
     rust!(out, "text: &'input str,"); // remaining input
     rust!(out, "consumed: usize,"); // number of chars consumed thus far
@@ -102,9 +120,9 @@ pub fn compile<W: Write>(
     rust!(out, "}}"); // impl Matcher<'input>
     rust!(out, "");
     rust!(out, "impl<'input> Iterator for {}Matcher<'input> {{", prefix);
-    rust!(out, "type Item = Result<(usize, {}lalrpop_util::InternalToken<'input>, usize), \
-                {}lalrpop_util::ParseError<usize,{}lalrpop_util::InternalToken<'input>,{}>>;",
-          prefix, prefix, prefix,
+    rust!(out, "type Item = Result<(usize, Token<'input>, usize), \
+                {}lalrpop_util::ParseError<usize,Token<'input>,{}>>;",
+          prefix,
           grammar.types.error_type());
     rust!(out, "");
     rust!(out, "fn next(&mut self) -> Option<Self::Item> {{");
@@ -162,8 +180,8 @@ pub fn compile<W: Write>(
     rust!(out, "let {}end_offset = {}start_offset + {}longest_match;", prefix, prefix, prefix);
     rust!(out, "self.text = {}remaining;", prefix);
     rust!(out, "self.consumed = {}end_offset;", prefix);
-    rust!(out, "Some(Ok(({}start_offset, {}lalrpop_util::InternalToken({}index, {}result), {}end_offset)))",
-          prefix, prefix, prefix, prefix, prefix);
+    rust!(out, "Some(Ok(({}start_offset, Token({}index, {}result), {}end_offset)))",
+          prefix, prefix, prefix, prefix);
 
     rust!(out, "}}"); // else
     rust!(out, "}}"); // else

--- a/lalrpop/src/lexer/intern_token/mod.rs
+++ b/lalrpop/src/lexer/intern_token/mod.rs
@@ -102,9 +102,10 @@ pub fn compile<W: Write>(
     rust!(out, "}}"); // impl Matcher<'input>
     rust!(out, "");
     rust!(out, "impl<'input> Iterator for {}Matcher<'input> {{", prefix);
-    rust!(out, "type Item = Result<(usize, (usize, &'input str), usize), \
-                {}lalrpop_util::ParseError<usize,(usize, &'input str),{}>>;",
-          prefix, grammar.types.error_type());
+    rust!(out, "type Item = Result<(usize, {}lalrpop_util::InternalToken<'input>, usize), \
+                {}lalrpop_util::ParseError<usize,{}lalrpop_util::InternalToken<'input>,{}>>;",
+          prefix, prefix, prefix,
+          grammar.types.error_type());
     rust!(out, "");
     rust!(out, "fn next(&mut self) -> Option<Self::Item> {{");
 
@@ -161,8 +162,8 @@ pub fn compile<W: Write>(
     rust!(out, "let {}end_offset = {}start_offset + {}longest_match;", prefix, prefix, prefix);
     rust!(out, "self.text = {}remaining;", prefix);
     rust!(out, "self.consumed = {}end_offset;", prefix);
-    rust!(out, "Some(Ok(({}start_offset, ({}index, {}result), {}end_offset)))",
-          prefix, prefix, prefix, prefix);
+    rust!(out, "Some(Ok(({}start_offset, {}lalrpop_util::InternalToken({}index, {}result), {}end_offset)))",
+          prefix, prefix, prefix, prefix, prefix);
 
     rust!(out, "}}"); // else
     rust!(out, "}}"); // else

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -877,6 +877,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent,
             pattern_names.last().cloned().unwrap()
         });
 
+        /* banana */
         let mut pattern = format!("{}", pattern);
         if pattern_names.is_empty() {
             pattern_names.push(format!("{}tok", self.prefix));

--- a/lalrpop/src/lr1/codegen/ascent.rs
+++ b/lalrpop/src/lr1/codegen/ascent.rs
@@ -877,7 +877,6 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent,
             pattern_names.last().cloned().unwrap()
         });
 
-        /* banana */
         let mut pattern = format!("{}", pattern);
         if pattern_names.is_empty() {
             pattern_names.push(format!("{}tok", self.prefix));

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -131,6 +131,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
             }
         }
 
+        rust!(self.out, "#[allow(dead_code)]");
         try!(self.out.write_pub_fn_header(self.grammar,
                                           format!("parse_{}", self.user_start_symbol),
                                           type_parameters,

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -89,7 +89,9 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
     pub fn write_uses(&mut self) -> io::Result<()> {
         try!(self.out.write_uses(&format!("{}::", self.action_module), &self.grammar));
 
-        if self.grammar.intern_token.is_none() {
+        if self.grammar.intern_token.is_some() {
+            rust!(self.out, "use {}::{}intern_token::Token;", self.action_module, self.prefix);
+        } else {
             rust!(self.out, "use {}::{}ToTriple;", self.action_module, self.prefix);
         }
 

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -49,8 +49,7 @@ impl<'s> LowerState<'s> {
         let mut token_span = None;
         let internal_token_path = Path {
             absolute: false,
-            ids: vec![intern(&format!("{}lalrpop_util", grammar.prefix.clone())),
-                intern("InternalToken")],
+            ids: vec![intern("Token")],
         };
 
         for item in grammar.items {

--- a/lalrpop/src/normalize/lower/mod.rs
+++ b/lalrpop/src/normalize/lower/mod.rs
@@ -7,7 +7,7 @@ use normalize::norm_util::{self, Symbols};
 use grammar::consts::*;
 use grammar::pattern::{Pattern, PatternKind};
 use grammar::parse_tree as pt;
-use grammar::parse_tree::{InternToken, NonterminalString, TerminalString, read_algorithm};
+use grammar::parse_tree::{InternToken, NonterminalString, TerminalString, Path, read_algorithm};
 use grammar::repr as r;
 use session::Session;
 use collections::{map, Map};
@@ -47,6 +47,11 @@ impl<'s> LowerState<'s> {
 
         let mut uses = vec![];
         let mut token_span = None;
+        let internal_token_path = Path {
+            absolute: false,
+            ids: vec![intern(&format!("{}lalrpop_util", grammar.prefix.clone())),
+                intern("InternalToken")],
+        };
 
         for item in grammar.items {
             match item {
@@ -78,7 +83,7 @@ impl<'s> LowerState<'s> {
                             .map(|(index, match_entry)| {
                                 let pattern = Pattern {
                                     span: span,
-                                    kind: PatternKind::Tuple(vec![
+                                    kind: PatternKind::TupleStruct(internal_token_path.clone(), vec![
                                         Pattern {
                                             span: span,
                                             kind: PatternKind::Usize(index),

--- a/lalrpop/src/normalize/tyinfer/mod.rs
+++ b/lalrpop/src/normalize/tyinfer/mod.rs
@@ -85,12 +85,11 @@ impl<'grammar> TypeInferencer<'grammar> {
                     mutable: false,
                     referent: Box::new(TypeRepr::str())
                 };
-            let enum_type = // lalrpop_util::InternalToken<'input>
+            let enum_type = // Token<'input>
                 TypeRepr::Nominal(NominalTypeRepr {
                     path: Path {
                         absolute: false,
-                        ids: vec![intern(&format!("{}lalrpop_util", grammar.prefix)),
-                            intern("InternalToken")],
+                        ids: vec![intern("Token")],
                     },
                     types: vec![TypeRepr::Lifetime(intern(INPUT_LIFETIME))]
                 });

--- a/lalrpop/src/normalize/tyinfer/mod.rs
+++ b/lalrpop/src/normalize/tyinfer/mod.rs
@@ -85,8 +85,15 @@ impl<'grammar> TypeInferencer<'grammar> {
                     mutable: false,
                     referent: Box::new(TypeRepr::str())
                 };
-            let enum_type = // (usize, &'input str)
-                TypeRepr::Tuple(vec![TypeRepr::usize(), input_str.clone()]);
+            let enum_type = // lalrpop_util::InternalToken<'input>
+                TypeRepr::Nominal(NominalTypeRepr {
+                    path: Path {
+                        absolute: false,
+                        ids: vec![intern(&format!("{}lalrpop_util", grammar.prefix)),
+                            intern("InternalToken")],
+                    },
+                    types: vec![TypeRepr::Lifetime(intern(INPUT_LIFETIME))]
+                });
 
             let mut types = Types::new(&grammar.prefix, Some(loc_type), error_type, enum_type);
 

--- a/lalrpop/src/normalize/tyinfer/test.rs
+++ b/lalrpop/src/normalize/tyinfer/test.rs
@@ -220,6 +220,6 @@ fn error() {
 grammar;
     Z = !;
 "#, vec![
-    ("Z", "__lalrpop_util::ParseError<usize, (usize, &'input str), ()>")
+    ("Z", "__lalrpop_util::ParseError<usize, (usize, &'input str), &'static str>")
         ])
 }

--- a/lalrpop/src/normalize/tyinfer/test.rs
+++ b/lalrpop/src/normalize/tyinfer/test.rs
@@ -220,6 +220,6 @@ fn error() {
 grammar;
     Z = !;
 "#, vec![
-    ("Z", "__lalrpop_util::ParseError<usize, (usize, &'input str), &'static str>")
+    ("Z", "__lalrpop_util::ParseError<usize, __lalrpop_util::InternalToken<'input>, &'static str>")
         ])
 }

--- a/lalrpop/src/normalize/tyinfer/test.rs
+++ b/lalrpop/src/normalize/tyinfer/test.rs
@@ -220,6 +220,6 @@ fn error() {
 grammar;
     Z = !;
 "#, vec![
-    ("Z", "__lalrpop_util::ParseError<usize, __lalrpop_util::InternalToken<'input>, &'static str>")
+    ("Z", "__lalrpop_util::ParseError<usize, Token<'input>, &'static str>")
         ])
 }

--- a/lalrpop/src/rust/mod.rs
+++ b/lalrpop/src/rust/mod.rs
@@ -202,7 +202,9 @@ impl<W:Write> RustWrite<W> {
     }
 
     pub fn write_standard_uses(&mut self, prefix: &str) -> io::Result<()> {
-        // stuff that we plan to use
+        // Stuff that we plan to use.
+        // Occasionally we happen to not use it after all, hence the allow.
+        rust!(self, "#[allow(unused_extern_crates)]");
         rust!(self, "extern crate lalrpop_util as {}lalrpop_util;",
               prefix);
 


### PR DESCRIPTION
Because the types `(usize, &str)` and `()` do not implement `fmt::Display`, `lalrpop_util::ParseError<usize, (usize, &str),()>` doesn't either, which is a nuisance when displaying an error message.

I added three methods to ParseError that can be used to transform these types into more convenient types. They are of the form `fn map_loc<F,LL>(self, op: F) -> ParseError<LL, T, E> where F: Fn(L) -> LL`.

One use case is formatting, as above. Another is switching the `usize` byte offset locations into for example line/column numbers.

Although it is less pure, for user convenience it might be a good idea to use `String` rather than `()` as the default user-error type because strings have `fmt::Display`. I have not implemented this. Additionally, it might be an idea to add specific `Display` and `Error` impls for `ParseError<L,(usize,T),E>`. Together, these changes would make most ParseErrors printable, which seems desirable. I have not implemented this but will try if you'd like me to.
