### PR TITLE
Fix the "no-brackets" example code

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -970,7 +970,7 @@ the type will be replaced with "whatever the type of `T` is".
 Next, on (2), we parse `<v:(<T> ",")*> <e:T?>`.  That's a lot of
 symbols, so let's first remove all the angle brackets, which just
 serve to tell LALRPOP what values you want to propagate and which you
-want to discard. In that case, we have: `(T ",")* e?`. Hopefully you
+want to discard. In that case, we have: `(T ",")* T?`. Hopefully you
 can see that this matches a comma-separated list with an optional
 trailing comma. Now let's add those angle-brackets back in. In the
 parentheses, we get `(<T> ",")*` -- this just means that we keep the


### PR DESCRIPTION
It translated `<e:T?>` into `e?`, when it should've been `T?`.

`<e:T?>` is a nonterminal bound to the name, `T?` is a nonterminal bound to no name, and `e?` is meaningless.