### PR TITLE
Rework error recovery mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ lalrpop-test/src/error_issue_113.rs
 lalrpop-test/src/error_recovery.rs
 lalrpop-test/src/error_recovery_pull_182.rs
 lalrpop-test/src/error_recovery_issue_240.rs
+lalrpop-test/src/error_recovery_lock_in.rs
 lalrpop-test/src/expr.rs
 lalrpop-test/src/expr_arena.rs
 lalrpop-test/src/expr_generic.rs

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lalrpop-test/src/error_recovery.rs
 lalrpop-test/src/error_recovery_pull_182.rs
 lalrpop-test/src/error_recovery_issue_240.rs
 lalrpop-test/src/error_recovery_lock_in.rs
+lalrpop-test/src/error_recovery_lalr_loop.rs
 lalrpop-test/src/expr.rs
 lalrpop-test/src/expr_arena.rs
 lalrpop-test/src/expr_generic.rs

--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,13 @@ lalrpop-test/src/error.rs
 lalrpop-test/src/error_issue_113.rs
 lalrpop-test/src/error_recovery.rs
 lalrpop-test/src/error_recovery_pull_182.rs
+lalrpop-test/src/error_recovery_issue_240.rs
 lalrpop-test/src/expr.rs
 lalrpop-test/src/expr_arena.rs
 lalrpop-test/src/expr_generic.rs
 lalrpop-test/src/expr_intern_tok.rs
 lalrpop-test/src/expr_lalr.rs
+lalrpop-test/src/expr_module_attributes.rs
 lalrpop-test/src/generics_issue_104.rs
 lalrpop-test/src/inline.rs
 lalrpop-test/src/intern_tok.rs

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ lalrpop-test/src/error_recovery_pull_182.rs
 lalrpop-test/src/error_recovery_issue_240.rs
 lalrpop-test/src/error_recovery_lock_in.rs
 lalrpop-test/src/error_recovery_lalr_loop.rs
+lalrpop-test/src/error_recovery_span.rs
 lalrpop-test/src/expr.rs
 lalrpop-test/src/expr_arena.rs
 lalrpop-test/src/expr_generic.rs

--- a/lalrpop-test/src/associated_types.rs
+++ b/lalrpop-test/src/associated_types.rs
@@ -1,21 +1,25 @@
 // auto-generated: "lalrpop 0.13.1"
 use std::str::FromStr;
 use associated_types_lib::ParseCallbacks;
+#[allow(unused_extern_crates)]
 extern crate lalrpop_util as __lalrpop_util;
 
 mod __parse__Term {
-    #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
+    #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens)]
 
     use std::str::FromStr;
     use associated_types_lib::ParseCallbacks;
+    #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
+    use super::__intern_token::Token;
+    #[allow(dead_code)]
     pub fn parse_Term<
         'input,
         P,
     >(
         callbacks: &mut P,
         input: &'input str,
-    ) -> Result<P::Term, __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+    ) -> Result<P::Term, __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
       P:  ParseCallbacks,
     {
         let __ascent = __ascent::parse_Term::<P>(
@@ -32,18 +36,21 @@ mod __parse__Term {
     mod __ascent {
 
         mod __parse__Term {
-            #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
+            #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens)]
 
             use std::str::FromStr;
             use associated_types_lib::ParseCallbacks;
+            #[allow(unused_extern_crates)]
             extern crate lalrpop_util as __lalrpop_util;
+            use super::super::super::__intern_token::Token;
+            #[allow(dead_code)]
             pub fn parse_Term<
                 'input,
                 P,
             >(
                 callbacks: &mut P,
                 input: &'input str,
-            ) -> Result<P::Term, __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<P::Term, __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               P:  ParseCallbacks,
             {
                 let mut __tokens = super::super::super::__intern_token::__Matcher::new(input);
@@ -93,23 +100,23 @@ mod __parse__Term {
             fn __state0<
                 'input,
                 P,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 callbacks: &mut P,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
-                __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                __lookahead: Option<(usize, Token<'input>, usize)>,
                 _: ::std::marker::PhantomData<(P)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               P:  ParseCallbacks,
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<P>);
                 match __lookahead {
-                    Some((__loc1, (1, __tok0), __loc2)) => {
+                    Some((__loc1, Token(1, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
                         __result = try!(__state3(callbacks, input, __tokens, __sym0, ::std::marker::PhantomData::<(P)>));
                     }
-                    Some((__loc1, (0, __tok0), __loc2)) => {
+                    Some((__loc1, Token(0, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
                         __result = try!(__state4(callbacks, input, __tokens, __sym0, ::std::marker::PhantomData::<(P)>));
                     }
@@ -149,27 +156,25 @@ mod __parse__Term {
             //
             //     Term = Num (*) ["(", ")", r#"[0-9]+"#, EOF]
             //
-            //   ["(", ")", r#"[0-9]+"#, EOF] -> Term = Num => ActionFn(1);
+            //   [")", EOF] -> Term = Num => ActionFn(1);
             //
             fn __state1<
                 'input,
                 P,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 callbacks: &mut P,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
-                __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                __lookahead: Option<(usize, Token<'input>, usize)>,
                 __sym0: (usize, P::Num, usize),
                 _: ::std::marker::PhantomData<(P)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               P:  ParseCallbacks,
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<P>);
                 match __lookahead {
-                    Some((_, (1, _), _)) |
-                    Some((_, (2, _), _)) |
-                    Some((_, (0, _), _)) |
+                    Some((_, Token(2, _), _)) |
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
@@ -186,9 +191,7 @@ mod __parse__Term {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
                             token: __lookahead,
                             expected: vec![
-                                r###""(""###.to_string(),
                                 r###"")""###.to_string(),
-                                r###"r#"[0-9]+"#"###.to_string(),
                             ]
                         });
                     }
@@ -205,27 +208,24 @@ mod __parse__Term {
             //
             //     __Term = Term (*) ["(", ")", r#"[0-9]+"#, EOF]
             //
-            //   ["(", ")", r#"[0-9]+"#, EOF] -> __Term = Term => ActionFn(0);
+            //   [EOF] -> __Term = Term => ActionFn(0);
             //
             fn __state2<
                 'input,
                 P,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 callbacks: &mut P,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
-                __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                __lookahead: Option<(usize, Token<'input>, usize)>,
                 __sym0: (usize, P::Term, usize),
                 _: ::std::marker::PhantomData<(P)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               P:  ParseCallbacks,
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<P>);
                 match __lookahead {
-                    Some((_, (1, _), _)) |
-                    Some((_, (2, _), _)) |
-                    Some((_, (0, _), _)) |
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
@@ -242,9 +242,6 @@ mod __parse__Term {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
                             token: __lookahead,
                             expected: vec![
-                                r###""(""###.to_string(),
-                                r###"")""###.to_string(),
-                                r###"r#"[0-9]+"#"###.to_string(),
                             ]
                         });
                     }
@@ -272,28 +269,28 @@ mod __parse__Term {
             fn __state3<
                 'input,
                 P,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 callbacks: &mut P,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
                 _: ::std::marker::PhantomData<(P)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               P:  ParseCallbacks,
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<P>);
                 let __lookahead = match __tokens.next() {
                     Some(Ok(v)) => Some(v),
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
                 match __lookahead {
-                    Some((__loc1, (1, __tok0), __loc2)) => {
+                    Some((__loc1, Token(1, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
                         __result = try!(__state3(callbacks, input, __tokens, __sym1, ::std::marker::PhantomData::<(P)>));
                     }
-                    Some((__loc1, (0, __tok0), __loc2)) => {
+                    Some((__loc1, Token(0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
                         __result = try!(__state4(callbacks, input, __tokens, __sym1, ::std::marker::PhantomData::<(P)>));
                     }
@@ -334,31 +331,29 @@ mod __parse__Term {
             //
             //     Num = r#"[0-9]+"# (*) ["(", ")", r#"[0-9]+"#, EOF]
             //
-            //   ["(", ")", r#"[0-9]+"#, EOF] -> Num = r#"[0-9]+"# => ActionFn(3);
+            //   [")", EOF] -> Num = r#"[0-9]+"# => ActionFn(3);
             //
             fn __state4<
                 'input,
                 P,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 callbacks: &mut P,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
                 _: ::std::marker::PhantomData<(P)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               P:  ParseCallbacks,
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<P>);
                 let __lookahead = match __tokens.next() {
                     Some(Ok(v)) => Some(v),
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
                 match __lookahead {
-                    Some((_, (1, _), _)) |
-                    Some((_, (2, _), _)) |
-                    Some((_, (0, _), _)) |
+                    Some((_, Token(2, _), _)) |
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
@@ -375,9 +370,7 @@ mod __parse__Term {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
                             token: __lookahead,
                             expected: vec![
-                                r###""(""###.to_string(),
                                 r###"")""###.to_string(),
-                                r###"r#"[0-9]+"#"###.to_string(),
                             ]
                         });
                     }
@@ -399,21 +392,21 @@ mod __parse__Term {
             fn __state5<
                 'input,
                 P,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 callbacks: &mut P,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
-                __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                __lookahead: Option<(usize, Token<'input>, usize)>,
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, P::Term, usize),
                 _: ::std::marker::PhantomData<(P)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               P:  ParseCallbacks,
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<P>);
                 match __lookahead {
-                    Some((__loc1, (2, __tok0), __loc2)) => {
+                    Some((__loc1, Token(2, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
                         __result = try!(__state6(callbacks, input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(P)>));
                         return Ok(__result);
@@ -439,12 +432,12 @@ mod __parse__Term {
             //
             //     Term = "(" Term ")" (*) ["(", ")", r#"[0-9]+"#, EOF]
             //
-            //   ["(", ")", r#"[0-9]+"#, EOF] -> Term = "(", Term, ")" => ActionFn(2);
+            //   [")", EOF] -> Term = "(", Term, ")" => ActionFn(2);
             //
             fn __state6<
                 'input,
                 P,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 callbacks: &mut P,
                 input: &'input str,
@@ -453,19 +446,17 @@ mod __parse__Term {
                 __sym1: (usize, P::Term, usize),
                 __sym2: (usize, &'input str, usize),
                 _: ::std::marker::PhantomData<(P)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<P>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               P:  ParseCallbacks,
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<P>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<P>);
                 let __lookahead = match __tokens.next() {
                     Some(Ok(v)) => Some(v),
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
                 match __lookahead {
-                    Some((_, (1, _), _)) |
-                    Some((_, (2, _), _)) |
-                    Some((_, (0, _), _)) |
+                    Some((_, Token(2, _), _)) |
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
@@ -482,9 +473,7 @@ mod __parse__Term {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
                             token: __lookahead,
                             expected: vec![
-                                r###""(""###.to_string(),
                                 r###"")""###.to_string(),
-                                r###"r#"[0-9]+"#"###.to_string(),
                             ]
                         });
                     }
@@ -496,11 +485,13 @@ mod __parse__Term {
     mod __parse_table {
 
         mod __parse__Term {
-            #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
+            #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens)]
 
             use std::str::FromStr;
             use associated_types_lib::ParseCallbacks;
+            #[allow(unused_extern_crates)]
             extern crate lalrpop_util as __lalrpop_util;
+            use super::super::super::__intern_token::Token;
             #[allow(dead_code)]
             pub enum __Symbol<'input, P>
              where P:  ParseCallbacks
@@ -524,15 +515,15 @@ mod __parse__Term {
 
                 // State 1
                 //     Term = Num (*) ["(", ")", r#"[0-9]+"#, EOF]
-                -2,  // on "(", reduce `Term = Num => ActionFn(1);`
+                0,  // on "(", error
                 -2,  // on ")", reduce `Term = Num => ActionFn(1);`
-                -2,  // on r#"[0-9]+"#, reduce `Term = Num => ActionFn(1);`
+                0,  // on r#"[0-9]+"#, error
 
                 // State 2
                 //     __Term = Term (*) ["(", ")", r#"[0-9]+"#, EOF]
-                -4,  // on "(", reduce `__Term = Term => ActionFn(0);`
-                -4,  // on ")", reduce `__Term = Term => ActionFn(0);`
-                -4,  // on r#"[0-9]+"#, reduce `__Term = Term => ActionFn(0);`
+                0,  // on "(", error
+                0,  // on ")", error
+                0,  // on r#"[0-9]+"#, error
 
                 // State 3
                 //     Num = (*) r#"[0-9]+"# ["(", ")", r#"[0-9]+"#, EOF]
@@ -545,9 +536,9 @@ mod __parse__Term {
 
                 // State 4
                 //     Num = r#"[0-9]+"# (*) ["(", ")", r#"[0-9]+"#, EOF]
-                -1,  // on "(", reduce `Num = r#"[0-9]+"# => ActionFn(3);`
+                0,  // on "(", error
                 -1,  // on ")", reduce `Num = r#"[0-9]+"# => ActionFn(3);`
-                -1,  // on r#"[0-9]+"#, reduce `Num = r#"[0-9]+"# => ActionFn(3);`
+                0,  // on r#"[0-9]+"#, error
 
                 // State 5
                 //     Term = "(" Term (*) ")" ["(", ")", r#"[0-9]+"#, EOF]
@@ -557,24 +548,31 @@ mod __parse__Term {
 
                 // State 6
                 //     Term = "(" Term ")" (*) ["(", ")", r#"[0-9]+"#, EOF]
-                -3,  // on "(", reduce `Term = "(", Term, ")" => ActionFn(2);`
+                0,  // on "(", error
                 -3,  // on ")", reduce `Term = "(", Term, ")" => ActionFn(2);`
-                -3,  // on r#"[0-9]+"#, reduce `Term = "(", Term, ")" => ActionFn(2);`
+                0,  // on r#"[0-9]+"#, error
 
             ];
             const __EOF_ACTION: &'static [i32] = &[
+                // State 0
                 0,  // on EOF, error
 
+                // State 1
                 -2,  // on EOF, reduce `Term = Num => ActionFn(1);`
 
+                // State 2
                 -4,  // on EOF, reduce `__Term = Term => ActionFn(0);`
 
+                // State 3
                 0,  // on EOF, error
 
+                // State 4
                 -1,  // on EOF, reduce `Num = r#"[0-9]+"# => ActionFn(3);`
 
+                // State 5
                 0,  // on EOF, error
 
+                // State 6
                 -3,  // on EOF, reduce `Term = "(", Term, ")" => ActionFn(2);`
 
             ];
@@ -629,13 +627,14 @@ mod __parse__Term {
                     }
                 }).collect()
             }
+            #[allow(dead_code)]
             pub fn parse_Term<
                 'input,
                 P,
             >(
                 callbacks: &mut P,
                 input: &'input str,
-            ) -> Result<P::Term, __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<P::Term, __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               P:  ParseCallbacks,
             {
                 let mut __tokens = super::super::super::__intern_token::__Matcher::new(input);
@@ -643,18 +642,18 @@ mod __parse__Term {
                 let mut __symbols = vec![];
                 let mut __integer;
                 let mut __lookahead;
-                let mut __last_location = Default::default();
+                let __last_location = &mut Default::default();
                 '__shift: loop {
                     __lookahead = match __tokens.next() {
                         Some(Ok(v)) => v,
                         None => break '__shift,
                         Some(Err(e)) => return Err(e),
                     };
-                    __last_location = __lookahead.2.clone();
+                    *__last_location = __lookahead.2.clone();
                     __integer = match __lookahead.1 {
-                        (1, _) if true => 0,
-                        (2, _) if true => 1,
-                        (0, _) if true => 2,
+                        Token(1, _) if true => 0,
+                        Token(2, _) if true => 1,
+                        Token(0, _) if true => 2,
                         _ => {
                             let __state = *__states.last().unwrap() as usize;
                             let __error = __lalrpop_util::ParseError::UnrecognizedToken {
@@ -670,15 +669,15 @@ mod __parse__Term {
                         if __action > 0 {
                             let __symbol = match __integer {
                                 0 => match __lookahead.1 {
-                                    (1, __tok0) => __Symbol::Term_22_28_22((__tok0)),
+                                    Token(1, __tok0) => __Symbol::Term_22_28_22((__tok0)),
                                     _ => unreachable!(),
                                 },
                                 1 => match __lookahead.1 {
-                                    (2, __tok0) => __Symbol::Term_22_29_22((__tok0)),
+                                    Token(2, __tok0) => __Symbol::Term_22_29_22((__tok0)),
                                     _ => unreachable!(),
                                 },
                                 2 => match __lookahead.1 {
-                                    (0, __tok0) => __Symbol::Termr_23_22_5b0_2d9_5d_2b_22_23((__tok0)),
+                                    Token(0, __tok0) => __Symbol::Termr_23_22_5b0_2d9_5d_2b_22_23((__tok0)),
                                     _ => unreachable!(),
                                 },
                                 _ => unreachable!(),
@@ -691,9 +690,11 @@ mod __parse__Term {
                                 return Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead });
                             }
                         } else {
+                            let mut __err_lookahead = Some(__lookahead);
+                            let mut __err_integer: Option<usize> = Some(__integer);
                             let __state = *__states.last().unwrap() as usize;
                             let __error = __lalrpop_util::ParseError::UnrecognizedToken {
-                                token: Some(__lookahead),
+                                token: __err_lookahead,
                                 expected: __expected_tokens(__state),
                             };
                             return Err(__error)
@@ -708,12 +709,14 @@ mod __parse__Term {
                             return r;
                         }
                     } else {
+                        let mut __err_lookahead = None;
+                        let mut __err_integer: Option<usize> = None;
                         let __state = *__states.last().unwrap() as usize;
                         let __error = __lalrpop_util::ParseError::UnrecognizedToken {
-                            token: None,
+                            token: __err_lookahead,
                             expected: __expected_tokens(__state),
                         };
-                        return Err(__error);
+                        return Err(__error)
                     }
                 }
             }
@@ -728,7 +731,7 @@ mod __parse__Term {
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input, P>,usize)>,
                 _: ::std::marker::PhantomData<(P)>,
-            ) -> Option<Result<P::Term,__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>> where
+            ) -> Option<Result<P::Term,__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>> where
               P:  ParseCallbacks,
             {
                 let __nonterminal = match -__action {
@@ -869,8 +872,19 @@ mod __intern_token {
     #![allow(unused_imports)]
     use std::str::FromStr;
     use associated_types_lib::ParseCallbacks;
+    #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
     extern crate regex as __regex;
+    use std::fmt as __fmt;
+
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Token<'input>(pub usize, pub &'input str);
+    impl<'a> __fmt::Display for Token<'a> {
+        fn fmt(&self, formatter: &mut __fmt::Formatter) -> Result<(), __fmt::Error> {
+            __fmt::Display::fmt(self.1, formatter)
+        }
+    }
+
     pub struct __Matcher<'input> {
         text: &'input str,
         consumed: usize,
@@ -901,7 +915,7 @@ mod __intern_token {
     }
 
     impl<'input> Iterator for __Matcher<'input> {
-        type Item = Result<(usize, (usize, &'input str), usize), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>;
+        type Item = Result<(usize, Token<'input>, usize), __lalrpop_util::ParseError<usize,Token<'input>,&'static str>>;
 
         fn next(&mut self) -> Option<Self::Item> {
             let __text = self.text.trim_left();
@@ -935,12 +949,13 @@ mod __intern_token {
                     let __end_offset = __start_offset + __longest_match;
                     self.text = __remaining;
                     self.consumed = __end_offset;
-                    Some(Ok((__start_offset, (__index, __result), __end_offset)))
+                    Some(Ok((__start_offset, Token(__index, __result), __end_offset)))
                 }
             }
         }
     }
 }
+pub use self::__intern_token::Token;
 
 #[allow(unused_variables)]
 fn __action0<
@@ -1002,18 +1017,18 @@ fn __action3<
 
 pub trait __ToTriple<'input, P, > {
     type Error;
-    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),Self::Error>;
+    fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize),Self::Error>;
 }
 
-impl<'input, P, > __ToTriple<'input, P, > for (usize, (usize, &'input str), usize) {
-    type Error = ();
-    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),()> {
+impl<'input, P, > __ToTriple<'input, P, > for (usize, Token<'input>, usize) {
+    type Error = &'static str;
+    fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize),&'static str> {
         Ok(value)
     }
 }
-impl<'input, P, > __ToTriple<'input, P, > for Result<(usize, (usize, &'input str), usize),()> {
-    type Error = ();
-    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),()> {
+impl<'input, P, > __ToTriple<'input, P, > for Result<(usize, Token<'input>, usize),&'static str> {
+    type Error = &'static str;
+    fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize),&'static str> {
         value
     }
 }

--- a/lalrpop-test/src/error_recovery_issue_240.lalrpop
+++ b/lalrpop-test/src/error_recovery_issue_240.lalrpop
@@ -1,0 +1,33 @@
+use util::tok::Tok;
+use lalrpop_util::ErrorRecovery;
+
+grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<(), Tok, ()>>);
+
+extern {
+    enum Tok {
+        "(" => Tok::LParen,
+        ")" => Tok::RParen,
+        "+" => Tok::Plus,
+        "-" => Tok::Minus,
+        "/" => Tok::Div,
+        Num => Tok::Num(<i32>)
+    }
+}
+
+SkipExtraTokens: () = {
+    => (),
+    <!> => errors.push(<>),
+};
+
+pub Expr: ()  = {
+    Num => (),
+    "+" Expr => (),
+    Paren,
+    ! => {
+        errors.push(<>);
+    }
+};
+
+Paren: ()  = {
+    "(" Expr ")" => (),
+};

--- a/lalrpop-test/src/error_recovery_issue_240.lalrpop
+++ b/lalrpop-test/src/error_recovery_issue_240.lalrpop
@@ -1,9 +1,11 @@
 use util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
-grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<(), Tok, ()>>);
+#[LALR]
+grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<usize, Tok, ()>>);
 
 extern {
+    type Location = usize;
     enum Tok {
         "(" => Tok::LParen,
         ")" => Tok::RParen,

--- a/lalrpop-test/src/error_recovery_issue_240.lalrpop
+++ b/lalrpop-test/src/error_recovery_issue_240.lalrpop
@@ -2,7 +2,7 @@ use util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
 #[LALR]
-grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<usize, Tok, ()>>);
+grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<usize, Tok, &'static str>>);
 
 extern {
     type Location = usize;

--- a/lalrpop-test/src/error_recovery_lalr_loop.lalrpop
+++ b/lalrpop-test/src/error_recovery_lalr_loop.lalrpop
@@ -2,7 +2,7 @@ use util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
 #[LALR]
-grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<usize, Tok, ()>>);
+grammar<'input, 'e>(errors: &'e mut Vec<(usize, ErrorRecovery<usize, Tok, &'static str>, usize)>);
 
 extern {
     type Location = usize;
@@ -18,7 +18,7 @@ extern {
 
 SkipExtraTokens: () = {
     => (),
-    <!> => errors.push(<>),
+    @L ! @R => errors.push((<>)),
 };
 
 pub Expr: ()  = {
@@ -28,8 +28,8 @@ pub Expr: ()  = {
     Expr "+" Expr1 => (),
     Expr "-" Expr1 => (),
     Paren,
-    ! => {
-        errors.push(<>);
+    @L ! @R => {
+        errors.push((<>));
     }
 };
 

--- a/lalrpop-test/src/error_recovery_lalr_loop.lalrpop
+++ b/lalrpop-test/src/error_recovery_lalr_loop.lalrpop
@@ -1,0 +1,42 @@
+use util::tok::Tok;
+use lalrpop_util::ErrorRecovery;
+
+#[LALR]
+grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<usize, Tok, ()>>);
+
+extern {
+    type Location = usize;
+    enum Tok {
+        "(" => Tok::LParen,
+        ")" => Tok::RParen,
+        "+" => Tok::Plus,
+        "-" => Tok::Minus,
+        "/" => Tok::Div,
+        Num => Tok::Num(<i32>)
+    }
+}
+
+SkipExtraTokens: () = {
+    => (),
+    <!> => errors.push(<>),
+};
+
+pub Expr: ()  = {
+    Expr1 => (),
+    "+" Expr1 => (),
+    Expr "/" Expr1 => (),
+    Expr "+" Expr1 => (),
+    Expr "-" Expr1 => (),
+    Paren,
+    ! => {
+        errors.push(<>);
+    }
+};
+
+Expr1: ()  = {
+    Num => (),
+};
+
+Paren: ()  = {
+    "(" Expr ")" => (),
+};

--- a/lalrpop-test/src/error_recovery_lock_in.lalrpop
+++ b/lalrpop-test/src/error_recovery_lock_in.lalrpop
@@ -1,7 +1,7 @@
 use util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
-grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<usize, Tok, ()>>);
+grammar<'input, 'e>(errors: &'e mut Vec<(usize, ErrorRecovery<usize, Tok, &'static str>, usize)>);
 
 extern {
     type Location = usize;
@@ -15,22 +15,18 @@ extern {
     }
 }
 
-SkipExtraTokens: () = {
-    => (),
-    <!> => errors.push(<>),
-};
-
 pub A: () = {
     "(" B ")",
     A "/" Num,
-    ! => {
-        errors.push(<>);
+    @L ! @R => {
+        errors.push((<>));
     }
 };
 
 B: ()  = {
     Num => (),
-    ! => {
-        errors.push(<>);
+    @L ! @R => {
+        // the test input should not lead us to recover from here
+        panic!("should not get here!");
     }
 };

--- a/lalrpop-test/src/error_recovery_lock_in.lalrpop
+++ b/lalrpop-test/src/error_recovery_lock_in.lalrpop
@@ -1,0 +1,37 @@
+use util::tok::Tok;
+use lalrpop_util::ErrorRecovery;
+
+#[LALR]
+grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<usize, Tok, ()>>);
+
+extern {
+    type Location = usize;
+    enum Tok {
+        "(" => Tok::LParen,
+        ")" => Tok::RParen,
+        "+" => Tok::Plus,
+        "-" => Tok::Minus,
+        "/" => Tok::Div,
+        Num => Tok::Num(<i32>)
+    }
+}
+
+SkipExtraTokens: () = {
+    => (),
+    <!> => errors.push(<>),
+};
+
+pub A: () = {
+    "(" B ")",
+    A "/" Num,
+    ! => {
+        errors.push(<>);
+    }
+};
+
+B: ()  = {
+    Num => (),
+    ! => {
+        errors.push(<>);
+    }
+};

--- a/lalrpop-test/src/error_recovery_lock_in.lalrpop
+++ b/lalrpop-test/src/error_recovery_lock_in.lalrpop
@@ -1,7 +1,6 @@
 use util::tok::Tok;
 use lalrpop_util::ErrorRecovery;
 
-#[LALR]
 grammar<'input, 'e>(errors: &'e mut Vec<ErrorRecovery<usize, Tok, ()>>);
 
 extern {

--- a/lalrpop-test/src/error_recovery_span.lalrpop
+++ b/lalrpop-test/src/error_recovery_span.lalrpop
@@ -1,0 +1,48 @@
+use util::tok::Tok;
+
+grammar<'e>(errors: &'e mut Vec<(usize, usize)>);
+
+extern {
+    type Location = usize;
+    enum Tok {
+        "-" => Tok::Minus,
+        "+" => Tok::Plus,
+        "/" => Tok::Div,
+        "(" => Tok::LParen,
+        ")" => Tok::RParen,
+        Num => Tok::Num(<i32>)
+    }
+}
+
+pub Expr: String = {
+    Expr1,
+    <Expr> "+" <Expr1> => format!("{} + {}", <>),
+    <Expr> "-" <Expr1> => format!("{} - {}", <>),
+
+    // NB we intentionally cannot recover from a `"+"` here,
+    // just a `"-"`. This allows us to test when we must drop
+    // the `"+"` to recover.
+    <n:Expr> "-" <l:@L> ! <r:@R> => {
+        errors.push((l, r));
+        format!("{} -!", n)
+    },
+
+    <n:Expr> <l:@L> ! <r:@R> => {
+        errors.push((l, r));
+        n
+    },
+
+    <@L> ! <@R> => {
+        errors.push((<>));
+        format!("!")
+    },
+};
+
+Expr1: String = {
+    Expr2,
+};
+
+Expr2: String = {
+    Num => format!("{:?}", <>),
+    "(" <Expr> ")" => format!("({})", <>),
+};

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -83,6 +83,7 @@ mod error_issue_113;
 /// Test error recovery
 mod error_recovery;
 mod error_recovery_pull_182;
+mod error_recovery_issue_240;
 
 /// test for inlining expansion issue #55
 mod issue_55;
@@ -435,6 +436,14 @@ fn error_recovery_dont_panic_on_reduce_at_eof() {
     util::test(|v| error_recovery_pull_182::parse_Item(&mut errors, v), "1+", ());
 
     assert_eq!(errors.len(), 1);
+}
+
+#[test]
+fn error_recovery_issue_240() {
+    let mut errors = vec![];
+    util::test(|v| error_recovery_issue_240::parse_Expr(&mut errors, v), "(+1/", ());
+
+    assert_eq!(errors.len(), 1, "{:?}", errors);
 }
 
 #[test]

--- a/lalrpop-test/src/main.rs
+++ b/lalrpop-test/src/main.rs
@@ -441,9 +441,17 @@ fn error_recovery_dont_panic_on_reduce_at_eof() {
 #[test]
 fn error_recovery_issue_240() {
     let mut errors = vec![];
-    util::test(|v| error_recovery_issue_240::parse_Expr(&mut errors, v), "(+1/", ());
 
-    assert_eq!(errors.len(), 1, "{:?}", errors);
+    match util::test_err_gen(|v| error_recovery_issue_240::parse_Expr(&mut errors, v), "(+1/") {
+        Err(ParseError::UnrecognizedToken { expected, token: _ }) => {
+            assert_eq!(expected, vec![format!(r#"")""#)]);
+        }
+        r => {
+            panic!("unexpected response from parser: {:?}", r);
+        }
+    }
+
+    assert_eq!(errors, vec![]);
 }
 
 #[test]

--- a/lalrpop-test/src/where_clause_with_forall.rs
+++ b/lalrpop-test/src/where_clause_with_forall.rs
@@ -1,19 +1,23 @@
 // auto-generated: "lalrpop 0.13.1"
 use std::str::FromStr;
+#[allow(unused_extern_crates)]
 extern crate lalrpop_util as __lalrpop_util;
 
 mod __parse__Term {
-    #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
+    #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens)]
 
     use std::str::FromStr;
+    #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
+    use super::__intern_token::Token;
+    #[allow(dead_code)]
     pub fn parse_Term<
         'input,
         F,
     >(
         logger: &mut F,
         input: &'input str,
-    ) -> Result<i32, __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+    ) -> Result<i32, __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
       F:  for<'a> FnMut(&'a str),
     {
         let __ascent = __ascent::parse_Term::<F>(
@@ -30,17 +34,20 @@ mod __parse__Term {
     mod __ascent {
 
         mod __parse__Term {
-            #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
+            #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens)]
 
             use std::str::FromStr;
+            #[allow(unused_extern_crates)]
             extern crate lalrpop_util as __lalrpop_util;
+            use super::super::super::__intern_token::Token;
+            #[allow(dead_code)]
             pub fn parse_Term<
                 'input,
                 F,
             >(
                 logger: &mut F,
                 input: &'input str,
-            ) -> Result<i32, __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<i32, __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               F:  for<'a> FnMut(&'a str),
             {
                 let mut __tokens = super::super::super::__intern_token::__Matcher::new(input);
@@ -89,23 +96,23 @@ mod __parse__Term {
             fn __state0<
                 'input,
                 F,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 logger: &mut F,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
-                __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                __lookahead: Option<(usize, Token<'input>, usize)>,
                 _: ::std::marker::PhantomData<(F)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               F:  for<'a> FnMut(&'a str),
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<>);
                 match __lookahead {
-                    Some((__loc1, (1, __tok0), __loc2)) => {
+                    Some((__loc1, Token(1, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
                         __result = try!(__state3(logger, input, __tokens, __sym0, ::std::marker::PhantomData::<(F)>));
                     }
-                    Some((__loc1, (0, __tok0), __loc2)) => {
+                    Some((__loc1, Token(0, __tok0), __loc2)) => {
                         let __sym0 = (__loc1, (__tok0), __loc2);
                         __result = try!(__state4(logger, input, __tokens, __sym0, ::std::marker::PhantomData::<(F)>));
                     }
@@ -145,27 +152,25 @@ mod __parse__Term {
             //
             //     Term = Num (*) ["(", ")", r#"[0-9]+"#, EOF]
             //
-            //   ["(", ")", r#"[0-9]+"#, EOF] -> Term = Num => ActionFn(1);
+            //   [")", EOF] -> Term = Num => ActionFn(1);
             //
             fn __state1<
                 'input,
                 F,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 logger: &mut F,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
-                __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                __lookahead: Option<(usize, Token<'input>, usize)>,
                 __sym0: (usize, i32, usize),
                 _: ::std::marker::PhantomData<(F)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               F:  for<'a> FnMut(&'a str),
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<>);
                 match __lookahead {
-                    Some((_, (1, _), _)) |
-                    Some((_, (2, _), _)) |
-                    Some((_, (0, _), _)) |
+                    Some((_, Token(2, _), _)) |
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
@@ -182,9 +187,7 @@ mod __parse__Term {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
                             token: __lookahead,
                             expected: vec![
-                                r###""(""###.to_string(),
                                 r###"")""###.to_string(),
-                                r###"r#"[0-9]+"#"###.to_string(),
                             ]
                         });
                     }
@@ -201,27 +204,24 @@ mod __parse__Term {
             //
             //     __Term = Term (*) ["(", ")", r#"[0-9]+"#, EOF]
             //
-            //   ["(", ")", r#"[0-9]+"#, EOF] -> __Term = Term => ActionFn(0);
+            //   [EOF] -> __Term = Term => ActionFn(0);
             //
             fn __state2<
                 'input,
                 F,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 logger: &mut F,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
-                __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                __lookahead: Option<(usize, Token<'input>, usize)>,
                 __sym0: (usize, i32, usize),
                 _: ::std::marker::PhantomData<(F)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               F:  for<'a> FnMut(&'a str),
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<>);
                 match __lookahead {
-                    Some((_, (1, _), _)) |
-                    Some((_, (2, _), _)) |
-                    Some((_, (0, _), _)) |
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
@@ -238,9 +238,6 @@ mod __parse__Term {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
                             token: __lookahead,
                             expected: vec![
-                                r###""(""###.to_string(),
-                                r###"")""###.to_string(),
-                                r###"r#"[0-9]+"#"###.to_string(),
                             ]
                         });
                     }
@@ -268,28 +265,28 @@ mod __parse__Term {
             fn __state3<
                 'input,
                 F,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 logger: &mut F,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
                 _: ::std::marker::PhantomData<(F)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               F:  for<'a> FnMut(&'a str),
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<>);
                 let __lookahead = match __tokens.next() {
                     Some(Ok(v)) => Some(v),
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
                 match __lookahead {
-                    Some((__loc1, (1, __tok0), __loc2)) => {
+                    Some((__loc1, Token(1, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
                         __result = try!(__state3(logger, input, __tokens, __sym1, ::std::marker::PhantomData::<(F)>));
                     }
-                    Some((__loc1, (0, __tok0), __loc2)) => {
+                    Some((__loc1, Token(0, __tok0), __loc2)) => {
                         let __sym1 = (__loc1, (__tok0), __loc2);
                         __result = try!(__state4(logger, input, __tokens, __sym1, ::std::marker::PhantomData::<(F)>));
                     }
@@ -330,31 +327,29 @@ mod __parse__Term {
             //
             //     Num = r#"[0-9]+"# (*) ["(", ")", r#"[0-9]+"#, EOF]
             //
-            //   ["(", ")", r#"[0-9]+"#, EOF] -> Num = r#"[0-9]+"# => ActionFn(3);
+            //   [")", EOF] -> Num = r#"[0-9]+"# => ActionFn(3);
             //
             fn __state4<
                 'input,
                 F,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 logger: &mut F,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
                 __sym0: (usize, &'input str, usize),
                 _: ::std::marker::PhantomData<(F)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               F:  for<'a> FnMut(&'a str),
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<>);
                 let __lookahead = match __tokens.next() {
                     Some(Ok(v)) => Some(v),
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
                 match __lookahead {
-                    Some((_, (1, _), _)) |
-                    Some((_, (2, _), _)) |
-                    Some((_, (0, _), _)) |
+                    Some((_, Token(2, _), _)) |
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym0.2.clone();
@@ -371,9 +366,7 @@ mod __parse__Term {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
                             token: __lookahead,
                             expected: vec![
-                                r###""(""###.to_string(),
                                 r###"")""###.to_string(),
-                                r###"r#"[0-9]+"#"###.to_string(),
                             ]
                         });
                     }
@@ -395,21 +388,21 @@ mod __parse__Term {
             fn __state5<
                 'input,
                 F,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 logger: &mut F,
                 input: &'input str,
                 __tokens: &mut __TOKENS,
-                __lookahead: Option<(usize, (usize, &'input str), usize)>,
+                __lookahead: Option<(usize, Token<'input>, usize)>,
                 __sym0: (usize, &'input str, usize),
                 __sym1: (usize, i32, usize),
                 _: ::std::marker::PhantomData<(F)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               F:  for<'a> FnMut(&'a str),
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<>);
                 match __lookahead {
-                    Some((__loc1, (2, __tok0), __loc2)) => {
+                    Some((__loc1, Token(2, __tok0), __loc2)) => {
                         let __sym2 = (__loc1, (__tok0), __loc2);
                         __result = try!(__state6(logger, input, __tokens, __sym0, __sym1, __sym2, ::std::marker::PhantomData::<(F)>));
                         return Ok(__result);
@@ -435,12 +428,12 @@ mod __parse__Term {
             //
             //     Term = "(" Term ")" (*) ["(", ")", r#"[0-9]+"#, EOF]
             //
-            //   ["(", ")", r#"[0-9]+"#, EOF] -> Term = "(", Term, ")" => ActionFn(2);
+            //   [")", EOF] -> Term = "(", Term, ")" => ActionFn(2);
             //
             fn __state6<
                 'input,
                 F,
-                __TOKENS: Iterator<Item=Result<(usize, (usize, &'input str), usize),__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>>,
+                __TOKENS: Iterator<Item=Result<(usize, Token<'input>, usize),__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>,
             >(
                 logger: &mut F,
                 input: &'input str,
@@ -449,19 +442,17 @@ mod __parse__Term {
                 __sym1: (usize, i32, usize),
                 __sym2: (usize, &'input str, usize),
                 _: ::std::marker::PhantomData<(F)>,
-            ) -> Result<(Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<(Option<(usize, Token<'input>, usize)>, __Nonterminal<>), __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               F:  for<'a> FnMut(&'a str),
             {
-                let mut __result: (Option<(usize, (usize, &'input str), usize)>, __Nonterminal<>);
+                let mut __result: (Option<(usize, Token<'input>, usize)>, __Nonterminal<>);
                 let __lookahead = match __tokens.next() {
                     Some(Ok(v)) => Some(v),
                     None => None,
                     Some(Err(e)) => return Err(e),
                 };
                 match __lookahead {
-                    Some((_, (1, _), _)) |
-                    Some((_, (2, _), _)) |
-                    Some((_, (0, _), _)) |
+                    Some((_, Token(2, _), _)) |
                     None => {
                         let __start = __sym0.0.clone();
                         let __end = __sym2.2.clone();
@@ -478,9 +469,7 @@ mod __parse__Term {
                         return Err(__lalrpop_util::ParseError::UnrecognizedToken {
                             token: __lookahead,
                             expected: vec![
-                                r###""(""###.to_string(),
                                 r###"")""###.to_string(),
-                                r###"r#"[0-9]+"#"###.to_string(),
                             ]
                         });
                     }
@@ -492,10 +481,12 @@ mod __parse__Term {
     mod __parse_table {
 
         mod __parse__Term {
-            #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports)]
+            #![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens)]
 
             use std::str::FromStr;
+            #[allow(unused_extern_crates)]
             extern crate lalrpop_util as __lalrpop_util;
+            use super::super::super::__intern_token::Token;
             #[allow(dead_code)]
             pub enum __Symbol<'input>
              {
@@ -518,15 +509,15 @@ mod __parse__Term {
 
                 // State 1
                 //     Term = Num (*) ["(", ")", r#"[0-9]+"#, EOF]
-                -2,  // on "(", reduce `Term = Num => ActionFn(1);`
+                0,  // on "(", error
                 -2,  // on ")", reduce `Term = Num => ActionFn(1);`
-                -2,  // on r#"[0-9]+"#, reduce `Term = Num => ActionFn(1);`
+                0,  // on r#"[0-9]+"#, error
 
                 // State 2
                 //     __Term = Term (*) ["(", ")", r#"[0-9]+"#, EOF]
-                -4,  // on "(", reduce `__Term = Term => ActionFn(0);`
-                -4,  // on ")", reduce `__Term = Term => ActionFn(0);`
-                -4,  // on r#"[0-9]+"#, reduce `__Term = Term => ActionFn(0);`
+                0,  // on "(", error
+                0,  // on ")", error
+                0,  // on r#"[0-9]+"#, error
 
                 // State 3
                 //     Num = (*) r#"[0-9]+"# ["(", ")", r#"[0-9]+"#, EOF]
@@ -539,9 +530,9 @@ mod __parse__Term {
 
                 // State 4
                 //     Num = r#"[0-9]+"# (*) ["(", ")", r#"[0-9]+"#, EOF]
-                -1,  // on "(", reduce `Num = r#"[0-9]+"# => ActionFn(3);`
+                0,  // on "(", error
                 -1,  // on ")", reduce `Num = r#"[0-9]+"# => ActionFn(3);`
-                -1,  // on r#"[0-9]+"#, reduce `Num = r#"[0-9]+"# => ActionFn(3);`
+                0,  // on r#"[0-9]+"#, error
 
                 // State 5
                 //     Term = "(" Term (*) ")" ["(", ")", r#"[0-9]+"#, EOF]
@@ -551,24 +542,31 @@ mod __parse__Term {
 
                 // State 6
                 //     Term = "(" Term ")" (*) ["(", ")", r#"[0-9]+"#, EOF]
-                -3,  // on "(", reduce `Term = "(", Term, ")" => ActionFn(2);`
+                0,  // on "(", error
                 -3,  // on ")", reduce `Term = "(", Term, ")" => ActionFn(2);`
-                -3,  // on r#"[0-9]+"#, reduce `Term = "(", Term, ")" => ActionFn(2);`
+                0,  // on r#"[0-9]+"#, error
 
             ];
             const __EOF_ACTION: &'static [i32] = &[
+                // State 0
                 0,  // on EOF, error
 
+                // State 1
                 -2,  // on EOF, reduce `Term = Num => ActionFn(1);`
 
+                // State 2
                 -4,  // on EOF, reduce `__Term = Term => ActionFn(0);`
 
+                // State 3
                 0,  // on EOF, error
 
+                // State 4
                 -1,  // on EOF, reduce `Num = r#"[0-9]+"# => ActionFn(3);`
 
+                // State 5
                 0,  // on EOF, error
 
+                // State 6
                 -3,  // on EOF, reduce `Term = "(", Term, ")" => ActionFn(2);`
 
             ];
@@ -623,13 +621,14 @@ mod __parse__Term {
                     }
                 }).collect()
             }
+            #[allow(dead_code)]
             pub fn parse_Term<
                 'input,
                 F,
             >(
                 logger: &mut F,
                 input: &'input str,
-            ) -> Result<i32, __lalrpop_util::ParseError<usize, (usize, &'input str), ()>> where
+            ) -> Result<i32, __lalrpop_util::ParseError<usize, Token<'input>, &'static str>> where
               F:  for<'a> FnMut(&'a str),
             {
                 let mut __tokens = super::super::super::__intern_token::__Matcher::new(input);
@@ -637,18 +636,18 @@ mod __parse__Term {
                 let mut __symbols = vec![];
                 let mut __integer;
                 let mut __lookahead;
-                let mut __last_location = Default::default();
+                let __last_location = &mut Default::default();
                 '__shift: loop {
                     __lookahead = match __tokens.next() {
                         Some(Ok(v)) => v,
                         None => break '__shift,
                         Some(Err(e)) => return Err(e),
                     };
-                    __last_location = __lookahead.2.clone();
+                    *__last_location = __lookahead.2.clone();
                     __integer = match __lookahead.1 {
-                        (1, _) if true => 0,
-                        (2, _) if true => 1,
-                        (0, _) if true => 2,
+                        Token(1, _) if true => 0,
+                        Token(2, _) if true => 1,
+                        Token(0, _) if true => 2,
                         _ => {
                             let __state = *__states.last().unwrap() as usize;
                             let __error = __lalrpop_util::ParseError::UnrecognizedToken {
@@ -664,15 +663,15 @@ mod __parse__Term {
                         if __action > 0 {
                             let __symbol = match __integer {
                                 0 => match __lookahead.1 {
-                                    (1, __tok0) => __Symbol::Term_22_28_22((__tok0)),
+                                    Token(1, __tok0) => __Symbol::Term_22_28_22((__tok0)),
                                     _ => unreachable!(),
                                 },
                                 1 => match __lookahead.1 {
-                                    (2, __tok0) => __Symbol::Term_22_29_22((__tok0)),
+                                    Token(2, __tok0) => __Symbol::Term_22_29_22((__tok0)),
                                     _ => unreachable!(),
                                 },
                                 2 => match __lookahead.1 {
-                                    (0, __tok0) => __Symbol::Termr_23_22_5b0_2d9_5d_2b_22_23((__tok0)),
+                                    Token(0, __tok0) => __Symbol::Termr_23_22_5b0_2d9_5d_2b_22_23((__tok0)),
                                     _ => unreachable!(),
                                 },
                                 _ => unreachable!(),
@@ -685,9 +684,11 @@ mod __parse__Term {
                                 return Err(__lalrpop_util::ParseError::ExtraToken { token: __lookahead });
                             }
                         } else {
+                            let mut __err_lookahead = Some(__lookahead);
+                            let mut __err_integer: Option<usize> = Some(__integer);
                             let __state = *__states.last().unwrap() as usize;
                             let __error = __lalrpop_util::ParseError::UnrecognizedToken {
-                                token: Some(__lookahead),
+                                token: __err_lookahead,
                                 expected: __expected_tokens(__state),
                             };
                             return Err(__error)
@@ -702,12 +703,14 @@ mod __parse__Term {
                             return r;
                         }
                     } else {
+                        let mut __err_lookahead = None;
+                        let mut __err_integer: Option<usize> = None;
                         let __state = *__states.last().unwrap() as usize;
                         let __error = __lalrpop_util::ParseError::UnrecognizedToken {
-                            token: None,
+                            token: __err_lookahead,
                             expected: __expected_tokens(__state),
                         };
-                        return Err(__error);
+                        return Err(__error)
                     }
                 }
             }
@@ -722,7 +725,7 @@ mod __parse__Term {
                 __states: &mut ::std::vec::Vec<i32>,
                 __symbols: &mut ::std::vec::Vec<(usize,__Symbol<'input>,usize)>,
                 _: ::std::marker::PhantomData<(F)>,
-            ) -> Option<Result<i32,__lalrpop_util::ParseError<usize, (usize, &'input str), ()>>> where
+            ) -> Option<Result<i32,__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>> where
               F:  for<'a> FnMut(&'a str),
             {
                 let __nonterminal = match -__action {
@@ -850,8 +853,19 @@ pub use self::__parse__Term::parse_Term;
 mod __intern_token {
     #![allow(unused_imports)]
     use std::str::FromStr;
+    #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
     extern crate regex as __regex;
+    use std::fmt as __fmt;
+
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Token<'input>(pub usize, pub &'input str);
+    impl<'a> __fmt::Display for Token<'a> {
+        fn fmt(&self, formatter: &mut __fmt::Formatter) -> Result<(), __fmt::Error> {
+            __fmt::Display::fmt(self.1, formatter)
+        }
+    }
+
     pub struct __Matcher<'input> {
         text: &'input str,
         consumed: usize,
@@ -882,7 +896,7 @@ mod __intern_token {
     }
 
     impl<'input> Iterator for __Matcher<'input> {
-        type Item = Result<(usize, (usize, &'input str), usize), __lalrpop_util::ParseError<usize,(usize, &'input str),()>>;
+        type Item = Result<(usize, Token<'input>, usize), __lalrpop_util::ParseError<usize,Token<'input>,&'static str>>;
 
         fn next(&mut self) -> Option<Self::Item> {
             let __text = self.text.trim_left();
@@ -916,12 +930,13 @@ mod __intern_token {
                     let __end_offset = __start_offset + __longest_match;
                     self.text = __remaining;
                     self.consumed = __end_offset;
-                    Some(Ok((__start_offset, (__index, __result), __end_offset)))
+                    Some(Ok((__start_offset, Token(__index, __result), __end_offset)))
                 }
             }
         }
     }
 }
+pub use self::__intern_token::Token;
 
 #[allow(unused_variables)]
 fn __action0<
@@ -994,18 +1009,18 @@ fn __action3<
 
 pub trait __ToTriple<'input, F, > {
     type Error;
-    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),Self::Error>;
+    fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize),Self::Error>;
 }
 
-impl<'input, F, > __ToTriple<'input, F, > for (usize, (usize, &'input str), usize) {
-    type Error = ();
-    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),()> {
+impl<'input, F, > __ToTriple<'input, F, > for (usize, Token<'input>, usize) {
+    type Error = &'static str;
+    fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize),&'static str> {
         Ok(value)
     }
 }
-impl<'input, F, > __ToTriple<'input, F, > for Result<(usize, (usize, &'input str), usize),()> {
-    type Error = ();
-    fn to_triple(value: Self) -> Result<(usize,(usize, &'input str),usize),()> {
+impl<'input, F, > __ToTriple<'input, F, > for Result<(usize, Token<'input>, usize),&'static str> {
+    type Error = &'static str;
+    fn to_triple(value: Self) -> Result<(usize,Token<'input>,usize),&'static str> {
         value
     }
 }

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -75,7 +75,7 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         // which doesn't follow conventions:
         rust!(self.out,
               "#![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
-               unused_imports)]");
+               unused_imports, unused_parens)]");
         rust!(self.out, "");
 
         try!(self.write_uses());

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -446,7 +446,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
         rust!(self.out, "let mut {}lookahead;", self.prefix);
         // The location of the last token is necessary for for error recovery at EOF (or they would not have
         // a location)
-        rust!(self.out, "let mut {}last_location = Default::default();", self.prefix);
+        rust!(self.out, "let {}last_location = &mut Default::default();", self.prefix);
 
         // Outer loop: each time we continue around this loop, we
         // shift a new token from the input. We break from the loop
@@ -768,7 +768,7 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
                   p = self.prefix);
         }
         rust!(self.out, "}};");
-        rust!(self.out, "{p}{} = {p}{}.2.clone();",
+        rust!(self.out, "*{p}{} = {p}{}.2.clone();",
               last_location,
               lookahead,
               p = self.prefix);

--- a/lalrpop/src/lr1/codegen/parse_table.rs
+++ b/lalrpop/src/lr1/codegen/parse_table.rs
@@ -389,7 +389,8 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
         rust!(self.out,
               "const {}EOF_ACTION: &'static [i32] = &[",
               self.prefix);
-        for state in self.states {
+        for (index, state) in self.states.iter().enumerate() {
+            rust!(self.out, "// State {}", index);
             let reduction = Self::write_reduction(&self.custom, state, Token::EOF);
             try!(self.out.write_table_row(Some(reduction)));
         }
@@ -1100,7 +1101,11 @@ impl<'ascent, 'grammar, W: Write> CodeGenerator<'ascent, 'grammar, W, TableDrive
             self.prefix,
             self.prefix,
             self.grammar.terminals.all.len());
-
+        if DEBUG_PRINT {
+            rust!(self.out, "println!(\"EOF Loop: top state = {{}} (error state+1) = {{}}\", \
+                             {}state, {}error_state);",
+                  self.prefix, self.prefix);
+        }
         rust!(self.out, "if {}error_state > 0 {} {{", self.prefix, extra_test);
         rust!(self.out, "break;");
         rust!(self.out, "}}");


### PR DESCRIPTION
This change reworks LALRPOP's error recovery mechanism:

- Internally, we now generate a function (two, really) that gets invoked, rather than inlining the code twice.
- We now handle LALR and lane-table grammars correctly, in particular accounting for the fact that they can reduce several times before encountering an error (and hence we must trace through reductions when testing if we can recover from a particular state).
    - This avoids the infinite loops.
- We now use a modified algorithm that prefers to drop fewer tokens (but may drop more states as a result) -- [see description here](https://github.com/nikomatsakis/lalrpop/issues/240/#issuecomment-338483176).

I am not sure about the final bullet point. At first I thought it was clearly better, but I've become less sure. I'd be curious on feedback (cc @Marwes, do you have an opinion?). It should be relatively easy to change back, if we want to. (If you look at the new `error_recovery_span` test cases, you can see that I tried to enumerate some of the details of how the new error recovery can behave.)

To do list:

- [ ] Rework the big comment at the top of `parse_table.rs` to account for how it works now

Fixes #240 