### PR TITLE
Return grammar errors first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ doc/whitespace/src/parser.rs
 
 lalrpop-test/src/error.rs
 lalrpop-test/src/error_issue_113.rs
+lalrpop-test/src/error_issue_278.rs
 lalrpop-test/src/error_recovery.rs
 lalrpop-test/src/error_recovery_pull_182.rs
 lalrpop-test/src/expr.rs

--- a/lalrpop-test/src/error_issue_278.lalrpop
+++ b/lalrpop-test/src/error_issue_278.lalrpop
@@ -1,0 +1,11 @@
+use lalrpop_util::ParseError;
+
+grammar;
+
+extern {
+	type Error = &'static str;
+}
+
+pub Value = <Int> "abc";
+
+Int: u64 = r"\d+" =>? Err(ParseError::User{ error: "Pretend there was an error" });

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -96,6 +96,9 @@ mod match_section;
 /// regression test for issue #253.
 mod partial_parse;
 
+/// regression test for issue #278.
+mod error_issue_278;
+
 // Check that error recovery (which requires cloneable tokens) is not created if it is not used
 #[allow(unused)]
 mod no_clone_tok;
@@ -506,4 +509,14 @@ fn test_action_return_associated_types() {
         associated_types::parse_Term(&mut callbacks, "(((((42)))))"),
         Ok(associated_types_lib::TestTerm(associated_types_lib::TestNum(42)))
     );
+}
+
+#[test]
+fn error_issue_278() {
+    match error_issue_278::parse_Value("123 abc") {
+        Err(ParseError::User { error: "Pretend there was an error" }) => { /* OK! */ }
+        r => {
+            panic!("unexpected response from parser: {:?}", r);
+        }
+    }
 }

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -104,7 +104,11 @@ pub fn compile<'grammar, W: Write>(grammar: &'grammar Grammar,
 //                symbols.push(symbol);
 //                continue 'shift;
 //            } else if action < 0 { // reduce
-//                if let Some(_) = reduce(action, Some(&lookahead.0), &mut states, &mut symbols) {
+//                if let Some(r) = reduce(action, Some(&lookahead.0), &mut states, &mut symbols) {
+//                    // Give errors from within grammar a higher priority
+//                    if r.is_err() {
+//                        return r;
+//                    }
 //                    return Err(lalrpop_util::ParseError::ExtraToken { token: lookahead });
 //                }
 //            } else {
@@ -513,7 +517,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             rust!(self.out, "println!(\"--> reduce\");");
         }
         rust!(self.out,
-              "if let Some(_) = {}reduce({}{}action, Some(&{}lookahead.0), &mut {}states, &mut \
+              "if let Some(r) = {}reduce({}{}action, Some(&{}lookahead.0), &mut {}states, &mut \
                {}symbols, {}) {{",
               self.prefix,
               self.grammar.user_parameter_refs(),
@@ -522,6 +526,9 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
               self.prefix,
               self.prefix,
               phantom_data_expr);
+        rust!(self.out, "if r.is_err() {{");
+        rust!(self.out, "return r;");
+        rust!(self.out, "}}");
         rust!(self.out,
               "return Err({}lalrpop_util::ParseError::ExtraToken {{ token: {}lookahead }});",
               self.prefix,


### PR DESCRIPTION
If some production in the grammar returns an error, give it priority
over built-in errors.

Fixes #278.